### PR TITLE
Lock journal books to owner-only on save

### DIFF
--- a/crates/bsmcp-server/src/remember/provision.rs
+++ b/crates/bsmcp-server/src/remember/provision.rs
@@ -104,6 +104,64 @@ pub async fn create_book(
     }
 }
 
+/// Lock both journal books to owner-only access. No-op for unset IDs.
+///
+/// Called on every settings save (UI, probe-accept, MCP) so journals are
+/// always private — whether auto-created or selected from existing books.
+pub async fn lock_journal_books_to_owner(
+    client: &BookStackClient,
+    ai_journal_book_id: Option<i64>,
+    user_journal_book_id: Option<i64>,
+) {
+    if let Some(id) = ai_journal_book_id {
+        lock_to_owner_only(client, ContentType::Book, id).await;
+    }
+    if let Some(id) = user_journal_book_id {
+        lock_to_owner_only(client, ContentType::Book, id).await;
+    }
+}
+
+/// Lock a piece of Hive content so only its owner (and admins via system
+/// permission) can access it. Used for journals — content nobody else should
+/// see, including other Hive users on the same instance.
+///
+/// Disables inheritance, clears all role permissions, and zeroes the fallback
+/// (so non-owner non-admin users get no view/create/update/delete). Owners and
+/// admins keep access via BookStack's built-in semantics.
+///
+/// Best-effort: BookStack returns 403 if the calling user can't manage
+/// permissions on the item. Logged + swallowed so it never blocks the save.
+pub async fn lock_to_owner_only(
+    client: &BookStackClient,
+    content_type: ContentType,
+    content_id: i64,
+) {
+    let payload = json!({
+        "role_permissions": [],
+        "fallback_permissions": {
+            "inheriting": false,
+            "view": false,
+            "create": false,
+            "update": false,
+            "delete": false,
+        }
+    });
+    let label = match content_type {
+        ContentType::Page => "page",
+        ContentType::Chapter => "chapter",
+        ContentType::Book => "book",
+        ContentType::Shelf => "shelf",
+    };
+    if let Err(e) = client
+        .update_content_permissions(content_type, content_id, &payload)
+        .await
+    {
+        eprintln!(
+            "Provision: failed to lock {label} {content_id} to owner-only (non-fatal): {e}"
+        );
+    }
+}
+
 /// Lock a piece of Hive content (shelf/book/chapter/page) so only the Admin
 /// role plus the page owner can edit it; everyone else gets read-only.
 ///

--- a/crates/bsmcp-server/src/remember/singletons.rs
+++ b/crates/bsmcp-server/src/remember/singletons.rs
@@ -10,6 +10,7 @@ use bsmcp_common::settings::{GlobalSettings, UserSettings};
 
 use super::envelope::ErrorCode;
 use super::frontmatter;
+use super::provision;
 use super::{Context, Outcome};
 
 // --- whoami ---
@@ -242,6 +243,14 @@ pub async fn write_config(ctx: &Context) -> Outcome {
         if let Err(e) = ctx.db.save_user_settings(&ctx.token_id_hash, &new_settings).await {
             return Outcome::error(ErrorCode::InternalError, e, None);
         }
+        // Lock journal books to owner-only on every config write — covers both
+        // freshly-set IDs and re-saves of existing IDs. Idempotent.
+        provision::lock_journal_books_to_owner(
+            &ctx.client,
+            new_settings.ai_hive_journal_book_id,
+            new_settings.user_journal_book_id,
+        )
+        .await;
         saved_user = Some(new_settings);
     }
 

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -433,9 +433,6 @@ pub async fn handle_settings_post(
         provision_log.push(r.human(NamedResource::JournalBook));
         if let Some(id) = r.id() {
             settings.ai_hive_journal_book_id = Some(id);
-            if let Some(role) = ensure_admin_role(&mut admin_role_id, &client).await {
-                provision::lock_to_admin_only(&client, ContentType::Book, id, role).await;
-            }
         }
     }
     if settings.ai_collage_book_id.is_none() && checkbox_on(form.create_ai_collage_book) {
@@ -492,6 +489,15 @@ pub async fn handle_settings_post(
         settings.ai_hive_shelf_id = Some(id);
     }
 
+    // Lock journal books to owner-only — applies to both freshly auto-created
+    // books and previously-existing books the user selected. Idempotent.
+    provision::lock_journal_books_to_owner(
+        &client,
+        settings.ai_hive_journal_book_id,
+        settings.user_journal_book_id,
+    )
+    .await;
+
     // Persist.
     if let Err(e) = state.db.save_global_settings(&globals, &token_id_hash).await {
         eprintln!("Settings: save_global_settings failed: {e}");
@@ -543,11 +549,12 @@ pub async fn handle_settings_probe_post(
     headers: HeaderMap,
     Form(form): Form<ProbeAcceptForm>,
 ) -> Response {
-    let (token_id, _) = match resolve_session(&headers, &state.settings_sessions).await {
+    let (token_id, token_secret) = match resolve_session(&headers, &state.settings_sessions).await {
         Some(c) => c,
         None => return Redirect::to("/authorize?response_type=code&client_id=settings-ui&redirect_uri=/settings&return_to=/settings").into_response(),
     };
     let token_id_hash = hash_token_id(&token_id);
+    let client = BookStackClient::new(&state.bookstack_url, &token_id, &token_secret, state.http_client.clone());
     let mut settings = state.db.get_user_settings(&token_id_hash).await.ok().flatten().unwrap_or_default();
 
     let assign = |checked: Option<String>, id: Option<String>| -> Option<i64> {
@@ -558,6 +565,13 @@ pub async fn handle_settings_probe_post(
     if let Some(v) = assign(form.accept_ai_hive_journal_book_id, form.ai_hive_journal_book_id) { settings.ai_hive_journal_book_id = Some(v); }
     if let Some(v) = assign(form.accept_ai_collage_book_id, form.ai_collage_book_id) { settings.ai_collage_book_id = Some(v); }
     if let Some(v) = assign(form.accept_ai_shared_collage_book_id, form.ai_shared_collage_book_id) { settings.ai_shared_collage_book_id = Some(v); }
+
+    provision::lock_journal_books_to_owner(
+        &client,
+        settings.ai_hive_journal_book_id,
+        settings.user_journal_book_id,
+    )
+    .await;
 
     if let Err(e) = state.db.save_user_settings(&token_id_hash, &settings).await {
         eprintln!("Probe: save failed: {e}");


### PR DESCRIPTION
## Summary

Journals (\`ai_hive_journal_book\` and \`user_journal_book\`) are private by nature — only the owner should see them. Previously the auto-create flow locked the AI journal to admin-only (which still grants view to all admins) and the user journal got no lock at all.

## What changed

- **New helper** \`provision::lock_to_owner_only\`: clears all role permissions and zeroes the fallback, breaking inheritance so non-owner non-admin users get nothing. Owners and BookStack admins keep access via system permissions.
- **\`provision::lock_journal_books_to_owner\`** wraps the two book IDs and applies the lock to each.
- **Wired into all three save paths:**
  - \`/settings\` save (covers both auto-created and selected-existing)
  - \`/settings/probe\` accept
  - \`remember_config action=write\` (MCP path)
- **Idempotent.** Safe to call on every save.
- **Best-effort.** BookStack 403s (e.g., user can't manage perms on the book) are logged + swallowed so they never block the save.

## Test plan

- [x] \`cargo check --workspace\` clean
- [x] \`cargo test --workspace\` — 21 tests pass
- [ ] Save /settings with a journal book selected → BookStack content permissions show inheriting=false, role_permissions=[], fallback all false
- [ ] Save again → no error, permissions unchanged (idempotent)
- [ ] Auto-create both journal books → both end up locked

🤖 Generated with [Claude Code](https://claude.com/claude-code)