### PR TITLE
Remove file_path, use staging_id as auth, return full upload URL

### DIFF
--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -478,24 +478,20 @@ async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semant
         "upload_attachment" => {
             let name = arg_str(args, "name")?;
             let uploaded_to = arg_i64_required(args, "uploaded_to")?;
-            let mime_type_arg = arg_str_default(args, "mime_type", "application/octet-stream");
             let staging_id = args.get("staging_id").and_then(|v| v.as_str());
-            let file_path = args.get("file_path").and_then(|v| v.as_str());
             let url = args.get("url").and_then(|v| v.as_str());
             let (bytes, auto_filename, resolved_mime) = if let Some(sid) = staging_id {
                 let entry = crate::staging::consume_staged(staging, sid).await
                     .ok_or_else(|| format!("Staging slot '{}' not found or already consumed (slots expire after 5 minutes)", sid))?;
                 (entry.bytes, entry.filename, entry.mime_type)
-            } else {
-                let (b, f) = bookstack::resolve_file_content(file_path, url).await
+            } else if let Some(u) = url {
+                let (b, f) = bookstack::resolve_file_content(None, Some(u)).await
                     .map_err(|e| e.to_string())?;
-                (b, f, mime_type_arg.clone())
-            };
-            let mime_type = if staging_id.is_some() && args.get("mime_type").is_none() {
-                resolved_mime
+                (b, f, "application/octet-stream".to_string())
             } else {
-                mime_type_arg
+                return Err("Either staging_id or url is required. Use prepare_upload to stage local files.".to_string());
             };
+            let mime_type = arg_str_default(args, "mime_type", &resolved_mime);
             let filename = match args.get("filename").and_then(|v| v.as_str()) {
                 Some(f) if !f.is_empty() => f.to_string(),
                 _ => auto_filename,
@@ -640,24 +636,20 @@ async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semant
             let image_type = arg_str_default(args, "type", "gallery");
             validate_enum(&image_type, &["gallery", "drawio"], "type")?;
             let uploaded_to = arg_i64_required(args, "uploaded_to")?;
-            let mime_type_arg = arg_str_default(args, "mime_type", "image/png");
             let staging_id = args.get("staging_id").and_then(|v| v.as_str());
-            let file_path = args.get("file_path").and_then(|v| v.as_str());
             let url = args.get("url").and_then(|v| v.as_str());
             let (bytes, auto_filename, resolved_mime) = if let Some(sid) = staging_id {
                 let entry = crate::staging::consume_staged(staging, sid).await
                     .ok_or_else(|| format!("Staging slot '{}' not found or already consumed (slots expire after 5 minutes)", sid))?;
                 (entry.bytes, entry.filename, entry.mime_type)
-            } else {
-                let (b, f) = bookstack::resolve_file_content(file_path, url).await
+            } else if let Some(u) = url {
+                let (b, f) = bookstack::resolve_file_content(None, Some(u)).await
                     .map_err(|e| e.to_string())?;
-                (b, f, mime_type_arg.clone())
-            };
-            let mime_type = if staging_id.is_some() && args.get("mime_type").is_none() {
-                resolved_mime
+                (b, f, "image/png".to_string())
             } else {
-                mime_type_arg
+                return Err("Either staging_id or url is required. Use prepare_upload to stage local files.".to_string());
             };
+            let mime_type = arg_str_default(args, "mime_type", &resolved_mime);
             let filename = match args.get("filename").and_then(|v| v.as_str()) {
                 Some(f) if !f.is_empty() => f.to_string(),
                 _ => auto_filename,
@@ -666,10 +658,30 @@ async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semant
         }
         "prepare_upload" => {
             let staging_id = uuid::Uuid::new_v4().to_string();
+            let base_url = env::var("BSMCP_PUBLIC_DOMAIN")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| format!("https://{}", s.trim().trim_end_matches('/')))
+                .unwrap_or_default();
+            let upload_url = if base_url.is_empty() {
+                format!("/stage/upload/{staging_id}")
+            } else {
+                format!("{base_url}/stage/upload/{staging_id}")
+            };
+            // Pre-register the slot so the staging_id acts as auth
+            {
+                let mut store = staging.write().await;
+                store.insert(staging_id.clone(), crate::staging::StagingEntry {
+                    bytes: Vec::new(),
+                    filename: String::new(),
+                    mime_type: String::new(),
+                    created_at: std::time::Instant::now(),
+                });
+            }
             format_json(&json!({
                 "staging_id": staging_id,
-                "upload_url": format!("/stage/upload/{staging_id}"),
-                "instructions": "POST a multipart/form-data request with a 'file' field to the upload_url (relative to this server's base URL). Include Authorization header. Then pass the staging_id to upload_image or upload_attachment.",
+                "upload_url": upload_url,
+                "instructions": "POST a multipart/form-data request with a 'file' field to the upload_url. No authorization header needed. Then pass the staging_id to upload_image or upload_attachment.",
                 "ttl_seconds": 300
             }))
         }
@@ -1171,7 +1183,14 @@ async fn build_instructions(client: &BookStackClient, semantic_enabled: bool, su
          the 'markdown' field for markdown pages, the 'html' field for WYSIWYG pages. \
          Check the editor type via get_page before using edit_page. \
          For append_to_page, replace_section, and insert_after, always pass markdown content — \
-         it is automatically converted to HTML for WYSIWYG pages.\n\n",
+         it is automatically converted to HTML for WYSIWYG pages.\n\n\
+         To upload images or file attachments from local files, use the staging upload flow: \
+         (1) call prepare_upload to get a staging_id and upload_url, \
+         (2) POST the file to the upload_url using curl: \
+         `curl -X POST -F 'file=@/path/to/file' <upload_url>` (no auth header needed), \
+         (3) call upload_image or upload_attachment with the staging_id. \
+         Alternatively, if the file is at a public URL, pass the url parameter directly \
+         to upload_image or upload_attachment without staging.\n\n",
     );
 
     // Include BookStack URL so AI can construct clickable links for users.
@@ -1482,13 +1501,12 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
             update_schema("attachment_id", &["name", "link"])),
         tool("delete_attachment", "Delete an attachment.",
             id_schema("attachment_id")),
-        tool("upload_attachment", "Upload a file attachment to a page from a local file path, URL, or staging slot.", json!({
+        tool("upload_attachment", "Upload a file attachment to a page. Use staging_id from prepare_upload for local files, or url to fetch from a remote URL.", json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string", "description": "Attachment name" },
                 "uploaded_to": { "type": "integer", "description": "Page ID to attach to" },
-                "staging_id": { "type": "string", "description": "Staging slot ID from prepare_upload (use instead of file_path/url when server cannot access local files)" },
-                "file_path": { "type": "string", "description": "Local filesystem path to the file" },
+                "staging_id": { "type": "string", "description": "Staging slot ID from prepare_upload — use for local file uploads" },
                 "url": { "type": "string", "description": "URL to fetch the file from" },
                 "filename": { "type": "string", "description": "Override the auto-detected filename" },
                 "mime_type": { "type": "string", "description": "MIME type of the file", "default": "application/octet-stream" }
@@ -1598,13 +1616,12 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
         })),
         tool("delete_image", "Delete an image from the gallery.",
             id_schema("image_id")),
-        tool("upload_image", "Upload an image to the BookStack image gallery from a local file path, URL, or staging slot.", json!({
+        tool("upload_image", "Upload an image to the BookStack image gallery. Use staging_id from prepare_upload for local files, or url to fetch from a remote URL.", json!({
             "type": "object",
             "properties": {
                 "name": { "type": "string", "description": "Image name" },
                 "uploaded_to": { "type": "integer", "description": "Page ID the image is associated with" },
-                "staging_id": { "type": "string", "description": "Staging slot ID from prepare_upload (use instead of file_path/url when server cannot access local files)" },
-                "file_path": { "type": "string", "description": "Local filesystem path to the image file" },
+                "staging_id": { "type": "string", "description": "Staging slot ID from prepare_upload — use for local file uploads" },
                 "url": { "type": "string", "description": "URL to fetch the image from" },
                 "filename": { "type": "string", "description": "Override the auto-detected filename" },
                 "type": { "type": "string", "enum": ["gallery", "drawio"], "description": "Image type", "default": "gallery" },
@@ -1612,7 +1629,7 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
             },
             "required": ["name", "uploaded_to"]
         })),
-        tool("prepare_upload", "Create a staging slot for file upload. Returns a staging_id and upload_url. Use when the server cannot access local files (e.g. running in Docker). Step 1: call prepare_upload to get a staging_id and upload_url. Step 2: POST a multipart/form-data request with a 'file' field to upload_url (relative to the MCP server base URL), including the same Authorization header. Step 3: call upload_image or upload_attachment with staging_id instead of file_path/url.", json!({
+        tool("prepare_upload", "Create a staging slot for uploading a local file. Returns a staging_id and upload_url. Step 1: call prepare_upload. Step 2: POST the file to upload_url as multipart/form-data with a 'file' field (no auth header needed): curl -X POST -F 'file=@/path/to/file' <upload_url>. Step 3: call upload_image or upload_attachment with the staging_id.", json!({
             "type": "object",
             "properties": {}
         })),

--- a/crates/bsmcp-server/src/staging.rs
+++ b/crates/bsmcp-server/src/staging.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::extract::{Multipart, Path, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::json;
@@ -29,11 +29,16 @@ pub fn new_staging_store() -> StagingStore {
 
 pub async fn consume_staged(store: &StagingStore, id: &str) -> Option<StagingEntry> {
     let mut map = store.write().await;
-    map.remove(id)
+    let entry = map.remove(id)?;
+    // Don't return empty pre-registered slots
+    if entry.bytes.is_empty() {
+        None
+    } else {
+        Some(entry)
+    }
 }
 
 pub fn cleanup_expired_sync(store: &StagingStore) {
-    // Use try_write to avoid blocking if someone else holds the lock
     if let Ok(mut map) = store.try_write() {
         let before = map.len();
         map.retain(|_, entry| entry.created_at.elapsed() < STAGING_TTL);
@@ -46,26 +51,19 @@ pub fn cleanup_expired_sync(store: &StagingStore) {
 
 pub async fn handle_stage_upload(
     State(state): State<AppState>,
-    headers: HeaderMap,
     Path(staging_id): Path<String>,
     mut multipart: Multipart,
 ) -> Response {
-    // Auth required
-    let (_token_id, _token_secret) = match crate::sse::resolve_credentials(
-        &headers,
-        state.db.as_ref(),
-        &state.known_urls,
-    ).await {
-        Ok(creds) => creds,
-        Err(resp) => return resp,
-    };
-
-    // Validate staging_id is a UUID
-    if uuid::Uuid::parse_str(&staging_id).is_err() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "Invalid staging_id format"})),
-        ).into_response();
+    // Auth is the staging_id itself — only someone who called prepare_upload
+    // (which requires MCP auth) has the UUID. Validate it exists in the store.
+    {
+        let store = state.staging.read().await;
+        if !store.contains_key(&staging_id) {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "Unknown staging_id — call prepare_upload first"})),
+            ).into_response();
+        }
     }
 
     // Extract the file from multipart
@@ -113,7 +111,7 @@ pub async fn handle_stage_upload(
 
     let size = bytes.len();
 
-    // Store in staging
+    // Replace the pre-registered slot with actual file data
     {
         let mut store = state.staging.write().await;
         store.insert(staging_id.clone(), StagingEntry {


### PR DESCRIPTION
## Summary
- Remove `file_path` parameter from `upload_image` and `upload_attachment` (server runs in Docker, local paths never work)
- Pre-register staging slots so the UUID acts as auth on the upload endpoint (no Bearer token needed on curl)
- Return absolute `upload_url` from `prepare_upload` using `BSMCP_PUBLIC_DOMAIN`
- Update instructions to document staging upload flow
- Clear error when neither `staging_id` nor `url` provided

Closes #5

## Test plan
- [ ] `prepare_upload` returns full absolute URL (not relative)
- [ ] `curl -X POST -F 'file=@/path/to/file' <upload_url>` works without auth header
- [ ] `upload_image` with `staging_id` succeeds
- [ ] `upload_image` without `staging_id` or `url` returns clear error
- [ ] `file_path` parameter is no longer accepted
- [ ] Unknown staging_id on upload endpoint returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)