### PR TITLE
Require descriptions on create_shelf/book/chapter + document staging upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An MCP (Model Context Protocol) server that gives Claude full access to a [BookS
 - **Pluggable database** — SQLite for simple deployments, PostgreSQL + pgvector for production
 - **Separate embedder** — background embedding service with pluggable backends (local ONNX, Ollama, OpenAI)
 - **Server-side markdown to HTML conversion** — send markdown, server converts before sending to BookStack
+- **Staging upload flow** — upload local images and attachments through a two-step staging endpoint without exposing local paths to the container ([see below](#uploading-local-files-images--attachments))
 - **OAuth 2.1 support** — use as a Claude.ai or Claude Desktop custom connector without config files
 - **Encrypted token storage** — OAuth tokens encrypted at rest with AES-256-GCM
 - **Dual transport** — SSE (MCP 2024-11-05) and Streamable HTTP (MCP 2025-03-26)
@@ -543,6 +544,57 @@ The `search_content` tool supports BookStack's search operators:
 - `{in_name:term}` - Search within names only
 - `{created_by:me}` - Filter by creator
 - `[tag_name=value]` - Filter by tag
+
+## Uploading Local Files (Images & Attachments)
+
+The MCP server runs in a container and cannot read files from the client machine's filesystem directly. To upload local images or file attachments, use the two-step **staging upload flow**:
+
+**Step 1:** Call `prepare_upload` — returns a `staging_id` and a full `upload_url`:
+
+```json
+{
+  "staging_id": "f0103f6c-7c98-46c2-adbe-606ba26937c3",
+  "upload_url": "https://your-mcp-host/stage/upload/f0103f6c-7c98-46c2-adbe-606ba26937c3",
+  "ttl_seconds": 300
+}
+```
+
+**Step 2:** POST the file to `upload_url` as multipart form-data. No auth header needed — the `staging_id` (a UUID that can only be generated via an authenticated MCP call) acts as the auth token for the one-time upload:
+
+```bash
+curl -X POST -F "file=@/path/to/image.jpg" \
+  "https://your-mcp-host/stage/upload/f0103f6c-7c98-46c2-adbe-606ba26937c3"
+```
+
+**Step 3:** Call `upload_image` (or `upload_attachment`) with the `staging_id`:
+
+```json
+{
+  "name": "Banner Logo",
+  "uploaded_to": 1908,
+  "staging_id": "f0103f6c-7c98-46c2-adbe-606ba26937c3",
+  "mime_type": "image/jpeg",
+  "embed": true
+}
+```
+
+The staging slot is **consumed on first use** (destructively removed from the store) and **auto-expires after 5 minutes**. Maximum file size is 50MB.
+
+### The `embed` parameter
+
+`upload_image` accepts an `embed` boolean parameter (default `false`). When `embed=true`, the image is automatically appended to the target page's content after uploading, so you don't need a separate `edit_page` or `append_to_page` call. Works for both markdown and WYSIWYG pages.
+
+### Alternative: `url` parameter
+
+If the file is already hosted at a public URL the MCP server can reach, you can skip the staging flow entirely and pass the `url` parameter directly to `upload_image` or `upload_attachment`. The server will fetch the file and forward it to BookStack.
+
+### Currently Claude Code only
+
+**The staging upload flow currently only works from [Claude Code](https://claude.com/claude-code) (the CLI tool).** It does not work from Claude.ai's web custom connectors or Claude Desktop custom connectors.
+
+The reason: Step 2 requires the MCP client to make an outbound HTTP POST to the MCP server's staging endpoint with the file bytes. Claude Code runs locally and has shell access (via its `Bash` tool), so it can `curl` the file directly. Claude.ai's remote MCP connector runs the MCP client inside Anthropic's sandboxed proxy infrastructure, which does not expose a mechanism for the client to make arbitrary HTTP file uploads to third-party hosts. Claude Desktop has similar limitations today.
+
+If you're using Claude.ai or Claude Desktop, you can still use `upload_image` with the `url` parameter for files that are already web-accessible, or upload through the BookStack web UI directly.
 
 ## License
 

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -126,7 +126,7 @@ async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semant
         }
         "create_shelf" => {
             let name = arg_str(args, "name")?;
-            let desc = arg_str_default(args, "description", "");
+            let desc = require_description(args, "shelf")?;
             let result = client.create_shelf(&name, &desc).await?;
             Ok(format_shelf_success("Shelf created successfully.", &result, client.base_url()))
         }
@@ -157,7 +157,7 @@ async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semant
         }
         "create_book" => {
             let name = arg_str(args, "name")?;
-            let desc = arg_str_default(args, "description", "");
+            let desc = require_description(args, "book")?;
             let result = client.create_book(&name, &desc).await?;
             Ok(format_book_success("Book created successfully.", &result, client.base_url()))
         }
@@ -186,7 +186,7 @@ async fn execute_tool(name: &str, args: &Value, client: &BookStackClient, semant
         "create_chapter" => {
             let book_id = arg_i64_required(args, "book_id")?;
             let name = arg_str(args, "name")?;
-            let desc = arg_str_default(args, "description", "");
+            let desc = require_description(args, "chapter")?;
             let result = client.create_chapter(book_id, &name, &desc).await?;
             Ok(format_chapter_success("Chapter created successfully.", &result, client.base_url()))
         }
@@ -787,6 +787,39 @@ fn join_base_url(base_url: &str, path: &str) -> String {
     }
 }
 
+/// Require a non-empty, meaningful description when creating shelves/books/chapters.
+/// Descriptions are surfaced to AI clients in the server's structure listing on connect,
+/// so missing or placeholder descriptions actively degrade future routing decisions.
+fn require_description(args: &Value, kind: &str) -> Result<String, String> {
+    let raw = args.get("description").and_then(|v| v.as_str()).unwrap_or("").trim();
+    if raw.is_empty() {
+        return Err(format!(
+            "description is required when creating a {kind}. \
+             Descriptions are surfaced to all Claude clients that connect to this BookStack, \
+             so they shape placement decisions for every future page created here. \
+             Provide a 1-2 sentence description that answers (1) what kind of content lives in \
+             this {kind}, and (2) what it's for. Avoid placeholders like 'TODO' or 'description'."
+        ));
+    }
+    if raw.len() < 15 {
+        return Err(format!(
+            "description is too short ({} chars) — write a meaningful 1-2 sentence description \
+             that tells future clients what content belongs in this {kind} and what it's for.",
+            raw.len()
+        ));
+    }
+    let lowered = raw.to_lowercase();
+    let placeholders = ["todo", "tbd", "placeholder", "description", "xxx", "fixme", "n/a"];
+    if placeholders.iter().any(|p| lowered == *p || lowered.starts_with(&format!("{p} "))) {
+        return Err(format!(
+            "description looks like a placeholder ('{raw}'). Write a real description that \
+             describes the {kind}'s purpose and contents — it will be shown to every future \
+             Claude client that connects."
+        ));
+    }
+    Ok(raw.to_string())
+}
+
 fn validate_enum(value: &str, allowed: &[&str], name: &str) -> Result<(), String> {
     if allowed.contains(&value) {
         Ok(())
@@ -1204,6 +1237,17 @@ async fn build_instructions(client: &BookStackClient, semantic_enabled: bool, su
          content. If the user asks to create content in a location that doesn't match the \
          target's purpose, push back and suggest the correct location. When unsure, check the \
          shelf/book/chapter descriptions using get_shelf, get_book, or get_chapter.\n\n\
+         IMPORTANT: Descriptions on shelves, books, and chapters are REQUIRED, not optional. \
+         When you call create_shelf, create_book, or create_chapter, you MUST provide a \
+         meaningful 1-2 sentence description. Descriptions are surfaced to every Claude \
+         client that connects to this BookStack — they literally shape how future content \
+         gets routed. A good description answers: (1) what kind of content lives here, and \
+         (2) what is this container for (so a future AI can decide whether new content \
+         belongs here vs elsewhere). Do NOT use placeholders like 'TODO', 'description', or \
+         'n/a' — the server will reject them. If you don't yet know what the container is \
+         for, ask the user before creating it. When you update existing shelves/books/chapters \
+         via update_shelf, update_book, or update_chapter and notice the description is \
+         missing or weak, offer to improve it.\n\n\
          Markdown content is automatically converted to HTML server-side. \
          You can send markdown via the 'markdown' parameter for pages and comments — \
          the server handles conversion reliably, avoiding JSON escaping issues with \
@@ -1375,7 +1419,7 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
             paginated_schema()),
         tool("get_shelf", "Get a shelf by ID, including its books.",
             id_schema("shelf_id")),
-        tool("create_shelf", "Create a new shelf.",
+        tool("create_shelf", "Create a new shelf. Description is REQUIRED — it tells future Claude clients what belongs here.",
             name_desc_schema()),
         tool("update_shelf", "Update a shelf's name, description, or set which books it contains via the 'books' array (replaces all existing book assignments on this shelf).", json!({
             "type": "object",
@@ -1394,7 +1438,7 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
         tool("list_books", "List all books.", paginated_schema()),
         tool("get_book", "Get a book by ID, including its chapters and pages.",
             id_schema("book_id")),
-        tool("create_book", "Create a new book.",
+        tool("create_book", "Create a new book. Description is REQUIRED — it tells future Claude clients what belongs here.",
             name_desc_schema()),
         tool("update_book", "Update a book.",
             update_schema("book_id", &["name", "description"])),
@@ -1405,14 +1449,17 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
         tool("list_chapters", "List all chapters across all books.", paginated_schema()),
         tool("get_chapter", "Get a chapter by ID, including its pages.",
             id_schema("chapter_id")),
-        tool("create_chapter", "Create a new chapter within a book.", json!({
+        tool("create_chapter", "Create a new chapter within a book. Description is REQUIRED — it tells future Claude clients what belongs here.", json!({
             "type": "object",
             "properties": {
                 "book_id": { "type": "integer", "description": "Book ID to create chapter in" },
                 "name": { "type": "string", "description": "Chapter name" },
-                "description": { "type": "string", "description": "Chapter description", "default": "" }
+                "description": {
+                    "type": "string",
+                    "description": "REQUIRED. A 1-2 sentence description of what content lives in this chapter and what it's for. Surfaced to every Claude client that connects, so it shapes future routing decisions. Do not use placeholders like 'TODO' or 'description'."
+                }
             },
-            "required": ["book_id", "name"]
+            "required": ["book_id", "name", "description"]
         })),
         tool("update_chapter", "Update a chapter's name, description, or move it to a different book by providing book_id.", json!({
             "type": "object",
@@ -1768,9 +1815,12 @@ fn name_desc_schema() -> Value {
         "type": "object",
         "properties": {
             "name": { "type": "string", "description": "Name" },
-            "description": { "type": "string", "description": "Description", "default": "" }
+            "description": {
+                "type": "string",
+                "description": "REQUIRED. A 1-2 sentence description of what content lives here and what it's for. Surfaced to every Claude client that connects, so it shapes future routing decisions. Do not use placeholders like 'TODO' or 'description'."
+            }
         },
-        "required": ["name"]
+        "required": ["name", "description"]
     })
 }
 


### PR DESCRIPTION
## Summary

Closes a silent gap where `create_shelf`, `create_book`, and `create_chapter` were treating descriptions as optional. Because the server surfaces the full BookStack hierarchy with descriptions in its connect-time instructions, every bare entity degrades future routing decisions for every AI client that connects. Missing descriptions aren't just cosmetic — they actively reduce the signal the AI has for where new content belongs.

### Behavior change

- **Schema level:** \`description\` is now in the \`required\` array for all three creation tools. AI clients that inspect tool schemas (which most do) will see it as required.
- **Handler level:** New \`require_description()\` helper rejects empty descriptions, placeholder strings (\`TODO\`, \`TBD\`, \`placeholder\`, \`description\`, \`xxx\`, \`fixme\`, \`n/a\`), and anything shorter than 15 characters. The error message explains *why* and gives guidance on what a good description looks like.
- **Instructions level:** Server instructions now include an IMPORTANT paragraph telling clients descriptions are required and what a good one answers: (1) what kind of content lives here, and (2) what the container is for.

This is intentional three-layer enforcement — schema signal, handler validation, and instruction text explaining the contract — so AI clients don't just type \"TODO\" to satisfy the validator.

### Also in this PR: README docs for staging upload

The image upload feature shipped in v0.7 had no README documentation. Added a new \"Uploading Local Files (Images & Attachments)\" section documenting:

- The three-step staging flow (\`prepare_upload\` → curl POST → \`upload_image\`)
- The \`embed\` parameter on \`upload_image\` for auto-appending to the target page
- The \`url\` alternative for publicly-hosted files
- **Important caveat:** the staging flow currently only works from **Claude Code** (the CLI tool). Claude.ai and Claude Desktop's remote MCP connectors can't do step 2 because they run inside Anthropic's sandboxed proxy infrastructure, which doesn't expose a way for the client to make arbitrary HTTP POSTs to third-party hosts. Claude Code has shell access via its Bash tool, so it can \`curl\` directly.

## Test plan
- [x] Compiles cleanly (only pre-existing warning in embedder)
- [ ] Try to \`create_book\` without a description → should get a clear error explaining why descriptions are required
- [ ] Try \`create_chapter\` with description=\"TODO\" → should be rejected as placeholder
- [ ] Try \`create_shelf\` with description=\"test\" → should be rejected as too short
- [ ] Create with a real description → should succeed
- [ ] Connect a fresh Claude client and verify the instructions include the new IMPORTANT paragraph about descriptions
- [ ] Verify the tool schema now shows description in \`required\` for all three creation tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)