### PR TITLE
Memory flow: admin-only globals, org defaults, content-perm lock, setup nudge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,14 @@ Browser-based config page. Token-gated via the same `/authorize` form, but skips
 
 The page lets users pick their book/chapter IDs from dropdowns (populated from BookStack's list APIs), toggle the semantic-search targets, and configure recent-counts. Save → upserts the `user_settings` row. Re-auth button at the bottom redirects back through `/authorize` with the same return_to flow.
 
-**Global shelves:** the Hive shelf and User Journals shelf are stored in a separate `global_settings` table (single row) and shared across every user on the same BookStack instance. First user to set them wins; subsequent users see the dropdowns rendered as locked. Per-user `ai_hive_shelf_id` is auto-mirrored from the global value.
+**Global shelves:** the Hive shelf and User Journals shelf are stored in a separate `global_settings` table (single row) and shared across every user on the same BookStack instance. **Admin-only and one-shot** — only BookStack admins (probed via `/api/users` access) can set them, and once set they're locked. Non-admin users see the fields rendered as info-only. The MCP tools have no write path for global shelves; they must be set via the `/settings` UI by an admin. Per-user `ai_hive_shelf_id` is auto-mirrored from the global value on save.
+
+**User settings vs global shelves — where to configure:**
+
+| Config | UI (`/settings`) | MCP (`remember_config`) |
+|---|---|---|
+| Per-user settings (book/chapter IDs, semantic toggles, etc.) | yes | yes — `action=read` / `action=write` with full `settings` object |
+| Global shelf IDs | yes (admins only, first-write-wins) | **no** — UI is the only path |
 
 **Auto-create:** every book/chapter setting has a "Create if missing" checkbox. On save, the server creates absent structure in dependency order (shelves → books → chapters) using sensible default names from the naming module. Permission denials surface as warnings rather than blocking the save.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,8 +148,10 @@ The page lets users pick their book/chapter IDs from dropdowns (populated from B
 
 | Config | UI (`/settings`) | MCP (`remember_config`) |
 |---|---|---|
-| Per-user settings (book/chapter IDs, semantic toggles, etc.) | yes | yes — `action=read` / `action=write` with full `settings` object |
-| Global shelf IDs | yes (admins only, first-write-wins) | **no** — UI is the only path |
+| Per-user settings | any user | `action=write` with `settings` object |
+| Global shelves | admins only, first-write-wins | `action=write` with `global_settings` object — admin-checked server-side, first-write-wins enforced (already-set fields trigger a `global_locked` warning rather than overwriting) |
+
+`remember_config action=read` returns both `{settings, global_settings}` in one envelope.
 
 **Auto-create:** every book/chapter setting has a "Create if missing" checkbox. On save, the server creates absent structure in dependency order (shelves → books → chapters) using sensible default names from the naming module. Permission denials surface as warnings rather than blocking the save.
 

--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -406,6 +406,31 @@ impl BookStackClient {
         }
     }
 
+    /// Look up BookStack's "Admin" role ID. Used to lock auto-created Hive
+    /// content to admin-only edit. Matches `display_name` case-insensitively
+    /// against "admin"; returns the first match. Errors if no matching role
+    /// is found (caller should treat as a non-fatal warning).
+    pub async fn find_admin_role_id(&self) -> Result<i64, String> {
+        let resp = self.list_roles(50, 0).await?;
+        let data = resp
+            .get("data")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        for role in data {
+            let name = role
+                .get("display_name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("");
+            if name.eq_ignore_ascii_case("admin") {
+                if let Some(id) = role.get("id").and_then(|i| i.as_i64()) {
+                    return Ok(id);
+                }
+            }
+        }
+        Err("No role named \"Admin\" found in BookStack — cannot apply admin-only permission lock".to_string())
+    }
+
     // --- Permission check ---
 
     /// Check if the user can access a specific page.

--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -394,6 +394,18 @@ impl BookStackClient {
         self.get("books", &[("count", "1")]).await
     }
 
+    /// Heuristic admin check: BookStack returns 403 from `/api/users` for
+    /// non-admins. We don't need the user list, just the success/failure.
+    /// Returns Ok(true) on success, Ok(false) on a 403, Err on other failures
+    /// (so callers can distinguish "not admin" from "couldn't reach BookStack").
+    pub async fn is_admin(&self) -> Result<bool, String> {
+        match self.list_users(1, 0).await {
+            Ok(_) => Ok(true),
+            Err(e) if e.contains("403") || e.to_lowercase().contains("forbidden") => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
     // --- Permission check ---
 
     /// Check if the user can access a specific page.

--- a/crates/bsmcp-common/src/settings.rs
+++ b/crates/bsmcp-common/src/settings.rs
@@ -184,6 +184,21 @@ pub struct GlobalSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_journals_shelf_id: Option<i64>,
 
+    /// Org-wide default AI identity manifest page ID. When a user has not set
+    /// their own `ai_identity_page_id`, the briefing / whoami response falls
+    /// back to this. Lets an admin stand up a "house" agent that any new user
+    /// gets automatically.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_ai_identity_page_id: Option<i64>,
+
+    /// Default AI identity display name (paired with the page above).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_ai_identity_name: Option<String>,
+
+    /// Default AI identity OUID (paired with the page above).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_ai_identity_ouid: Option<String>,
+
     /// Hash of the first token_id that set these values (informational; does
     /// not gate writes — UI handles the lock-after-set semantics).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -192,4 +207,31 @@ pub struct GlobalSettings {
     /// Unix epoch seconds of last update. 0 = never set.
     #[serde(default)]
     pub updated_at: i64,
+}
+
+impl GlobalSettings {
+    /// Resolve the AI identity for a user — user's own settings take precedence,
+    /// org defaults fill in any nulls. Returns the page_id, name, ouid triple.
+    pub fn resolve_identity(&self, user: &UserSettings) -> ResolvedIdentity {
+        ResolvedIdentity {
+            page_id: user.ai_identity_page_id.or(self.default_ai_identity_page_id),
+            name: user.ai_identity_name.clone().or_else(|| self.default_ai_identity_name.clone()),
+            ouid: user.ai_identity_ouid.clone().or_else(|| self.default_ai_identity_ouid.clone()),
+            using_default: user.ai_identity_page_id.is_none()
+                && self.default_ai_identity_page_id.is_some(),
+        }
+    }
+}
+
+/// Output of [`GlobalSettings::resolve_identity`] — the AI identity to use for
+/// a request after applying the user → org-default fallback chain.
+#[derive(Clone, Debug)]
+pub struct ResolvedIdentity {
+    pub page_id: Option<i64>,
+    pub name: Option<String>,
+    pub ouid: Option<String>,
+    /// True when the resolved page_id came from the org default (not the user).
+    /// Surfaced in the briefing response so the AI knows it's running on the
+    /// house identity rather than its own configured one.
+    pub using_default: bool,
 }

--- a/crates/bsmcp-common/src/settings.rs
+++ b/crates/bsmcp-common/src/settings.rs
@@ -135,6 +135,14 @@ pub struct UserSettings {
     /// Number of active collage entries to include (default 10).
     #[serde(default = "default_collage_count")]
     pub active_collage_count: usize,
+
+    /// Unix epoch seconds until which the briefing's "configure your settings"
+    /// nudge is snoozed. When `now < this`, the nudge is suppressed. Set via
+    /// `remember_config action=dismiss_setup_nudge days=N`. Auto-becomes
+    /// irrelevant once any user setting is configured (the nudge predicate
+    /// already returns false in that case).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settings_nudge_dismissed_until: Option<i64>,
 }
 
 fn default_true() -> bool {
@@ -198,6 +206,24 @@ pub struct GlobalSettings {
     /// Default AI identity OUID (paired with the page above).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_ai_identity_ouid: Option<String>,
+
+    /// Org-mandated instruction pages — included verbatim in every briefing
+    /// response. Use for content that EVERY agent on this BookStack must
+    /// follow regardless of who they are (compliance directives, escalation
+    /// rules, etc.). Admin-only.
+    ///
+    /// Page IDs only (not chapters) — keeps the response size predictable and
+    /// auditable. If the policy set evolves frequently, an admin updates this
+    /// list rather than letting a chapter's contents drift into every briefing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub org_required_instructions_page_ids: Vec<i64>,
+
+    /// Org AI-usage policy pages — included verbatim in every briefing.
+    /// Same shape as org_required_instructions but tagged separately so the
+    /// AI can distinguish "policy" (what we're allowed/required to do) from
+    /// "instructions" (how to act). Admin-only. Page IDs only.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub org_ai_usage_policy_page_ids: Vec<i64>,
 
     /// Hash of the first token_id that set these values (informational; does
     /// not gate writes — UI handles the lock-after-set semantics).

--- a/crates/bsmcp-db-postgres/src/lib.rs
+++ b/crates/bsmcp-db-postgres/src/lib.rs
@@ -113,6 +113,9 @@ impl PostgresDb {
                 id INT PRIMARY KEY CHECK (id = 1),
                 hive_shelf_id BIGINT,
                 user_journals_shelf_id BIGINT,
+                default_ai_identity_page_id BIGINT,
+                default_ai_identity_name TEXT,
+                default_ai_identity_ouid TEXT,
                 set_by_token_hash TEXT,
                 updated_at BIGINT NOT NULL DEFAULT 0
             )"
@@ -120,6 +123,15 @@ impl PostgresDb {
         .execute(&pool)
         .await
         .map_err(|e| format!("Failed to create global_settings table: {e}"))?;
+
+        // Migrations for older deployments — ADD COLUMN IF NOT EXISTS is supported in PG 9.6+.
+        for sql in [
+            "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS default_ai_identity_page_id BIGINT",
+            "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS default_ai_identity_name TEXT",
+            "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS default_ai_identity_ouid TEXT",
+        ] {
+            sqlx::query(sql).execute(&pool).await.ok();
+        }
 
         sqlx::query("INSERT INTO global_settings (id, updated_at) VALUES (1, 0) ON CONFLICT (id) DO NOTHING")
             .execute(&pool).await.ok();
@@ -393,7 +405,9 @@ impl DbBackend for PostgresDb {
 
     async fn get_global_settings(&self) -> Result<GlobalSettings, String> {
         let row = sqlx::query(
-            "SELECT hive_shelf_id, user_journals_shelf_id, set_by_token_hash, updated_at
+            "SELECT hive_shelf_id, user_journals_shelf_id,
+                    default_ai_identity_page_id, default_ai_identity_name, default_ai_identity_ouid,
+                    set_by_token_hash, updated_at
              FROM global_settings WHERE id = 1"
         )
         .fetch_optional(&self.pool)
@@ -403,6 +417,9 @@ impl DbBackend for PostgresDb {
         Ok(row.map(|r| GlobalSettings {
             hive_shelf_id: r.get("hive_shelf_id"),
             user_journals_shelf_id: r.get("user_journals_shelf_id"),
+            default_ai_identity_page_id: r.get("default_ai_identity_page_id"),
+            default_ai_identity_name: r.get("default_ai_identity_name"),
+            default_ai_identity_ouid: r.get("default_ai_identity_ouid"),
             set_by_token_hash: r.get("set_by_token_hash"),
             updated_at: r.get("updated_at"),
         }).unwrap_or_default())
@@ -426,12 +443,18 @@ impl DbBackend for PostgresDb {
             "UPDATE global_settings
              SET hive_shelf_id = $1,
                  user_journals_shelf_id = $2,
-                 set_by_token_hash = $3,
-                 updated_at = $4
+                 default_ai_identity_page_id = $3,
+                 default_ai_identity_name = $4,
+                 default_ai_identity_ouid = $5,
+                 set_by_token_hash = $6,
+                 updated_at = $7
              WHERE id = 1"
         )
         .bind(settings.hive_shelf_id)
         .bind(settings.user_journals_shelf_id)
+        .bind(settings.default_ai_identity_page_id)
+        .bind(&settings.default_ai_identity_name)
+        .bind(&settings.default_ai_identity_ouid)
         .bind(&final_setter)
         .bind(Self::now_secs())
         .execute(&self.pool)

--- a/crates/bsmcp-db-postgres/src/lib.rs
+++ b/crates/bsmcp-db-postgres/src/lib.rs
@@ -19,6 +19,17 @@ use bsmcp_common::types::*;
 const BASE64: base64::engine::general_purpose::GeneralPurpose =
     base64::engine::general_purpose::STANDARD;
 
+fn encode_id_list(ids: &[i64]) -> Option<String> {
+    if ids.is_empty() { None } else { serde_json::to_string(ids).ok() }
+}
+
+fn decode_id_list(value: Option<String>) -> Vec<i64> {
+    match value {
+        Some(s) if !s.is_empty() => serde_json::from_str(&s).unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
 pub struct PostgresDb {
     pool: PgPool,
     encryption_key: Zeroizing<[u8; 32]>,
@@ -116,6 +127,8 @@ impl PostgresDb {
                 default_ai_identity_page_id BIGINT,
                 default_ai_identity_name TEXT,
                 default_ai_identity_ouid TEXT,
+                org_required_instructions_page_ids TEXT,
+                org_ai_usage_policy_page_ids TEXT,
                 set_by_token_hash TEXT,
                 updated_at BIGINT NOT NULL DEFAULT 0
             )"
@@ -125,10 +138,15 @@ impl PostgresDb {
         .map_err(|e| format!("Failed to create global_settings table: {e}"))?;
 
         // Migrations for older deployments — ADD COLUMN IF NOT EXISTS is supported in PG 9.6+.
+        // org_*_chapter_ids columns were briefly added during this PR's development and
+        // then dropped in favour of page-IDs-only — leaving any existing columns in place
+        // is harmless since we no longer read or write them.
         for sql in [
             "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS default_ai_identity_page_id BIGINT",
             "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS default_ai_identity_name TEXT",
             "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS default_ai_identity_ouid TEXT",
+            "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS org_required_instructions_page_ids TEXT",
+            "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS org_ai_usage_policy_page_ids TEXT",
         ] {
             sqlx::query(sql).execute(&pool).await.ok();
         }
@@ -407,6 +425,8 @@ impl DbBackend for PostgresDb {
         let row = sqlx::query(
             "SELECT hive_shelf_id, user_journals_shelf_id,
                     default_ai_identity_page_id, default_ai_identity_name, default_ai_identity_ouid,
+                    org_required_instructions_page_ids,
+                    org_ai_usage_policy_page_ids,
                     set_by_token_hash, updated_at
              FROM global_settings WHERE id = 1"
         )
@@ -420,6 +440,8 @@ impl DbBackend for PostgresDb {
             default_ai_identity_page_id: r.get("default_ai_identity_page_id"),
             default_ai_identity_name: r.get("default_ai_identity_name"),
             default_ai_identity_ouid: r.get("default_ai_identity_ouid"),
+            org_required_instructions_page_ids: decode_id_list(r.get("org_required_instructions_page_ids")),
+            org_ai_usage_policy_page_ids: decode_id_list(r.get("org_ai_usage_policy_page_ids")),
             set_by_token_hash: r.get("set_by_token_hash"),
             updated_at: r.get("updated_at"),
         }).unwrap_or_default())
@@ -446,8 +468,10 @@ impl DbBackend for PostgresDb {
                  default_ai_identity_page_id = $3,
                  default_ai_identity_name = $4,
                  default_ai_identity_ouid = $5,
-                 set_by_token_hash = $6,
-                 updated_at = $7
+                 org_required_instructions_page_ids = $6,
+                 org_ai_usage_policy_page_ids = $7,
+                 set_by_token_hash = $8,
+                 updated_at = $9
              WHERE id = 1"
         )
         .bind(settings.hive_shelf_id)
@@ -455,6 +479,8 @@ impl DbBackend for PostgresDb {
         .bind(settings.default_ai_identity_page_id)
         .bind(&settings.default_ai_identity_name)
         .bind(&settings.default_ai_identity_ouid)
+        .bind(encode_id_list(&settings.org_required_instructions_page_ids))
+        .bind(encode_id_list(&settings.org_ai_usage_policy_page_ids))
         .bind(&final_setter)
         .bind(Self::now_secs())
         .execute(&self.pool)

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -73,6 +73,8 @@ impl SqliteDb {
                  default_ai_identity_page_id INTEGER,
                  default_ai_identity_name TEXT,
                  default_ai_identity_ouid TEXT,
+                 org_required_instructions_page_ids TEXT,
+                 org_ai_usage_policy_page_ids TEXT,
                  set_by_token_hash TEXT,
                  updated_at INTEGER NOT NULL DEFAULT 0
              );
@@ -84,10 +86,16 @@ impl SqliteDb {
         // Migrations: ALTER existing global_settings rows to gain new columns.
         // SQLite doesn't support IF NOT EXISTS on ALTER ADD COLUMN; ignore the
         // duplicate-column error.
+        // Note: org_*_chapter_ids columns were briefly added during this PR's
+        // development and then dropped in favour of page-IDs-only. Existing
+        // rows with values in those columns are simply ignored — the columns
+        // remain on disk but are not read by the application.
         for sql in [
             "ALTER TABLE global_settings ADD COLUMN default_ai_identity_page_id INTEGER",
             "ALTER TABLE global_settings ADD COLUMN default_ai_identity_name TEXT",
             "ALTER TABLE global_settings ADD COLUMN default_ai_identity_ouid TEXT",
+            "ALTER TABLE global_settings ADD COLUMN org_required_instructions_page_ids TEXT",
+            "ALTER TABLE global_settings ADD COLUMN org_ai_usage_policy_page_ids TEXT",
         ] {
             conn.execute_batch(sql).ok();
         }
@@ -411,6 +419,8 @@ impl DbBackend for SqliteDb {
             let row = conn.query_row(
                 "SELECT hive_shelf_id, user_journals_shelf_id,
                         default_ai_identity_page_id, default_ai_identity_name, default_ai_identity_ouid,
+                        org_required_instructions_page_ids,
+                        org_ai_usage_policy_page_ids,
                         set_by_token_hash, updated_at
                  FROM global_settings WHERE id = 1",
                 [],
@@ -420,8 +430,10 @@ impl DbBackend for SqliteDb {
                     default_ai_identity_page_id: row.get::<_, Option<i64>>(2)?,
                     default_ai_identity_name: row.get::<_, Option<String>>(3)?,
                     default_ai_identity_ouid: row.get::<_, Option<String>>(4)?,
-                    set_by_token_hash: row.get::<_, Option<String>>(5)?,
-                    updated_at: row.get::<_, i64>(6)?,
+                    org_required_instructions_page_ids: decode_id_list(row.get::<_, Option<String>>(5)?),
+                    org_ai_usage_policy_page_ids: decode_id_list(row.get::<_, Option<String>>(6)?),
+                    set_by_token_hash: row.get::<_, Option<String>>(7)?,
+                    updated_at: row.get::<_, i64>(8)?,
                 }),
             ).unwrap_or_default();
             Ok(row)
@@ -453,8 +465,10 @@ impl DbBackend for SqliteDb {
                      default_ai_identity_page_id = ?3,
                      default_ai_identity_name = ?4,
                      default_ai_identity_ouid = ?5,
-                     set_by_token_hash = ?6,
-                     updated_at = ?7
+                     org_required_instructions_page_ids = ?6,
+                     org_ai_usage_policy_page_ids = ?7,
+                     set_by_token_hash = ?8,
+                     updated_at = ?9
                  WHERE id = 1",
                 params![
                     s.hive_shelf_id,
@@ -462,6 +476,8 @@ impl DbBackend for SqliteDb {
                     s.default_ai_identity_page_id,
                     s.default_ai_identity_name,
                     s.default_ai_identity_ouid,
+                    encode_id_list(&s.org_required_instructions_page_ids),
+                    encode_id_list(&s.org_ai_usage_policy_page_ids),
                     final_setter,
                     SqliteDb::now_secs(),
                 ],
@@ -1301,6 +1317,19 @@ impl SemanticDb for SqliteDb {
         })
         .await
         .map_err(|e| format!("Task failed: {e}"))?
+    }
+}
+
+/// Encode a Vec<i64> as a JSON array string (or NULL when empty so the column
+/// reads back as Option::None and round-trips cleanly).
+fn encode_id_list(ids: &[i64]) -> Option<String> {
+    if ids.is_empty() { None } else { serde_json::to_string(ids).ok() }
+}
+
+fn decode_id_list(value: Option<String>) -> Vec<i64> {
+    match value {
+        Some(s) if !s.is_empty() => serde_json::from_str(&s).unwrap_or_default(),
+        _ => Vec::new(),
     }
 }
 

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -70,6 +70,9 @@ impl SqliteDb {
                  id INTEGER PRIMARY KEY CHECK (id = 1),
                  hive_shelf_id INTEGER,
                  user_journals_shelf_id INTEGER,
+                 default_ai_identity_page_id INTEGER,
+                 default_ai_identity_name TEXT,
+                 default_ai_identity_ouid TEXT,
                  set_by_token_hash TEXT,
                  updated_at INTEGER NOT NULL DEFAULT 0
              );
@@ -77,6 +80,17 @@ impl SqliteDb {
              DROP TABLE IF EXISTS registrations;",
         )
         .expect("Failed to initialize database schema");
+
+        // Migrations: ALTER existing global_settings rows to gain new columns.
+        // SQLite doesn't support IF NOT EXISTS on ALTER ADD COLUMN; ignore the
+        // duplicate-column error.
+        for sql in [
+            "ALTER TABLE global_settings ADD COLUMN default_ai_identity_page_id INTEGER",
+            "ALTER TABLE global_settings ADD COLUMN default_ai_identity_name TEXT",
+            "ALTER TABLE global_settings ADD COLUMN default_ai_identity_ouid TEXT",
+        ] {
+            conn.execute_batch(sql).ok();
+        }
 
         let hash = sha2::Sha256::digest(encryption_key.as_bytes());
         let mut key = Zeroizing::new([0u8; 32]);
@@ -395,13 +409,19 @@ impl DbBackend for SqliteDb {
         tokio::task::spawn_blocking(move || -> Result<GlobalSettings, String> {
             let conn = conn.lock().unwrap();
             let row = conn.query_row(
-                "SELECT hive_shelf_id, user_journals_shelf_id, set_by_token_hash, updated_at FROM global_settings WHERE id = 1",
+                "SELECT hive_shelf_id, user_journals_shelf_id,
+                        default_ai_identity_page_id, default_ai_identity_name, default_ai_identity_ouid,
+                        set_by_token_hash, updated_at
+                 FROM global_settings WHERE id = 1",
                 [],
                 |row| Ok(GlobalSettings {
                     hive_shelf_id: row.get::<_, Option<i64>>(0)?,
                     user_journals_shelf_id: row.get::<_, Option<i64>>(1)?,
-                    set_by_token_hash: row.get::<_, Option<String>>(2)?,
-                    updated_at: row.get::<_, i64>(3)?,
+                    default_ai_identity_page_id: row.get::<_, Option<i64>>(2)?,
+                    default_ai_identity_name: row.get::<_, Option<String>>(3)?,
+                    default_ai_identity_ouid: row.get::<_, Option<String>>(4)?,
+                    set_by_token_hash: row.get::<_, Option<String>>(5)?,
+                    updated_at: row.get::<_, i64>(6)?,
                 }),
             ).unwrap_or_default();
             Ok(row)
@@ -420,8 +440,6 @@ impl DbBackend for SqliteDb {
         let setter = set_by_token_hash.to_string();
         tokio::task::spawn_blocking(move || {
             let conn = conn.lock().unwrap();
-            // If the row was never set (updated_at == 0), record this writer as the original setter.
-            // Otherwise preserve the existing set_by_token_hash.
             let existing_setter: Option<String> = conn.query_row(
                 "SELECT set_by_token_hash FROM global_settings WHERE id = 1 AND updated_at > 0",
                 [],
@@ -432,10 +450,21 @@ impl DbBackend for SqliteDb {
                 "UPDATE global_settings
                  SET hive_shelf_id = ?1,
                      user_journals_shelf_id = ?2,
-                     set_by_token_hash = ?3,
-                     updated_at = ?4
+                     default_ai_identity_page_id = ?3,
+                     default_ai_identity_name = ?4,
+                     default_ai_identity_ouid = ?5,
+                     set_by_token_hash = ?6,
+                     updated_at = ?7
                  WHERE id = 1",
-                params![s.hive_shelf_id, s.user_journals_shelf_id, final_setter, SqliteDb::now_secs()],
+                params![
+                    s.hive_shelf_id,
+                    s.user_journals_shelf_id,
+                    s.default_ai_identity_page_id,
+                    s.default_ai_identity_name,
+                    s.default_ai_identity_ouid,
+                    final_setter,
+                    SqliteDb::now_secs(),
+                ],
             ).map_err(|e| format!("save_global_settings: {e}"))?;
             Ok(())
         })

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -1909,10 +1909,11 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
 
     tools.push(remember_tool(
         "config",
-        "Per-user settings (the same object the /settings UI manages). read returns the current settings. write replaces them — pass the full UserSettings object as `settings`.",
+        "Per-user settings AND (admin-only) global shelves. read returns both `{settings, global_settings}`. write accepts `settings` (per-user — any user) and/or `global_settings` (admin-only, server-side first-write-wins; pre-set fields cannot be changed and trigger a `global_locked` warning).",
         &["read", "write"],
         json!({
-            "settings": { "type": "object", "description": "Full UserSettings object for write" },
+            "settings": { "type": "object", "description": "Full UserSettings object for per-user write" },
+            "global_settings": { "type": "object", "description": "GlobalSettings object (admin-only). Only null fields are written; set fields are preserved." },
         }),
     ));
 

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -1259,7 +1259,12 @@ async fn build_instructions(client: &BookStackClient, semantic_enabled: bool, su
          org-required instructions and AI usage policy, and semantic matches against the user's \
          first message — one structured pull instead of many tool calls. \
          Call the `remember_briefing` MCP tool (or POST /remember/v1/briefing/read) with the user's \
-         opening message as `user_prompt`.\n\n"
+         opening message as `user_prompt`.\n\n\
+         If the briefing response includes a `setup_nudge` field, the user hasn't configured their \
+         Hive yet. Walk them through the `suggested_workflow` in that nudge — use search_content + \
+         remember_directory to discover existing structure, propose moves with move_book_to_shelf / \
+         move_chapter / move_page, and lock in the IDs with `remember_config action=write`. The \
+         user can snooze the reminder via `remember_config action=dismiss_setup_nudge days=N`.\n\n"
     );
 
     if !instance_name.is_empty() {

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -1251,6 +1251,17 @@ async fn build_instructions(client: &BookStackClient, semantic_enabled: bool, su
     let instance_desc = env::var("BSMCP_INSTANCE_DESC").unwrap_or_default();
 
     let mut instructions = String::new();
+
+    // Hive memory flow — surface this FIRST so it lands before any other guidance.
+    instructions.push_str(
+        "It's a best practice to always use remember/briefing at the beginning of any session. \
+         The briefing returns the agent's identity manifest, recent journal entries, active topics, \
+         org-required instructions and AI usage policy, and semantic matches against the user's \
+         first message — one structured pull instead of many tool calls. \
+         Call the `remember_briefing` MCP tool (or POST /remember/v1/briefing/read) with the user's \
+         opening message as `user_prompt`.\n\n"
+    );
+
     if !instance_name.is_empty() {
         instructions.push_str(&instance_name);
         if !instance_desc.is_empty() {
@@ -1909,11 +1920,12 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
 
     tools.push(remember_tool(
         "config",
-        "Per-user settings AND (admin-only) global shelves. read returns both `{settings, global_settings}`. write accepts `settings` (per-user — any user) and/or `global_settings` (admin-only, server-side first-write-wins; pre-set fields cannot be changed and trigger a `global_locked` warning).",
-        &["read", "write"],
+        "Per-user settings AND (admin-only) global shelves. read returns both `{settings, global_settings}`. write accepts `settings` (per-user — any user) and/or `global_settings` (admin-only, server-side first-write-wins; pre-set fields cannot be changed and trigger a `global_locked` warning). dismiss_setup_nudge snoozes the briefing's setup reminder for `days` days (default 7, max 365).",
+        &["read", "write", "dismiss_setup_nudge"],
         json!({
             "settings": { "type": "object", "description": "Full UserSettings object for per-user write" },
             "global_settings": { "type": "object", "description": "GlobalSettings object (admin-only). Only null fields are written; set fields are preserved." },
+            "days": { "type": "integer", "description": "For dismiss_setup_nudge: how many days to snooze (default 7, max 365)" },
         }),
     ));
 

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -27,8 +27,13 @@ pub async fn read(ctx: &Context) -> Outcome {
         .map(|n| n as usize)
         .unwrap_or(ctx.settings.active_collage_count.max(1));
 
+    // Resolve identity with org-default fallback. If the user hasn't set
+    // their own ai_identity_page_id but the org has a default, use it.
+    let globals = ctx.db.get_global_settings().await.unwrap_or_default();
+    let resolved = globals.resolve_identity(&ctx.settings);
+
     // Identity manifest (page) + user manifest (page) — fetch in parallel.
-    let identity_fut = fetch_optional_page(&ctx.client, ctx.settings.ai_identity_page_id);
+    let identity_fut = fetch_optional_page(&ctx.client, resolved.page_id);
     let user_fut = fetch_optional_page(&ctx.client, ctx.settings.user_identity_page_id);
 
     // Subagents (chapter listing).
@@ -120,11 +125,12 @@ pub async fn read(ctx: &Context) -> Outcome {
     Outcome::ok(json!({
         "identity": match identity {
             Some(p) => json!({
-                "ouid": ctx.settings.ai_identity_ouid,
-                "name": ctx.settings.ai_identity_name.clone()
+                "ouid": resolved.ouid,
+                "name": resolved.name.clone()
                     .or_else(|| p.get("name").and_then(|v| v.as_str()).map(|s| s.to_string())),
+                "using_org_default": resolved.using_default,
                 "manifest": {
-                    "page_id": ctx.settings.ai_identity_page_id,
+                    "page_id": resolved.page_id,
                     "markdown": frontmatter::strip(p.get("markdown").and_then(|v| v.as_str()).unwrap_or("")),
                     "url": p.get("url").cloned().unwrap_or(Value::Null),
                 }

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -105,13 +105,27 @@ pub async fn read(ctx: &Context) -> Outcome {
         slice
     };
 
-    // Always-on context pages (writing style, communication prefs, etc).
-    let system_prompt_fut = fetch_system_prompt_pages(
+    // Always-on context pages — three sources, all run in parallel:
+    //   - user-configured (system_prompt_page_ids)
+    //   - org-required instructions (admin-mandated page IDs)
+    //   - org-required AI usage policy (admin-mandated page IDs)
+    let user_pages_fut = fetch_pages_with_source(
         &ctx.client,
         &ctx.settings.system_prompt_page_ids,
+        "user",
+    );
+    let org_instructions_fut = fetch_pages_with_source(
+        &ctx.client,
+        &globals.org_required_instructions_page_ids,
+        "org_instructions",
+    );
+    let org_policy_fut = fetch_pages_with_source(
+        &ctx.client,
+        &globals.org_ai_usage_policy_page_ids,
+        "org_policy",
     );
 
-    let (identity, user_page, subagents, recent_journals, active_collage, shared_collage, semantic, system_prompt) = tokio::join!(
+    let (identity, user_page, subagents, recent_journals, active_collage, shared_collage, semantic, user_pages, org_instructions, org_policy) = tokio::join!(
         identity_fut,
         user_fut,
         subagents_fut,
@@ -119,10 +133,46 @@ pub async fn read(ctx: &Context) -> Outcome {
         active_collage_fut,
         shared_collage_fut,
         semantic_fut,
-        system_prompt_fut,
+        user_pages_fut,
+        org_instructions_fut,
+        org_policy_fut,
     );
 
+    // Merge the three sources into one flat array. Each entry carries its
+    // `source` field so callers can group/filter as needed.
+    let mut system_prompt: Vec<Value> = Vec::with_capacity(
+        user_pages.len() + org_instructions.len() + org_policy.len(),
+    );
+    system_prompt.extend(user_pages);
+    system_prompt.extend(org_instructions);
+    system_prompt.extend(org_policy);
+
+    // Setup nudge — show when the user hasn't configured anything AND hasn't
+    // snoozed the reminder. Suppressed once they save anything to /settings or
+    // explicitly dismiss via remember_config.
+    let now_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let snoozed = ctx.settings.settings_nudge_dismissed_until.map(|t| now_unix < t).unwrap_or(false);
+    let setup_nudge = if !ctx.settings.is_configured() && !snoozed {
+        Some(json!({
+            "show": true,
+            "message": "Your Hive memory settings aren't configured yet — the briefing is running on org defaults (or empty sections). Visit the MCP server's /settings page to set your AI identity, journal, topics, and more, or call `remember_config` with action=write to do it via tool.",
+            "settings_path": "/settings",
+            "dismiss": {
+                "tool": "remember_config",
+                "action": "dismiss_setup_nudge",
+                "default_days": 7,
+                "example": "remember_config action=dismiss_setup_nudge days=14"
+            }
+        }))
+    } else {
+        None
+    };
+
     Outcome::ok(json!({
+        "setup_nudge": setup_nudge,
         "identity": match identity {
             Some(p) => json!({
                 "ouid": resolved.ouid,
@@ -170,18 +220,25 @@ pub async fn read(ctx: &Context) -> Outcome {
     }))
 }
 
-async fn fetch_system_prompt_pages(client: &BookStackClient, ids: &[i64]) -> Vec<Value> {
-    if ids.is_empty() {
+/// Fetch the markdown for every page in `page_ids` concurrently. Each result
+/// is tagged with the given `source` so the AI knows where the content came
+/// from (`user`, `org_instructions`, or `org_policy`).
+async fn fetch_pages_with_source(
+    client: &BookStackClient,
+    page_ids: &[i64],
+    source: &'static str,
+) -> Vec<Value> {
+    if page_ids.is_empty() {
         return Vec::new();
     }
-    let mut handles = Vec::with_capacity(ids.len());
-    for &id in ids {
+    let mut handles = Vec::with_capacity(page_ids.len());
+    for &id in page_ids {
         let client = client.clone();
         handles.push(tokio::spawn(async move {
             (id, client.get_page(id).await)
         }));
     }
-    let mut out = Vec::with_capacity(ids.len());
+    let mut out = Vec::new();
     for h in handles {
         let Ok((id, result)) = h.await else { continue; };
         match result {
@@ -192,10 +249,11 @@ async fn fetch_system_prompt_pages(client: &BookStackClient, ids: &[i64]) -> Vec
                     "name": page.get("name").cloned().unwrap_or(Value::Null),
                     "markdown": frontmatter::strip(raw),
                     "url": page.get("url").cloned().unwrap_or(Value::Null),
+                    "source": source,
                 }));
             }
             Err(e) => {
-                eprintln!("Briefing: system_prompt_page_ids[{id}] fetch failed: {e}");
+                eprintln!("Briefing: {source} page {id} fetch failed: {e}");
             }
         }
     }

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -158,7 +158,28 @@ pub async fn read(ctx: &Context) -> Outcome {
     let setup_nudge = if !ctx.settings.is_configured() && !snoozed {
         Some(json!({
             "show": true,
-            "message": "Your Hive memory settings aren't configured yet — the briefing is running on org defaults (or empty sections). Visit the MCP server's /settings page to set your AI identity, journal, topics, and more, or call `remember_config` with action=write to do it via tool.",
+            "summary": "Your Hive memory settings aren't configured yet. Briefing is running on org defaults (where set) or empty sections.",
+            "two_paths": {
+                "ui": "Visit the MCP server's /settings page in a browser — fill in dropdowns or use 'Probe existing Hive' to auto-detect.",
+                "mcp_guided": "Have the AI walk you through it via tool calls (recommended for chat-driven setups). See `suggested_workflow` below."
+            },
+            "suggested_workflow": [
+                "1. Ask the user what they want: a fresh identity, or to adopt an existing agent/structure that's already in this BookStack.",
+                "2. If existing: call `remember_directory action=read kind=identities` to see what's already on the global Hive shelf, and `remember_directory action=read kind=user_journals` for journals. If those return settings_not_configured, the global shelves themselves aren't set — surface that to the user (only an admin can fix).",
+                "3. Use `search_content` with queries like '{type:book} Identity', '{type:book} Journal', '{type:book} Topics' to find candidate content that may be elsewhere in BookStack and should belong on the Hive shelf.",
+                "4. For each match, propose to the user whether to (a) adopt it as-is by writing the ID into config, or (b) move it onto the Hive shelf first using `move_book_to_shelf` / `move_chapter` / `move_page`, then write the ID.",
+                "5. For brand-new structure, use `remember_identity action=create name=...` to scaffold a full Identity book + manifest + standard chapters in one call.",
+                "6. Save the resolved IDs with `remember_config action=write` and a `settings` object. The next briefing will reflect the new config and the nudge will stop showing."
+            ],
+            "key_tools": [
+                "remember_directory  — discover what's on the global shelves",
+                "search_content      — find existing candidates anywhere",
+                "list_books / list_chapters / list_shelves — browse",
+                "move_book_to_shelf / move_chapter / move_page — relocate",
+                "remember_identity action=create — scaffold a new identity",
+                "remember_config    action=write — persist the chosen IDs",
+                "remember_config    action=dismiss_setup_nudge days=N — snooze this reminder"
+            ],
             "settings_path": "/settings",
             "dismiss": {
                 "tool": "remember_config",

--- a/crates/bsmcp-server/src/remember/identity.rs
+++ b/crates/bsmcp-server/src/remember/identity.rs
@@ -208,6 +208,16 @@ async fn create(ctx: &Context) -> Outcome {
 
     // 3. Optional chapter scaffold.
     let mut scaffolded = json!({});
+    let admin_role = ctx.client.find_admin_role_id().await.ok();
+
+    // Lock the newly-created Identity book + manifest page to admin-only edit.
+    if let Some(role) = admin_role {
+        provision::lock_to_admin_only(&ctx.client, bsmcp_common::bookstack::ContentType::Book, book_id, role).await;
+        if let Some(pid) = page_id {
+            provision::lock_to_admin_only(&ctx.client, bsmcp_common::bookstack::ContentType::Page, pid, role).await;
+        }
+    }
+
     if auto_provision_chapters {
         for resource in [
             NamedResource::SubagentsChapter,
@@ -215,6 +225,9 @@ async fn create(ctx: &Context) -> Outcome {
             NamedResource::OpportunitiesChapter,
         ] {
             let result = provision::create_chapter(&ctx.client, resource, book_id).await;
+            if let (Some(id), Some(role)) = (result.id(), admin_role) {
+                provision::lock_to_admin_only(&ctx.client, bsmcp_common::bookstack::ContentType::Chapter, id, role).await;
+            }
             scaffolded[resource_key(resource)] = json!({
                 "id": result.id(),
                 "human": result.human(resource),

--- a/crates/bsmcp-server/src/remember/mod.rs
+++ b/crates/bsmcp-server/src/remember/mod.rs
@@ -133,6 +133,7 @@ async fn route(resource: &str, action: &str, ctx: &Context) -> Outcome {
         ("user", "write") => singletons::write_user(ctx).await,
         ("config", "read") => singletons::read_config(ctx).await,
         ("config", "write") => singletons::write_config(ctx).await,
+        ("config", "dismiss_setup_nudge") => singletons::dismiss_setup_nudge(ctx).await,
 
         // Collections (book parent)
         ("journal", a) => collection::handle(&collection::resources::Journal, a, ctx).await,

--- a/crates/bsmcp-server/src/remember/provision.rs
+++ b/crates/bsmcp-server/src/remember/provision.rs
@@ -5,7 +5,7 @@
 //! module and gracefully surface permission errors as `ProvisionResult::Denied`
 //! rather than crashing the settings save.
 
-use bsmcp_common::bookstack::BookStackClient;
+use bsmcp_common::bookstack::{BookStackClient, ContentType};
 use serde_json::json;
 
 use super::naming::NamedResource;
@@ -119,6 +119,58 @@ pub async fn create_chapter(
             None => ProvisionResult::Failed { reason: "create_chapter returned no id".to_string() },
         },
         Err(e) => classify_error(&e),
+    }
+}
+
+/// Lock a piece of Hive content (shelf/book/chapter/page) so only the Admin
+/// role plus the page owner can edit it; everyone else gets read-only.
+///
+/// BookStack default for newly-created content is to inherit permissions from
+/// its parent. This helper opts the content out of inheritance and writes an
+/// explicit role-permission entry for Admin (full access) plus a fallback that
+/// permits view-only for everyone else. Page owners always retain edit access
+/// regardless of role permissions — that's BookStack's built-in behaviour.
+///
+/// Best-effort: BookStack returns 403 if the calling user can't manage
+/// permissions on the item. Logged + swallowed so it never blocks the parent
+/// save flow.
+pub async fn lock_to_admin_only(
+    client: &BookStackClient,
+    content_type: ContentType,
+    content_id: i64,
+    admin_role_id: i64,
+) {
+    let payload = json!({
+        "role_permissions": [
+            {
+                "role_id": admin_role_id,
+                "view": true,
+                "create": true,
+                "update": true,
+                "delete": true,
+            }
+        ],
+        "fallback_permissions": {
+            "inheriting": false,
+            "view": true,
+            "create": false,
+            "update": false,
+            "delete": false,
+        }
+    });
+    let label = match content_type {
+        ContentType::Page => "page",
+        ContentType::Chapter => "chapter",
+        ContentType::Book => "book",
+        ContentType::Shelf => "shelf",
+    };
+    if let Err(e) = client
+        .update_content_permissions(content_type, content_id, &payload)
+        .await
+    {
+        eprintln!(
+            "Provision: failed to lock {label} {content_id} to admin-only (non-fatal): {e}"
+        );
     }
 }
 

--- a/crates/bsmcp-server/src/remember/singletons.rs
+++ b/crates/bsmcp-server/src/remember/singletons.rs
@@ -15,12 +15,14 @@ use super::{Context, Outcome};
 // --- whoami ---
 
 pub async fn read_whoami(ctx: &Context) -> Outcome {
-    let page_id = match ctx.settings.ai_identity_page_id {
+    let globals = ctx.db.get_global_settings().await.unwrap_or_default();
+    let resolved = globals.resolve_identity(&ctx.settings);
+    let page_id = match resolved.page_id {
         Some(id) => id,
         None => {
             return Outcome::error(
                 ErrorCode::SettingsNotConfigured,
-                "ai_identity_page_id not configured",
+                "ai_identity_page_id not configured (no user setting and no org default)",
                 Some("ai_identity_page_id"),
             );
         }
@@ -49,9 +51,10 @@ pub async fn read_whoami(ctx: &Context) -> Outcome {
     let body = frontmatter::strip(raw_md).to_string();
 
     Outcome::ok(json!({
-        "ouid": ctx.settings.ai_identity_ouid,
-        "name": ctx.settings.ai_identity_name.clone()
+        "ouid": resolved.ouid,
+        "name": resolved.name.clone()
             .or_else(|| page.get("name").and_then(|v| v.as_str()).map(|s| s.to_string())),
+        "using_org_default": resolved.using_default,
         "manifest": {
             "page_id": page_id,
             "name": page.get("name").cloned().unwrap_or(Value::Null),

--- a/crates/bsmcp-server/src/remember/singletons.rs
+++ b/crates/bsmcp-server/src/remember/singletons.rs
@@ -334,6 +334,35 @@ pub async fn write_config(ctx: &Context) -> Outcome {
     outcome
 }
 
+/// `remember_config action=dismiss_setup_nudge days=N` — snooze the briefing's
+/// "configure your settings" reminder for N days (default 7, max 365).
+pub async fn dismiss_setup_nudge(ctx: &Context) -> Outcome {
+    let days = ctx
+        .body
+        .get("days")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(7)
+        .clamp(1, 365);
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let dismiss_until = now + days * 86400;
+
+    let mut new_settings = ctx.settings.clone();
+    new_settings.settings_nudge_dismissed_until = Some(dismiss_until);
+    if let Err(e) = ctx.db.save_user_settings(&ctx.token_id_hash, &new_settings).await {
+        return Outcome::error(ErrorCode::InternalError, e, None);
+    }
+    Outcome::ok(json!({
+        "action": "dismissed",
+        "days": days,
+        "snoozed_until_unix": dismiss_until,
+        "message": format!("Setup nudge snoozed for {days} days. The briefing will surface it again after that, or sooner if any setting is configured.")
+    }))
+}
+
 // --- helpers ---
 
 pub(super) async fn list_pages_in_chapter(

--- a/crates/bsmcp-server/src/remember/singletons.rs
+++ b/crates/bsmcp-server/src/remember/singletons.rs
@@ -6,7 +6,7 @@
 
 use serde_json::{json, Value};
 
-use bsmcp_common::settings::UserSettings;
+use bsmcp_common::settings::{GlobalSettings, UserSettings};
 
 use super::envelope::ErrorCode;
 use super::frontmatter;
@@ -208,45 +208,127 @@ pub async fn write_user(ctx: &Context) -> Outcome {
     }
 }
 
-// --- config (UserSettings) ---
+// --- config (UserSettings + GlobalSettings) ---
 
 pub async fn read_config(ctx: &Context) -> Outcome {
-    let json_value = match serde_json::to_value(&ctx.settings) {
+    let user_json = match serde_json::to_value(&ctx.settings) {
         Ok(v) => v,
         Err(e) => return Outcome::error(ErrorCode::InternalError, e.to_string(), None),
     };
-    Outcome::ok(json_value)
+    let globals = ctx.db.get_global_settings().await.unwrap_or_default();
+    let global_json = match serde_json::to_value(&globals) {
+        Ok(v) => v,
+        Err(e) => return Outcome::error(ErrorCode::InternalError, e.to_string(), None),
+    };
+    Outcome::ok(json!({
+        "settings": user_json,
+        "global_settings": global_json,
+    }))
 }
 
 pub async fn write_config(ctx: &Context) -> Outcome {
-    // Body must be a UserSettings JSON object (partial = full replace).
-    let raw = match ctx.body.get("settings") {
-        Some(v) => v.clone(),
-        None => {
-            return Outcome::error(
-                ErrorCode::InvalidArgument,
-                "settings field (object) is required",
-                Some("settings"),
-            );
-        }
-    };
-    let new_settings: UserSettings = match serde_json::from_value(raw) {
-        Ok(s) => s,
-        Err(e) => {
-            return Outcome::error(
-                ErrorCode::InvalidArgument,
-                format!("settings parse error: {e}"),
-                Some("settings"),
-            );
-        }
-    };
-    if let Err(e) = ctx.db.save_user_settings(&ctx.token_id_hash, &new_settings).await {
-        return Outcome::error(ErrorCode::InternalError, e, None);
+    // Two optional sub-objects:
+    //   - "settings"        : per-user UserSettings (anyone can write their own)
+    //   - "global_settings" : instance-wide GlobalSettings (admins only,
+    //                         server-side first-write-wins for set fields)
+    let user_settings_arg = ctx.body.get("settings").cloned();
+    let global_settings_arg = ctx.body.get("global_settings").cloned();
+
+    if user_settings_arg.is_none() && global_settings_arg.is_none() {
+        return Outcome::error(
+            ErrorCode::InvalidArgument,
+            "at least one of `settings` or `global_settings` is required",
+            None,
+        );
     }
-    Outcome::ok(json!({
+
+    let mut warnings: Vec<super::envelope::RememberWarning> = Vec::new();
+    let mut saved_user: Option<UserSettings> = None;
+    let mut saved_globals: Option<GlobalSettings> = None;
+
+    // --- per-user settings ---
+    if let Some(raw) = user_settings_arg {
+        let new_settings: UserSettings = match serde_json::from_value(raw) {
+            Ok(s) => s,
+            Err(e) => {
+                return Outcome::error(
+                    ErrorCode::InvalidArgument,
+                    format!("settings parse error: {e}"),
+                    Some("settings"),
+                );
+            }
+        };
+        if let Err(e) = ctx.db.save_user_settings(&ctx.token_id_hash, &new_settings).await {
+            return Outcome::error(ErrorCode::InternalError, e, None);
+        }
+        saved_user = Some(new_settings);
+    }
+
+    // --- global settings (admin-only, first-write-wins) ---
+    if let Some(raw) = global_settings_arg {
+        let proposed: GlobalSettings = match serde_json::from_value(raw) {
+            Ok(g) => g,
+            Err(e) => {
+                return Outcome::error(
+                    ErrorCode::InvalidArgument,
+                    format!("global_settings parse error: {e}"),
+                    Some("global_settings"),
+                );
+            }
+        };
+        let is_admin = ctx.client.is_admin().await.unwrap_or(false);
+        if !is_admin {
+            return Outcome::error(
+                ErrorCode::InvalidArgument,
+                "global_settings can only be written by BookStack admins",
+                Some("global_settings"),
+            );
+        }
+
+        // Enforce first-write-wins server-side: only fields that are currently
+        // null may be set; pre-existing values are preserved silently.
+        let existing = ctx.db.get_global_settings().await.unwrap_or_default();
+        let mut merged = existing.clone();
+        if existing.hive_shelf_id.is_none() {
+            if let Some(v) = proposed.hive_shelf_id {
+                merged.hive_shelf_id = Some(v);
+            }
+        } else if proposed.hive_shelf_id.is_some()
+            && proposed.hive_shelf_id != existing.hive_shelf_id
+        {
+            warnings.push(super::envelope::RememberWarning::new(
+                "global_locked",
+                "hive_shelf_id is already set; ignoring requested change (first-write-wins).",
+            ));
+        }
+        if existing.user_journals_shelf_id.is_none() {
+            if let Some(v) = proposed.user_journals_shelf_id {
+                merged.user_journals_shelf_id = Some(v);
+            }
+        } else if proposed.user_journals_shelf_id.is_some()
+            && proposed.user_journals_shelf_id != existing.user_journals_shelf_id
+        {
+            warnings.push(super::envelope::RememberWarning::new(
+                "global_locked",
+                "user_journals_shelf_id is already set; ignoring requested change (first-write-wins).",
+            ));
+        }
+
+        if let Err(e) = ctx.db.save_global_settings(&merged, &ctx.token_id_hash).await {
+            return Outcome::error(ErrorCode::InternalError, e, None);
+        }
+        saved_globals = Some(merged);
+    }
+
+    let mut outcome = Outcome::ok(json!({
         "action": "saved",
-        "settings": new_settings,
-    }))
+        "settings": saved_user,
+        "global_settings": saved_globals,
+    }));
+    for w in warnings {
+        outcome = outcome.with_warning(w);
+    }
+    outcome
 }
 
 // --- helpers ---

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -164,17 +164,19 @@ pub async fn handle_settings_get(
         state.http_client.clone(),
     );
 
-    let (shelves_res, books_res, chapters_res) = tokio::join!(
+    let (shelves_res, books_res, chapters_res, admin_res) = tokio::join!(
         client.list_shelves(500, 0),
         client.list_books(500, 0),
         client.list_chapters(500, 0),
+        client.is_admin(),
     );
 
     let shelves = extract_named_list(shelves_res.ok().as_ref());
     let books = extract_named_list(books_res.ok().as_ref());
     let chapters = extract_named_list(chapters_res.ok().as_ref());
+    let is_admin = admin_res.unwrap_or(false);
 
-    Html(render_settings_page(&settings, &globals, &shelves, &books, &chapters)).into_response()
+    Html(render_settings_page(&settings, &globals, &shelves, &books, &chapters, is_admin)).into_response()
 }
 
 #[derive(Deserialize)]
@@ -300,25 +302,69 @@ pub async fn handle_settings_post(
         system_prompt_page_ids: parse_id_list(form.system_prompt_page_ids),
     };
 
-    // Globals: respect existing values (first-write-wins for the UI; DB allows overwrites).
+    // Globals: server-side first-write-wins, gated to BookStack admins.
+    // Once a global field is set, it cannot be changed via this UI; once set
+    // by a non-admin (shouldn't happen — UI hides the controls), subsequent
+    // form submissions cannot rewrite them either.
     let existing_globals = state.db.get_global_settings().await.unwrap_or_default();
-    let mut globals = GlobalSettings {
-        hive_shelf_id: existing_globals.hive_shelf_id.or(parse_id(form.hive_shelf_id)),
-        user_journals_shelf_id: existing_globals.user_journals_shelf_id.or(parse_id(form.user_journals_shelf_id)),
-        set_by_token_hash: existing_globals.set_by_token_hash.clone(),
-        updated_at: existing_globals.updated_at,
-    };
+    let is_admin = client.is_admin().await.unwrap_or(false);
+
+    let mut globals = existing_globals.clone();
+    let mut global_warnings: Vec<String> = Vec::new();
+    let proposed_hive = parse_id(form.hive_shelf_id);
+    let proposed_user_journals = parse_id(form.user_journals_shelf_id);
+
+    if existing_globals.hive_shelf_id.is_none() {
+        if let Some(new_id) = proposed_hive {
+            if is_admin {
+                globals.hive_shelf_id = Some(new_id);
+            } else {
+                global_warnings.push(
+                    "Ignoring hive_shelf_id submission — only BookStack admins can set global shelves.".into()
+                );
+            }
+        }
+    } else if proposed_hive.is_some() && proposed_hive != existing_globals.hive_shelf_id {
+        global_warnings.push(
+            "Ignoring hive_shelf_id change — global shelves are first-write-wins; current value preserved.".into()
+        );
+    }
+
+    if existing_globals.user_journals_shelf_id.is_none() {
+        if let Some(new_id) = proposed_user_journals {
+            if is_admin {
+                globals.user_journals_shelf_id = Some(new_id);
+            } else {
+                global_warnings.push(
+                    "Ignoring user_journals_shelf_id submission — only BookStack admins can set global shelves.".into()
+                );
+            }
+        }
+    } else if proposed_user_journals.is_some() && proposed_user_journals != existing_globals.user_journals_shelf_id {
+        global_warnings.push(
+            "Ignoring user_journals_shelf_id change — global shelves are first-write-wins; current value preserved.".into()
+        );
+    }
+
+    // Same admin gate for create-if-missing on the global shelves themselves.
+    if !is_admin {
+        if checkbox_on(form.create_hive_shelf.clone()) || checkbox_on(form.create_user_journals_shelf.clone()) {
+            global_warnings.push(
+                "Ignoring create-if-missing for global shelves — only BookStack admins can provision them.".into()
+            );
+        }
+    }
 
     // Auto-provisioning in dependency order. Each step writes back into
     // `settings` / `globals` so later steps can use the just-created IDs.
     let mut provision_log: Vec<String> = Vec::new();
 
-    if globals.hive_shelf_id.is_none() && checkbox_on(form.create_hive_shelf) {
+    if is_admin && globals.hive_shelf_id.is_none() && checkbox_on(form.create_hive_shelf) {
         let r = provision::create_shelf(&client, NamedResource::HiveShelf).await;
         provision_log.push(r.human(NamedResource::HiveShelf));
         if let Some(id) = r.id() { globals.hive_shelf_id = Some(id); }
     }
-    if globals.user_journals_shelf_id.is_none() && checkbox_on(form.create_user_journals_shelf) {
+    if is_admin && globals.user_journals_shelf_id.is_none() && checkbox_on(form.create_user_journals_shelf) {
         let r = provision::create_shelf(&client, NamedResource::UserJournalsShelf).await;
         provision_log.push(r.human(NamedResource::UserJournalsShelf));
         if let Some(id) = r.id() { globals.user_journals_shelf_id = Some(id); }
@@ -420,7 +466,11 @@ pub async fn handle_settings_post(
         eprintln!("Settings: auto-provisioned items:");
         for line in &provision_log { eprintln!("  - {line}"); }
     }
-    eprintln!("Settings: saved for user (token_id_hash={}…)", &token_id_hash[..16.min(token_id_hash.len())]);
+    if !global_warnings.is_empty() {
+        eprintln!("Settings: global-write warnings:");
+        for line in &global_warnings { eprintln!("  - {line}"); }
+    }
+    eprintln!("Settings: saved for user (token_id_hash={}…, admin={is_admin})", &token_id_hash[..16.min(token_id_hash.len())]);
     Redirect::to("/settings?saved=1").into_response()
 }
 
@@ -726,6 +776,7 @@ fn render_settings_page(
     shelves: &[NamedItem],
     books: &[NamedItem],
     chapters: &[NamedItem],
+    is_admin: bool,
 ) -> String {
     let css = r#"
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -982,11 +1033,17 @@ a.reauth:hover { color: #cbd5e1; text-decoration: underline; }
         collage_count = s.active_collage_count,
         system_prompt_ids = html_escape(&format_id_list(&s.system_prompt_page_ids)),
 
-        global_lock_note = if g.updated_at > 0 { "(set globally — locked here)" } else { "" },
-        hive_shelf_select = render_select_locked("hive_shelf_id", shelves, g.hive_shelf_id, g.hive_shelf_id.is_some()),
-        user_journals_shelf_select = render_select_locked("user_journals_shelf_id", shelves, g.user_journals_shelf_id, g.user_journals_shelf_id.is_some()),
-        hive_shelf_create = if g.hive_shelf_id.is_some() { String::new() } else { create_inline("create_hive_shelf", "Create \"Hive\" shelf if missing") },
-        user_journals_shelf_create = if g.user_journals_shelf_id.is_some() { String::new() } else { create_inline("create_user_journals_shelf", "Create \"User Journals\" shelf if missing") },
+        global_lock_note = match (g.updated_at > 0, is_admin) {
+            (true, _) => "(set globally — locked)",
+            (false, true) => "(unset — you are an admin and may set this once)",
+            (false, false) => "(unset — only a BookStack admin can configure this)",
+        },
+        // Lock the field if globals are already set OR the user isn't an admin.
+        hive_shelf_select = render_select_locked("hive_shelf_id", shelves, g.hive_shelf_id, g.hive_shelf_id.is_some() || !is_admin),
+        user_journals_shelf_select = render_select_locked("user_journals_shelf_id", shelves, g.user_journals_shelf_id, g.user_journals_shelf_id.is_some() || !is_admin),
+        // Only show the create checkboxes for admins setting unset globals.
+        hive_shelf_create = if g.hive_shelf_id.is_none() && is_admin { create_inline("create_hive_shelf", "Create \"Hive\" shelf if missing") } else { String::new() },
+        user_journals_shelf_create = if g.user_journals_shelf_id.is_none() && is_admin { create_inline("create_user_journals_shelf", "Create \"User Journals\" shelf if missing") } else { String::new() },
 
         create_ai_identity_book_cb = create_row("create_ai_identity_book", "Create Identity book under the Hive shelf if blank above", s.ai_identity_book_id.is_some()),
         create_ai_hive_journal_book_cb = create_row("create_ai_hive_journal_book", "Create Journal book under the Hive shelf if blank above", s.ai_hive_journal_book_id.is_some()),

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -224,6 +224,11 @@ pub struct SettingsForm {
     pub create_ai_connections_chapter: Option<String>,
     pub create_ai_opportunities_chapter: Option<String>,
     pub create_ai_activity_chapter: Option<String>,
+
+    // Org-default AI identity (admins only).
+    pub default_ai_identity_page_id: Option<String>,
+    pub default_ai_identity_name: Option<String>,
+    pub default_ai_identity_ouid: Option<String>,
 }
 
 fn empty_to_none(s: Option<String>) -> Option<String> {
@@ -313,6 +318,9 @@ pub async fn handle_settings_post(
     let mut global_warnings: Vec<String> = Vec::new();
     let proposed_hive = parse_id(form.hive_shelf_id);
     let proposed_user_journals = parse_id(form.user_journals_shelf_id);
+    let proposed_default_id = parse_id(form.default_ai_identity_page_id);
+    let proposed_default_name = empty_to_none(form.default_ai_identity_name);
+    let proposed_default_ouid = empty_to_none(form.default_ai_identity_ouid);
 
     if existing_globals.hive_shelf_id.is_none() {
         if let Some(new_id) = proposed_hive {
@@ -343,6 +351,18 @@ pub async fn handle_settings_post(
     } else if proposed_user_journals.is_some() && proposed_user_journals != existing_globals.user_journals_shelf_id {
         global_warnings.push(
             "Ignoring user_journals_shelf_id change — global shelves are first-write-wins; current value preserved.".into()
+        );
+    }
+
+    // Org-default identity fields — admin-only writes, but they're updatable
+    // (not first-write-wins) so admins can swap the house agent later.
+    if is_admin {
+        globals.default_ai_identity_page_id = proposed_default_id;
+        globals.default_ai_identity_name = proposed_default_name;
+        globals.default_ai_identity_ouid = proposed_default_ouid;
+    } else if proposed_default_id.is_some() || proposed_default_name.is_some() || proposed_default_ouid.is_some() {
+        global_warnings.push(
+            "Ignoring org-default identity submission — only BookStack admins can set the org default.".into()
         );
     }
 
@@ -840,6 +860,26 @@ a.reauth:hover { color: #cbd5e1; text-decoration: underline; }
 </div>
 
 <div class="card">
+<h2>Org-default AI identity <span style="font-weight:400;font-size:.78rem;color:#94a3b8;">{org_default_note}</span></h2>
+<p class="subtitle" style="margin-bottom:.75rem;">When a user hasn't set their own AI identity, the briefing falls back to this. The "house agent". Admin-editable; can be changed later.</p>
+<div class="field">
+  <label for="default_ai_identity_page_id">Default identity manifest page ID</label>
+  {default_id_input}
+  <div class="hint">The page that defines the fallback agent. Find the ID in BookStack's URL.</div>
+</div>
+<div class="row2">
+<div class="field">
+  <label for="default_ai_identity_name">Default name</label>
+  {default_name_input}
+</div>
+<div class="field">
+  <label for="default_ai_identity_ouid">Default OUID</label>
+  {default_ouid_input}
+</div>
+</div>
+</div>
+
+<div class="card">
 <h2>Instance</h2>
 <div class="row2">
 <div class="field">
@@ -1045,6 +1085,23 @@ a.reauth:hover { color: #cbd5e1; text-decoration: underline; }
         hive_shelf_create = if g.hive_shelf_id.is_none() && is_admin { create_inline("create_hive_shelf", "Create \"Hive\" shelf if missing") } else { String::new() },
         user_journals_shelf_create = if g.user_journals_shelf_id.is_none() && is_admin { create_inline("create_user_journals_shelf", "Create \"User Journals\" shelf if missing") } else { String::new() },
 
+        org_default_note = if is_admin { "(admin-editable)" } else { "(read-only — admin only)" },
+        default_id_input = if is_admin {
+            render_id_input("default_ai_identity_page_id", g.default_ai_identity_page_id)
+        } else {
+            render_locked_value(g.default_ai_identity_page_id.map(|v| v.to_string()))
+        },
+        default_name_input = if is_admin {
+            render_text("default_ai_identity_name", g.default_ai_identity_name.as_deref(), "Pia")
+        } else {
+            render_locked_value(g.default_ai_identity_name.clone())
+        },
+        default_ouid_input = if is_admin {
+            render_text("default_ai_identity_ouid", g.default_ai_identity_ouid.as_deref(), "019dc66e4dd87ea080ebf5d5e2985d91")
+        } else {
+            render_locked_value(g.default_ai_identity_ouid.clone())
+        },
+
         create_ai_identity_book_cb = create_row("create_ai_identity_book", "Create Identity book under the Hive shelf if blank above", s.ai_identity_book_id.is_some()),
         create_ai_hive_journal_book_cb = create_row("create_ai_hive_journal_book", "Create Journal book under the Hive shelf if blank above", s.ai_hive_journal_book_id.is_some()),
         create_ai_collage_book_cb = create_row("create_ai_collage_book", "Create Topics / Collage book under the Hive shelf if blank above", s.ai_collage_book_id.is_some()),
@@ -1074,6 +1131,14 @@ fn create_inline(field_name: &str, label: &str) -> String {
         r#"<label class="cb" style="margin-top:.3rem;"><input type="checkbox" name="{name}" value="on"> {label}</label>"#,
         name = html_escape(field_name),
         label = html_escape(label),
+    )
+}
+
+fn render_locked_value(value: Option<String>) -> String {
+    let display = value.unwrap_or_else(|| "(unset)".into());
+    format!(
+        r#"<div style="padding:.55rem .7rem;border:1px solid #2a3a5c;border-radius:6px;background:#0a0f1f;color:#94a3b8;font-size:.9rem;">{}</div>"#,
+        html_escape(&display),
     )
 }
 

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -305,6 +305,16 @@ pub async fn handle_settings_post(
         recent_journal_count: parse_count(form.recent_journal_count, 3),
         active_collage_count: parse_count(form.active_collage_count, 10),
         system_prompt_page_ids: parse_id_list(form.system_prompt_page_ids),
+        // Carry over the existing dismiss timestamp — saving via /settings
+        // doesn't change the snooze. (The nudge auto-stops showing once
+        // is_configured() is true.)
+        settings_nudge_dismissed_until: state
+            .db
+            .get_user_settings(&token_id_hash)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|s| s.settings_nudge_dismissed_until),
     };
 
     // Globals: server-side first-write-wins, gated to BookStack admins.
@@ -377,17 +387,47 @@ pub async fn handle_settings_post(
 
     // Auto-provisioning in dependency order. Each step writes back into
     // `settings` / `globals` so later steps can use the just-created IDs.
+    // After each successful create we lock the new content to admin-only edit
+    // (everyone else read-only; owner keeps default edit). admin_role_id is
+    // looked up lazily so we only pay the cost when something is being created.
     let mut provision_log: Vec<String> = Vec::new();
+    let mut admin_role_id: Option<i64> = None;
+    async fn ensure_admin_role(
+        cached: &mut Option<i64>,
+        client: &BookStackClient,
+    ) -> Option<i64> {
+        if cached.is_some() {
+            return *cached;
+        }
+        match client.find_admin_role_id().await {
+            Ok(id) => { *cached = Some(id); Some(id) }
+            Err(e) => {
+                eprintln!("Settings: admin role lookup failed (locking will be skipped): {e}");
+                None
+            }
+        }
+    }
+    use bsmcp_common::bookstack::ContentType;
 
     if is_admin && globals.hive_shelf_id.is_none() && checkbox_on(form.create_hive_shelf) {
         let r = provision::create_shelf(&client, NamedResource::HiveShelf).await;
         provision_log.push(r.human(NamedResource::HiveShelf));
-        if let Some(id) = r.id() { globals.hive_shelf_id = Some(id); }
+        if let Some(id) = r.id() {
+            globals.hive_shelf_id = Some(id);
+            if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                provision::lock_to_admin_only(&client, ContentType::Shelf, id, role).await;
+            }
+        }
     }
     if is_admin && globals.user_journals_shelf_id.is_none() && checkbox_on(form.create_user_journals_shelf) {
         let r = provision::create_shelf(&client, NamedResource::UserJournalsShelf).await;
         provision_log.push(r.human(NamedResource::UserJournalsShelf));
-        if let Some(id) = r.id() { globals.user_journals_shelf_id = Some(id); }
+        if let Some(id) = r.id() {
+            globals.user_journals_shelf_id = Some(id);
+            if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                provision::lock_to_admin_only(&client, ContentType::Shelf, id, role).await;
+            }
+        }
     }
 
     // Books that live on the Hive shelf.
@@ -395,22 +435,42 @@ pub async fn handle_settings_post(
     if settings.ai_identity_book_id.is_none() && checkbox_on(form.create_ai_identity_book) {
         let r = provision::create_book(&client, NamedResource::IdentityBook, hive_shelf).await;
         provision_log.push(r.human(NamedResource::IdentityBook));
-        if let Some(id) = r.id() { settings.ai_identity_book_id = Some(id); }
+        if let Some(id) = r.id() {
+            settings.ai_identity_book_id = Some(id);
+            if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                provision::lock_to_admin_only(&client, ContentType::Book, id, role).await;
+            }
+        }
     }
     if settings.ai_hive_journal_book_id.is_none() && checkbox_on(form.create_ai_hive_journal_book) {
         let r = provision::create_book(&client, NamedResource::JournalBook, hive_shelf).await;
         provision_log.push(r.human(NamedResource::JournalBook));
-        if let Some(id) = r.id() { settings.ai_hive_journal_book_id = Some(id); }
+        if let Some(id) = r.id() {
+            settings.ai_hive_journal_book_id = Some(id);
+            if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                provision::lock_to_admin_only(&client, ContentType::Book, id, role).await;
+            }
+        }
     }
     if settings.ai_collage_book_id.is_none() && checkbox_on(form.create_ai_collage_book) {
         let r = provision::create_book(&client, NamedResource::CollageBook, hive_shelf).await;
         provision_log.push(r.human(NamedResource::CollageBook));
-        if let Some(id) = r.id() { settings.ai_collage_book_id = Some(id); }
+        if let Some(id) = r.id() {
+            settings.ai_collage_book_id = Some(id);
+            if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                provision::lock_to_admin_only(&client, ContentType::Book, id, role).await;
+            }
+        }
     }
     if settings.ai_shared_collage_book_id.is_none() && checkbox_on(form.create_ai_shared_collage_book) {
         let r = provision::create_book(&client, NamedResource::SharedCollageBook, hive_shelf).await;
         provision_log.push(r.human(NamedResource::SharedCollageBook));
-        if let Some(id) = r.id() { settings.ai_shared_collage_book_id = Some(id); }
+        if let Some(id) = r.id() {
+            settings.ai_shared_collage_book_id = Some(id);
+            if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                provision::lock_to_admin_only(&client, ContentType::Book, id, role).await;
+            }
+        }
     }
 
     // User journal book on the User Journals shelf — name personalized by user_id.
@@ -445,17 +505,32 @@ pub async fn handle_settings_post(
         if settings.ai_subagents_chapter_id.is_none() && checkbox_on(form.create_ai_subagents_chapter) {
             let r = provision::create_chapter(&client, NamedResource::SubagentsChapter, book_id).await;
             provision_log.push(r.human(NamedResource::SubagentsChapter));
-            if let Some(id) = r.id() { settings.ai_subagents_chapter_id = Some(id); }
+            if let Some(id) = r.id() {
+                settings.ai_subagents_chapter_id = Some(id);
+                if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                    provision::lock_to_admin_only(&client, ContentType::Chapter, id, role).await;
+                }
+            }
         }
         if settings.ai_connections_chapter_id.is_none() && checkbox_on(form.create_ai_connections_chapter) {
             let r = provision::create_chapter(&client, NamedResource::ConnectionsChapter, book_id).await;
             provision_log.push(r.human(NamedResource::ConnectionsChapter));
-            if let Some(id) = r.id() { settings.ai_connections_chapter_id = Some(id); }
+            if let Some(id) = r.id() {
+                settings.ai_connections_chapter_id = Some(id);
+                if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                    provision::lock_to_admin_only(&client, ContentType::Chapter, id, role).await;
+                }
+            }
         }
         if settings.ai_opportunities_chapter_id.is_none() && checkbox_on(form.create_ai_opportunities_chapter) {
             let r = provision::create_chapter(&client, NamedResource::OpportunitiesChapter, book_id).await;
             provision_log.push(r.human(NamedResource::OpportunitiesChapter));
-            if let Some(id) = r.id() { settings.ai_opportunities_chapter_id = Some(id); }
+            if let Some(id) = r.id() {
+                settings.ai_opportunities_chapter_id = Some(id);
+                if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                    provision::lock_to_admin_only(&client, ContentType::Chapter, id, role).await;
+                }
+            }
         }
     }
     // Activity chapter inside the Journal book.
@@ -463,7 +538,12 @@ pub async fn handle_settings_post(
         if settings.ai_activity_chapter_id.is_none() && checkbox_on(form.create_ai_activity_chapter) {
             let r = provision::create_chapter(&client, NamedResource::ActivityChapter, journal_book_id).await;
             provision_log.push(r.human(NamedResource::ActivityChapter));
-            if let Some(id) = r.id() { settings.ai_activity_chapter_id = Some(id); }
+            if let Some(id) = r.id() {
+                settings.ai_activity_chapter_id = Some(id);
+                if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
+                    provision::lock_to_admin_only(&client, ContentType::Chapter, id, role).await;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the merged #13. Five commits that round out the Hive memory flow:

- Admin-only writes for global shelves (UI + MCP)
- `remember_config` gains a write path for global settings (admin-gated, first-write-wins)
- Org-default AI identity fallback so unconfigured users still get something
- Org-required instructions + AI usage policy pages (admin-set, page-IDs only — chapters dropped after design discussion)
- BookStack admin-only permission lock on every auto-created Hive shelf/book/chapter/page
- Briefing surfaces a `setup_nudge` block with a six-step AI-driven setup workflow when the user hasn't configured anything; dismissible via `remember_config action=dismiss_setup_nudge days=N`
- MCP server `instructions` (returned in `initialize`) now leads with "It's a best practice to always use remember/briefing at the beginning of any session"
- `/status` page is auth-gated (Bearer or settings cookie)

## What's in each commit

| Commit | Change |
|---|---|
| `bf85008` | Admin-gate global shelves in `/settings` (`is_admin()` via probing `/api/users`). Non-admins see globals as locked info. First-write-wins enforced server-side, not just UI. CLAUDE.md table of UI-vs-MCP config paths. |
| `73d8483` | `remember_config action=write` accepts a `global_settings` object in addition to per-user `settings`. Admin-checked; first-write-wins; pre-set fields trigger a `global_locked` warning instead of overwriting. `read` returns both `{settings, global_settings}` in one envelope. |
| `222c2f6` | New GlobalSettings fields `default_ai_identity_page_id` / `_name` / `_ouid`. Briefing and whoami fall back to these when user fields are null; response includes `using_org_default: true|false` so callers can tell. Admin-editable (not first-write-wins) so admins can swap the house agent later. |
| `f603ec8` | (a) Drop `org_*_chapter_ids` (page IDs only). (b) Admin-only permission lock on auto-created shelves/books/chapters/pages — sets fallback to view-only and grants Admin role full edit; owner keeps edit by BookStack default. (c) Setup nudge in briefing + `dismiss_setup_nudge` action. (d) MCP `instructions` leads with the briefing best-practice line. |
| `330f668` | Setup nudge gains a `suggested_workflow` array + `key_tools` cheat sheet so any AI client can walk the user through Hive setup using existing tools (search, move, remember_directory, etc.) without a server-side scan endpoint. MCP `instructions` references the workflow path. |

## New permissioning model

| Surface | Per-user settings | Global shelves & defaults |
|---|---|---|
| `/settings` UI | any user | admins only; first-write-wins for shelf IDs (locked once set), org-default identity is admin-editable |
| `remember_config` MCP | `action=write` `settings={...}` | `action=write` `global_settings={...}` admin-gated; pre-set fields preserved with `global_locked` warning |

Auto-created Hive content gets BookStack content-permissions set to: Admin role full access, fallback view-only for everyone else, owner keeps edit. Failures are non-fatal (logged + swallowed) so a missing Admin role or 403 doesn't block the auto-create.

## New `setup_nudge` in `briefing/read`

When `UserSettings::is_configured()` is false AND the snooze window hasn't expired, briefing returns:

```json
{
  "setup_nudge": {
    "show": true,
    "summary": "Your Hive memory settings aren't configured yet...",
    "two_paths": { "ui": "...", "mcp_guided": "..." },
    "suggested_workflow": [
      "1. Ask the user what they want...",
      "2. remember_directory action=read kind=identities...",
      "3. search_content for existing candidate content...",
      "4. Propose adopt-as-is or move-then-adopt...",
      "5. remember_identity action=create for brand-new structure...",
      "6. remember_config action=write to persist..."
    ],
    "key_tools": [...],
    "dismiss": { "tool": "remember_config", "action": "dismiss_setup_nudge", "default_days": 7 }
  }
}
```

The workflow uses tools the AI already has — no new server endpoint, the AI does the discovery with its own search judgment.

## Test plan

- [ ] Log in as a non-admin via `/settings`. Verify global shelves render as locked info-only with no create-if-missing checkboxes; org-default identity fields are info-only.
- [ ] Log in as an admin with no globals set. Verify shelves and org-default identity are editable; create-if-missing checkboxes appear; submit; verify globals + DB row.
- [ ] Hand-craft a non-admin POST that tries to set globals. Verify server logs the warning and globals are unchanged.
- [ ] As an admin, hit `remember_config action=write` with a `global_settings` object. Verify it persists. Try again with different shelf IDs — verify `global_locked` warning and original values preserved.
- [ ] As a non-admin, hit `remember_config action=write` with `global_settings`. Verify rejected with `invalid_argument`.
- [ ] Set `default_ai_identity_page_id` as admin. As a different user with no `ai_identity_page_id`, call `remember_briefing/read`. Verify identity loaded from the org default with `using_org_default: true`.
- [ ] Same user with their own `ai_identity_page_id` set — verify their own identity loads with `using_org_default: false`.
- [ ] As admin, on `/settings` check the create-if-missing boxes for the Hive shelf + Identity book + Subagents chapter; save. Verify each new BookStack item has admin-only permissions (test in BookStack UI or via `get_content_permissions`).
- [ ] Call `remember_briefing/read` as a user with no settings. Verify the `setup_nudge` block appears with workflow + tool list.
- [ ] Call `remember_config action=dismiss_setup_nudge days=14`. Verify next briefing has no nudge. Verify settings DB has the timestamp.
- [ ] Call `remember_config action=write` with even one populated field. Verify next briefing has no nudge (auto-resolves regardless of dismiss timestamp).
- [ ] Set `org_required_instructions_page_ids: [N]` and `org_ai_usage_policy_page_ids: [M]` as admin. Call briefing — verify both pages appear in `system_prompt_additions` with `source: "org_instructions"` / `"org_policy"`.
- [ ] Verify the MCP `initialize` response `instructions` field begins with the briefing best-practice line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
