### PR TITLE
Add staging upload endpoint for containerized file transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -308,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-common"
-version = "0.6.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -316,12 +317,13 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "url",
  "zeroize",
 ]
 
 [[package]]
 name = "bsmcp-db-postgres"
-version = "0.6.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -336,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-sqlite"
-version = "0.6.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -350,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-embedder"
-version = "0.6.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -369,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-server"
-version = "0.6.0"
+version = "0.7.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -1962,6 +1964,23 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.7.0"
+version = "0.7.1"
 
 [profile.release]
 lto = true

--- a/crates/bsmcp-server/Cargo.toml
+++ b/crates/bsmcp-server/Cargo.toml
@@ -8,7 +8,7 @@ bsmcp-common = { path = "../bsmcp-common" }
 bsmcp-db-sqlite = { path = "../bsmcp-db-sqlite" }
 bsmcp-db-postgres = { path = "../bsmcp-db-postgres" }
 tokio = { version = "1", features = ["full"] }
-axum = { version = "0.8", features = ["tokio"] }
+axum = { version = "0.8", features = ["tokio", "multipart"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/bsmcp-server/src/main.rs
+++ b/crates/bsmcp-server/src/main.rs
@@ -4,6 +4,7 @@ mod migrate;
 mod oauth;
 mod semantic;
 mod sse;
+mod staging;
 mod summary;
 
 use std::env;
@@ -234,6 +235,14 @@ async fn main() {
         .route("/token", axum::routing::post(oauth::handle_token))
         .route("/register", axum::routing::post(oauth::handle_register))
         .route("/health", get(|| async { Json(json!({"status": "ok"})) }));
+
+    // Staging upload endpoint for file uploads (50MB limit)
+    app = app.route(
+        "/stage/upload/{staging_id}",
+        axum::routing::post(staging::handle_stage_upload)
+            .layer(DefaultBodyLimit::max(50 * 1024 * 1024)),
+    );
+    eprintln!("Staging: upload endpoint active at POST /stage/upload/:id");
 
     // Conditional webhook + status routes for semantic search
     if state.semantic.is_some() {

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -15,6 +15,7 @@ pub async fn handle_request(
     client: &BookStackClient,
     semantic: Option<&SemanticState>,
     summary_cache: &crate::summary::SummaryCache,
+    staging: &crate::staging::StagingStore,
 ) -> Option<Value> {
     let id = request.get("id");
 
@@ -47,7 +48,7 @@ pub async fn handle_request(
         "tools/call" => {
             let name = params["name"].as_str().unwrap_or("");
             let args = params.get("arguments").cloned().unwrap_or(json!({}));
-            let result = execute_tool(name, &args, client, semantic).await;
+            let result = execute_tool(name, &args, client, semantic, staging).await;
             match result {
                 Ok(text) => Some(json_rpc_result(id, json!({
                     "content": [{ "type": "text", "text": text }],
@@ -78,7 +79,7 @@ fn json_rpc_error(id: Option<&Value>, code: i64, message: &str) -> Value {
     })
 }
 
-async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semantic: Option<&SemanticState>) -> Result<String, String> {
+async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semantic: Option<&SemanticState>, staging: &crate::staging::StagingStore) -> Result<String, String> {
     match name {
         // Semantic Search (conditional)
         "semantic_search" => {
@@ -477,11 +478,24 @@ async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semant
         "upload_attachment" => {
             let name = arg_str(args, "name")?;
             let uploaded_to = arg_i64_required(args, "uploaded_to")?;
-            let mime_type = arg_str_default(args, "mime_type", "application/octet-stream");
+            let mime_type_arg = arg_str_default(args, "mime_type", "application/octet-stream");
+            let staging_id = args.get("staging_id").and_then(|v| v.as_str());
             let file_path = args.get("file_path").and_then(|v| v.as_str());
             let url = args.get("url").and_then(|v| v.as_str());
-            let (bytes, auto_filename) = bookstack::resolve_file_content(file_path, url).await
-                .map_err(|e| e.to_string())?;
+            let (bytes, auto_filename, resolved_mime) = if let Some(sid) = staging_id {
+                let entry = crate::staging::consume_staged(staging, sid).await
+                    .ok_or_else(|| format!("Staging slot '{}' not found or already consumed (slots expire after 5 minutes)", sid))?;
+                (entry.bytes, entry.filename, entry.mime_type)
+            } else {
+                let (b, f) = bookstack::resolve_file_content(file_path, url).await
+                    .map_err(|e| e.to_string())?;
+                (b, f, mime_type_arg.clone())
+            };
+            let mime_type = if staging_id.is_some() && args.get("mime_type").is_none() {
+                resolved_mime
+            } else {
+                mime_type_arg
+            };
             let filename = match args.get("filename").and_then(|v| v.as_str()) {
                 Some(f) if !f.is_empty() => f.to_string(),
                 _ => auto_filename,
@@ -626,16 +640,38 @@ async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semant
             let image_type = arg_str_default(args, "type", "gallery");
             validate_enum(&image_type, &["gallery", "drawio"], "type")?;
             let uploaded_to = arg_i64_required(args, "uploaded_to")?;
-            let mime_type = arg_str_default(args, "mime_type", "image/png");
+            let mime_type_arg = arg_str_default(args, "mime_type", "image/png");
+            let staging_id = args.get("staging_id").and_then(|v| v.as_str());
             let file_path = args.get("file_path").and_then(|v| v.as_str());
             let url = args.get("url").and_then(|v| v.as_str());
-            let (bytes, auto_filename) = bookstack::resolve_file_content(file_path, url).await
-                .map_err(|e| e.to_string())?;
+            let (bytes, auto_filename, resolved_mime) = if let Some(sid) = staging_id {
+                let entry = crate::staging::consume_staged(staging, sid).await
+                    .ok_or_else(|| format!("Staging slot '{}' not found or already consumed (slots expire after 5 minutes)", sid))?;
+                (entry.bytes, entry.filename, entry.mime_type)
+            } else {
+                let (b, f) = bookstack::resolve_file_content(file_path, url).await
+                    .map_err(|e| e.to_string())?;
+                (b, f, mime_type_arg.clone())
+            };
+            let mime_type = if staging_id.is_some() && args.get("mime_type").is_none() {
+                resolved_mime
+            } else {
+                mime_type_arg
+            };
             let filename = match args.get("filename").and_then(|v| v.as_str()) {
                 Some(f) if !f.is_empty() => f.to_string(),
                 _ => auto_filename,
             };
             format_json(&client.upload_image(&name, &image_type, uploaded_to, &filename, bytes, &mime_type).await?)
+        }
+        "prepare_upload" => {
+            let staging_id = uuid::Uuid::new_v4().to_string();
+            format_json(&json!({
+                "staging_id": staging_id,
+                "upload_url": format!("/stage/upload/{staging_id}"),
+                "instructions": "POST a multipart/form-data request with a 'file' field to the upload_url (relative to this server's base URL). Include Authorization header. Then pass the staging_id to upload_image or upload_attachment.",
+                "ttl_seconds": 300
+            }))
         }
 
         // Content Permissions
@@ -1446,11 +1482,12 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
             update_schema("attachment_id", &["name", "link"])),
         tool("delete_attachment", "Delete an attachment.",
             id_schema("attachment_id")),
-        tool("upload_attachment", "Upload a file attachment to a page from a local file path or URL.", json!({
+        tool("upload_attachment", "Upload a file attachment to a page from a local file path, URL, or staging slot.", json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string", "description": "Attachment name" },
                 "uploaded_to": { "type": "integer", "description": "Page ID to attach to" },
+                "staging_id": { "type": "string", "description": "Staging slot ID from prepare_upload (use instead of file_path/url when server cannot access local files)" },
                 "file_path": { "type": "string", "description": "Local filesystem path to the file" },
                 "url": { "type": "string", "description": "URL to fetch the file from" },
                 "filename": { "type": "string", "description": "Override the auto-detected filename" },
@@ -1561,11 +1598,12 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
         })),
         tool("delete_image", "Delete an image from the gallery.",
             id_schema("image_id")),
-        tool("upload_image", "Upload an image to the BookStack image gallery from a local file path or URL.", json!({
+        tool("upload_image", "Upload an image to the BookStack image gallery from a local file path, URL, or staging slot.", json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string", "description": "Image name" },
                 "uploaded_to": { "type": "integer", "description": "Page ID the image is associated with" },
+                "staging_id": { "type": "string", "description": "Staging slot ID from prepare_upload (use instead of file_path/url when server cannot access local files)" },
                 "file_path": { "type": "string", "description": "Local filesystem path to the image file" },
                 "url": { "type": "string", "description": "URL to fetch the image from" },
                 "filename": { "type": "string", "description": "Override the auto-detected filename" },
@@ -1573,6 +1611,10 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
                 "mime_type": { "type": "string", "description": "MIME type of the image", "default": "image/png" }
             },
             "required": ["name", "uploaded_to"]
+        })),
+        tool("prepare_upload", "Create a staging slot for file upload. Returns a staging_id and upload_url. Use when the server cannot access local files (e.g. running in Docker). Step 1: call prepare_upload to get a staging_id and upload_url. Step 2: POST a multipart/form-data request with a 'file' field to upload_url (relative to the MCP server base URL), including the same Authorization header. Step 3: call upload_image or upload_attachment with staging_id instead of file_path/url.", json!({
+            "type": "object",
+            "properties": {}
         })),
 
         // Content Permissions

--- a/crates/bsmcp-server/src/sse.rs
+++ b/crates/bsmcp-server/src/sse.rs
@@ -44,6 +44,7 @@ pub struct AppState {
     backup_path: PathBuf,
     pub semantic: Option<Arc<SemanticState>>,
     pub summary_cache: crate::summary::SummaryCache,
+    pub staging: crate::staging::StagingStore,
 }
 
 pub(crate) struct RateLimit {
@@ -120,6 +121,7 @@ impl AppState {
             backup_path,
             semantic,
             summary_cache,
+            staging: crate::staging::new_staging_store(),
         }
     }
 
@@ -129,6 +131,7 @@ impl AppState {
         let db = self.db.clone();
         let streamable_rate_limits = self.streamable_rate_limits.clone();
         let streamable_sessions = self.streamable_sessions.clone();
+        let staging_clone = self.staging.clone();
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(30)).await;
@@ -159,6 +162,9 @@ impl AppState {
                 {
                     let mut ss = streamable_sessions.write().await;
                     ss.retain(|_, created| created.elapsed() < SESSION_TTL);
+                }
+                {
+                    crate::staging::cleanup_expired_sync(&staging_clone);
                 }
                 if let Err(e) = db.cleanup_expired_tokens().await {
                     eprintln!("Token cleanup error: {e}");
@@ -212,7 +218,7 @@ fn unauthorized(hint: &str, headers: &HeaderMap, known_urls: &[String]) -> Respo
     resp
 }
 
-async fn resolve_credentials(
+pub(crate) async fn resolve_credentials(
     headers: &HeaderMap,
     db: &dyn DbBackend,
     known_urls: &[String],
@@ -404,7 +410,7 @@ pub async fn handle_message(
     };
 
     let semantic = state.semantic.as_deref();
-    let response = mcp::handle_request(&request, &client, semantic, &state.summary_cache).await;
+    let response = mcp::handle_request(&request, &client, semantic, &state.summary_cache, &state.staging).await;
 
     if let Some(response) = response {
         let data = serde_json::to_string(&response).unwrap_or_default();
@@ -480,7 +486,7 @@ pub async fn handle_streamable(
     }
 
     let semantic = state.semantic.as_deref();
-    let response = mcp::handle_request(&request, &client, semantic, &state.summary_cache).await;
+    let response = mcp::handle_request(&request, &client, semantic, &state.summary_cache, &state.staging).await;
 
     match response {
         Some(resp) => {

--- a/crates/bsmcp-server/src/staging.rs
+++ b/crates/bsmcp-server/src/staging.rs
@@ -1,0 +1,138 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::extract::{Multipart, Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::json;
+use tokio::sync::RwLock;
+
+use crate::sse::AppState;
+
+const STAGING_TTL: Duration = Duration::from_secs(300); // 5 minutes
+const MAX_STAGING_SIZE: usize = 50 * 1024 * 1024; // 50MB
+
+pub struct StagingEntry {
+    pub bytes: Vec<u8>,
+    pub filename: String,
+    pub mime_type: String,
+    pub created_at: Instant,
+}
+
+pub type StagingStore = Arc<RwLock<HashMap<String, StagingEntry>>>;
+
+pub fn new_staging_store() -> StagingStore {
+    Arc::new(RwLock::new(HashMap::new()))
+}
+
+pub async fn consume_staged(store: &StagingStore, id: &str) -> Option<StagingEntry> {
+    let mut map = store.write().await;
+    map.remove(id)
+}
+
+pub fn cleanup_expired_sync(store: &StagingStore) {
+    // Use try_write to avoid blocking if someone else holds the lock
+    if let Ok(mut map) = store.try_write() {
+        let before = map.len();
+        map.retain(|_, entry| entry.created_at.elapsed() < STAGING_TTL);
+        let removed = before - map.len();
+        if removed > 0 {
+            eprintln!("Staging: cleaned up {removed} expired slot(s)");
+        }
+    }
+}
+
+pub async fn handle_stage_upload(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(staging_id): Path<String>,
+    mut multipart: Multipart,
+) -> Response {
+    // Auth required
+    let (_token_id, _token_secret) = match crate::sse::resolve_credentials(
+        &headers,
+        state.db.as_ref(),
+        &state.known_urls,
+    ).await {
+        Ok(creds) => creds,
+        Err(resp) => return resp,
+    };
+
+    // Validate staging_id is a UUID
+    if uuid::Uuid::parse_str(&staging_id).is_err() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Invalid staging_id format"})),
+        ).into_response();
+    }
+
+    // Extract the file from multipart
+    let field = match multipart.next_field().await {
+        Ok(Some(field)) => field,
+        Ok(None) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "No file field in multipart body"})),
+            ).into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("Multipart parse error: {e}")})),
+            ).into_response();
+        }
+    };
+
+    let filename = field.file_name()
+        .unwrap_or("upload")
+        .to_string();
+    let mime_type = field.content_type()
+        .unwrap_or("application/octet-stream")
+        .to_string();
+
+    // Read bytes with size limit
+    let bytes = match field.bytes().await {
+        Ok(b) => {
+            if b.len() > MAX_STAGING_SIZE {
+                return (
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    Json(json!({"error": format!("File exceeds maximum size of {}MB", MAX_STAGING_SIZE / 1024 / 1024)})),
+                ).into_response();
+            }
+            b.to_vec()
+        }
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": format!("Failed to read file: {e}")})),
+            ).into_response();
+        }
+    };
+
+    let size = bytes.len();
+
+    // Store in staging
+    {
+        let mut store = state.staging.write().await;
+        store.insert(staging_id.clone(), StagingEntry {
+            bytes,
+            filename: filename.clone(),
+            mime_type: mime_type.clone(),
+            created_at: Instant::now(),
+        });
+    }
+
+    eprintln!("Staging: stored {staging_id} ({filename}, {mime_type}, {size} bytes)");
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "staging_id": staging_id,
+            "filename": filename,
+            "mime_type": mime_type,
+            "size": size,
+        })),
+    ).into_response()
+}


### PR DESCRIPTION
## Summary
- Adds `prepare_upload` MCP tool that returns a staging_id and upload URL
- Adds `POST /stage/upload/{staging_id}` HTTP endpoint accepting multipart file uploads (50MB limit, auth required)
- Updates `upload_image` and `upload_attachment` to accept `staging_id` as alternative to `file_path`/`url`
- In-memory staging store with 5-minute TTL, single-use consumption, cleanup every 30s

## Why
MCP has no native binary input support. The `file_path` parameter on upload tools only works when the server can access the client's filesystem, which breaks in Docker deployments. This two-step flow (prepare → curl → consume) works from any client including Claude Code and Claude Desktop.

## Test plan
- [ ] Call `prepare_upload`, verify staging_id and upload_url returned
- [ ] POST a file to the upload URL with auth header, verify 200 response
- [ ] Call `upload_image` with staging_id, verify image uploads to BookStack
- [ ] Call `upload_attachment` with staging_id, verify attachment uploads
- [ ] Verify staging slot is consumed (second use returns error)
- [ ] Wait 5+ minutes, verify expired slots are cleaned up
- [ ] Verify auth is required on the staging endpoint
- [ ] Verify existing file_path and url params still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)