### PR TITLE
Briefing: book-scoped listings, full pages, time/user-aware semantic, complete admin merge

### DIFF
--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -554,6 +554,74 @@ impl BookStackClient {
         self.delete(&format!("pages/{id}")).await
     }
 
+    // --- Book traversal helpers ---
+    //
+    // These exist because BookStack's search API silently ignores
+    // `{in_book:N}` / `{name:foo}` filters when the query has no positive
+    // keyword term — `{type:page} {in_book:986}` parses fine but returns
+    // system-wide matches, not book-scoped ones. Filter-only listings must
+    // go through `get_book` (page row metadata) instead. Callers get
+    // `updated_at` from the database row, never parsed from page content.
+
+    /// Returns the most-recently-updated pages within a book, sorted by
+    /// `updated_at` descending, capped at `limit`. Page rows include
+    /// `id`, `name`, `slug`, `book_id`, `chapter_id`, `updated_at`, `url`.
+    pub async fn list_book_pages_by_updated(
+        &self,
+        book_id: i64,
+        limit: usize,
+    ) -> Result<Vec<Value>, String> {
+        let book = self.get_book(book_id).await?;
+        let mut pages = flatten_book_pages(&book);
+        pages.sort_by(|a, b| {
+            let a_t = a.get("updated_at").and_then(|t| t.as_str()).unwrap_or("");
+            let b_t = b.get("updated_at").and_then(|t| t.as_str()).unwrap_or("");
+            b_t.cmp(a_t)
+        });
+        pages.truncate(limit);
+        Ok(pages)
+    }
+
+    /// Find a page in a book by exact (case-insensitive) name. Returns the
+    /// page row if found, or `None`. One `get_book` call.
+    pub async fn find_page_in_book(
+        &self,
+        book_id: i64,
+        name: &str,
+    ) -> Result<Option<Value>, String> {
+        let book = self.get_book(book_id).await?;
+        let pages = flatten_book_pages(&book);
+        Ok(pages.into_iter().find(|p| {
+            p.get("name")
+                .and_then(|n| n.as_str())
+                .map(|n| n.eq_ignore_ascii_case(name))
+                .unwrap_or(false)
+        }))
+    }
+
+    /// Find a chapter in a book by exact (case-insensitive) name. Returns
+    /// the chapter row if found, or `None`. One `get_book` call.
+    pub async fn find_chapter_in_book(
+        &self,
+        book_id: i64,
+        name: &str,
+    ) -> Result<Option<Value>, String> {
+        let book = self.get_book(book_id).await?;
+        let contents = book
+            .get("contents")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        Ok(contents.into_iter().find(|item| {
+            item.get("type").and_then(|t| t.as_str()) == Some("chapter")
+                && item
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .map(|n| n.eq_ignore_ascii_case(name))
+                    .unwrap_or(false)
+        }))
+    }
+
     // --- Search ---
 
     pub async fn search(&self, query: &str, page: i64, count: i64) -> Result<Value, String> {
@@ -744,5 +812,100 @@ impl BookStackClient {
 
     pub async fn get_role(&self, id: i64) -> Result<Value, String> {
         self.get(&format!("roles/{id}"), &[]).await
+    }
+}
+
+/// Flatten a `get_book` response into a single list of page rows —
+/// top-level pages plus every chapter's nested pages. Returns an empty
+/// vec if `contents` is missing or malformed.
+fn flatten_book_pages(book: &Value) -> Vec<Value> {
+    let Some(contents) = book.get("contents").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    let mut pages = Vec::new();
+    for item in contents {
+        match item.get("type").and_then(|t| t.as_str()) {
+            Some("page") => pages.push(item.clone()),
+            Some("chapter") => {
+                if let Some(ch_pages) = item.get("pages").and_then(|p| p.as_array()) {
+                    for p in ch_pages {
+                        pages.push(p.clone());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    pages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn fixture_book() -> Value {
+        // Mimics the shape of `GET /api/books/{id}` — top-level pages
+        // mixed with chapters that have their own nested pages.
+        json!({
+            "id": 986,
+            "name": "Pia's Journal",
+            "contents": [
+                {
+                    "type": "page",
+                    "id": 1003,
+                    "name": "Archive Daily Log",
+                    "updated_at": "2026-03-02T20:07:50Z"
+                },
+                {
+                    "type": "chapter",
+                    "id": 989,
+                    "name": "2026-02",
+                    "pages": [
+                        { "id": 990, "name": "2026-02-22", "updated_at": "2026-03-03T20:32:51Z" },
+                        { "id": 991, "name": "2026-02-19", "updated_at": "2026-03-03T20:32:53Z" },
+                    ]
+                },
+                {
+                    "type": "chapter",
+                    "id": 1869,
+                    "name": "2026-04",
+                    "pages": [
+                        { "id": 2025, "name": "2026-04-26", "updated_at": "2026-04-26T06:10:24Z" },
+                        { "id": 2006, "name": "2026-04-25", "updated_at": "2026-04-25T22:29:51Z" },
+                    ]
+                },
+            ]
+        })
+    }
+
+    #[test]
+    fn flatten_collects_top_level_and_chapter_pages() {
+        let pages = flatten_book_pages(&fixture_book());
+        let ids: Vec<i64> = pages
+            .iter()
+            .map(|p| p.get("id").and_then(|v| v.as_i64()).unwrap_or(0))
+            .collect();
+        // 5 pages total: 1 top-level + 2 in 2026-02 + 2 in 2026-04
+        assert_eq!(ids.len(), 5);
+        assert!(ids.contains(&1003));
+        assert!(ids.contains(&2025));
+        assert!(ids.contains(&990));
+    }
+
+    #[test]
+    fn flatten_handles_missing_contents() {
+        let book = json!({ "id": 1, "name": "Empty" });
+        assert!(flatten_book_pages(&book).is_empty());
+    }
+
+    #[test]
+    fn flatten_handles_malformed_chapter() {
+        let book = json!({
+            "contents": [
+                { "type": "chapter", "id": 1, "name": "no pages array" }
+            ]
+        });
+        assert!(flatten_book_pages(&book).is_empty());
     }
 }

--- a/crates/bsmcp-common/src/settings.rs
+++ b/crates/bsmcp-common/src/settings.rs
@@ -117,6 +117,12 @@ pub struct UserSettings {
     #[serde(default = "default_collage_count")]
     pub active_collage_count: usize,
 
+    /// User's IANA timezone name (e.g., "America/New_York"). Surfaced in the
+    /// briefing's `time` block so the AI can format timestamps in the user's
+    /// local time. If unset, the briefing reports UTC.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+
     /// Unix epoch seconds until which the briefing's "configure your settings"
     /// nudge is snoozed. When `now < this`, the nudge is suppressed. Set via
     /// `remember_config action=dismiss_setup_nudge days=N`. Auto-becomes

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -36,9 +36,15 @@ pub async fn read(ctx: &Context) -> Outcome {
     let identity_fut = fetch_optional_page(&ctx.client, resolved.page_id);
     let user_fut = fetch_optional_page(&ctx.client, ctx.settings.user_identity_page_id);
 
-    // Recent journals (newest pages in the journal book).
+    // Recent journals (newest pages in each journal book — both the AI's
+    // reflection journal and the user's personal journal).
     let recent_journals_fut = list_recent_pages(
         ctx.settings.ai_hive_journal_book_id,
+        recent_count,
+        &ctx.client,
+    );
+    let recent_user_journal_fut = list_recent_pages(
+        ctx.settings.user_journal_book_id,
         recent_count,
         &ctx.client,
     );
@@ -116,10 +122,11 @@ pub async fn read(ctx: &Context) -> Outcome {
         "org_policy",
     );
 
-    let (identity, user_page, recent_journals, active_collage, shared_collage, semantic, user_pages, org_instructions, org_policy) = tokio::join!(
+    let (identity, user_page, recent_journals, recent_user_journal, active_collage, shared_collage, semantic, user_pages, org_instructions, org_policy) = tokio::join!(
         identity_fut,
         user_fut,
         recent_journals_fut,
+        recent_user_journal_fut,
         active_collage_fut,
         shared_collage_fut,
         semantic_fut,
@@ -214,11 +221,12 @@ pub async fn read(ctx: &Context) -> Outcome {
         },
         "journal_recent": recent_journals,
         "journal_semantic_matches": semantic.journal_matches,
+        "user_journal_recent": recent_user_journal,
+        "user_journal_semantic_matches": semantic.user_journal_matches,
         "collage_active": active_collage,
         "collage_semantic_matches": semantic.collage_matches,
         "shared_collage_active": shared_collage,
         "shared_collage_semantic_matches": semantic.shared_collage_matches,
-        "user_journal_semantic_matches": semantic.user_journal_matches,
         "kb_semantic_matches": if ctx.settings.semantic_against_full_kb { json!(semantic.kb_matches) } else { Value::Null },
         "system_prompt_additions": system_prompt,
         "time": {
@@ -296,59 +304,28 @@ async fn fetch_optional_page(client: &BookStackClient, page_id: Option<i64>) -> 
     }
 }
 
-/// Lists the most-recently-updated pages within a book.
-///
-/// Uses `get_book` rather than `search` because BookStack's search API silently
-/// returns unfiltered results when no positive keyword term is present —
-/// `{type:page} {in_book:N}` alone produces system-wide matches, not book-scoped
-/// ones. `get_book` returns the book's full contents (top-level pages + chapter-
-/// nested pages) in one call, which we flatten and sort by `updated_at` desc.
+/// Lists the most-recently-updated pages within a book, using the
+/// `BookStackClient::list_book_pages_by_updated` helper. The helper sorts
+/// by the page row's `updated_at` from BookStack's database — never from
+/// markdown content. We just narrow the page row down to the four fields
+/// the briefing surfaces.
 async fn list_recent_pages(book_id: Option<i64>, limit: usize, client: &BookStackClient) -> Vec<Value> {
     let Some(book_id) = book_id else { return Vec::new(); };
-    let book = match client.get_book(book_id).await {
-        Ok(b) => b,
+    match client.list_book_pages_by_updated(book_id, limit).await {
+        Ok(pages) => pages
+            .into_iter()
+            .map(|p| json!({
+                "page_id": p.get("id").cloned().unwrap_or(Value::Null),
+                "name": p.get("name").cloned().unwrap_or(Value::Null),
+                "url": p.get("url").cloned().unwrap_or(Value::Null),
+                "updated_at": p.get("updated_at").cloned().unwrap_or(Value::Null),
+            }))
+            .collect(),
         Err(e) => {
-            eprintln!("Briefing: get_book({book_id}) failed: {e}");
-            return Vec::new();
-        }
-    };
-
-    // Flatten contents — top-level pages + every chapter's nested pages.
-    let mut pages: Vec<Value> = Vec::new();
-    if let Some(contents) = book.get("contents").and_then(|v| v.as_array()) {
-        for item in contents {
-            let kind = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
-            match kind {
-                "page" => pages.push(item.clone()),
-                "chapter" => {
-                    if let Some(ch_pages) = item.get("pages").and_then(|p| p.as_array()) {
-                        for p in ch_pages {
-                            pages.push(p.clone());
-                        }
-                    }
-                }
-                _ => {}
-            }
+            eprintln!("Briefing: list_book_pages_by_updated({book_id}) failed: {e}");
+            Vec::new()
         }
     }
-
-    // Sort by updated_at descending (ISO-8601 strings sort lexicographically).
-    pages.sort_by(|a, b| {
-        let a_t = a.get("updated_at").and_then(|t| t.as_str()).unwrap_or("");
-        let b_t = b.get("updated_at").and_then(|t| t.as_str()).unwrap_or("");
-        b_t.cmp(a_t)
-    });
-
-    pages
-        .into_iter()
-        .take(limit)
-        .map(|p| json!({
-            "page_id": p.get("id").cloned().unwrap_or(Value::Null),
-            "name": p.get("name").cloned().unwrap_or(Value::Null),
-            "url": p.get("url").cloned().unwrap_or(Value::Null),
-            "updated_at": p.get("updated_at").cloned().unwrap_or(Value::Null),
-        }))
-        .collect()
 }
 
 fn filter_by_book(hits: &[Value], book_id: Option<i64>, limit: usize) -> Vec<Value> {

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -62,9 +62,19 @@ pub async fn read(ctx: &Context) -> Outcome {
     );
 
     // Semantic search fan-out — one per configured target.
-    let prompt_for_semantic = user_prompt.clone();
+    //
+    // The query string we send to `sem.search` is the user's prompt prefixed
+    // with a `[Context: ...]` block carrying current time, timezone, user
+    // identity, and AI identity. Both halves of hybrid search benefit:
+    //   - Embedding side: the query vector is enriched with date / user
+    //     signal so prompts like "what was I working on yesterday" can match
+    //     pages dated relative to *today*, not relative to whenever the
+    //     embedding model was trained.
+    //   - Keyword side: the user_id and identity name appear in pages that
+    //     mention the same person, biasing relevance toward their content.
+    let prompt_for_semantic = build_semantic_query(&user_prompt, ctx);
     let semantic_fut = async {
-        if prompt_for_semantic.is_empty() {
+        if user_prompt.is_empty() {
             return SemanticSlice::default();
         }
         let Some(sem) = &ctx.semantic else {
@@ -244,9 +254,38 @@ pub async fn read(ctx: &Context) -> Outcome {
     }))
 }
 
+/// Build the semantic-search query string by prefixing the user's prompt
+/// with a `[Context: ...]` block carrying current time, timezone, user
+/// identity, and AI identity. The whole string is used for both vector
+/// embedding and the hybrid keyword pass.
+fn build_semantic_query(user_prompt: &str, ctx: &Context) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    parts.push(format!("time={}", frontmatter::now_iso_utc()));
+    if let Some(tz) = &ctx.settings.timezone {
+        parts.push(format!("tz={tz}"));
+    }
+    if let Some(uid) = &ctx.settings.user_id {
+        parts.push(format!("user={uid}"));
+    }
+    if let Some(name) = &ctx.settings.ai_identity_name {
+        parts.push(format!("ai={name}"));
+    }
+    if parts.is_empty() {
+        user_prompt.to_string()
+    } else {
+        format!("[Context: {}]\n{}", parts.join(", "), user_prompt)
+    }
+}
+
 /// Fetch the markdown for every page in `page_ids` concurrently. Each result
 /// is tagged with the given `source` so the AI knows where the content came
 /// from (`user`, `org_instructions`, or `org_policy`).
+///
+/// **Invariant: no truncation.** System prompts and org policies are
+/// load-bearing — every word matters. The body returned here is the full
+/// page markdown with only the leading YAML frontmatter (provenance metadata)
+/// stripped. Do not add length caps, summarization, or chunking. If the body
+/// is too large for some downstream consumer, fix the consumer.
 async fn fetch_pages_with_source(
     client: &BookStackClient,
     page_ids: &[i64],

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -221,6 +221,12 @@ pub async fn read(ctx: &Context) -> Outcome {
         "user_journal_semantic_matches": semantic.user_journal_matches,
         "kb_semantic_matches": if ctx.settings.semantic_against_full_kb { json!(semantic.kb_matches) } else { Value::Null },
         "system_prompt_additions": system_prompt,
+        "time": {
+            "now_unix": frontmatter::now_unix(),
+            "now_utc": frontmatter::now_iso_utc(),
+            "timezone": ctx.settings.timezone.clone().unwrap_or_else(|| "UTC".to_string()),
+            "timezone_source": if ctx.settings.timezone.is_some() { "user_settings" } else { "default_utc" },
+        },
         "config": {
             "label": ctx.settings.label,
             "role": ctx.settings.role,
@@ -290,24 +296,55 @@ async fn fetch_optional_page(client: &BookStackClient, page_id: Option<i64>) -> 
     }
 }
 
+/// Lists the most-recently-updated pages within a book.
+///
+/// Uses `get_book` rather than `search` because BookStack's search API silently
+/// returns unfiltered results when no positive keyword term is present —
+/// `{type:page} {in_book:N}` alone produces system-wide matches, not book-scoped
+/// ones. `get_book` returns the book's full contents (top-level pages + chapter-
+/// nested pages) in one call, which we flatten and sort by `updated_at` desc.
 async fn list_recent_pages(book_id: Option<i64>, limit: usize, client: &BookStackClient) -> Vec<Value> {
     let Some(book_id) = book_id else { return Vec::new(); };
-    let query = format!("{{type:page}} {{in_book:{book_id}}} {{updated_after:1970-01-01}}");
-    let resp = match client.search(&query, 1, limit as i64).await {
-        Ok(v) => v,
+    let book = match client.get_book(book_id).await {
+        Ok(b) => b,
         Err(e) => {
-            eprintln!("Briefing: list_recent_pages({book_id}) failed: {e}");
+            eprintln!("Briefing: get_book({book_id}) failed: {e}");
             return Vec::new();
         }
     };
-    let data = resp.get("data").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    data.into_iter()
-        .filter(|item| item.get("type").and_then(|t| t.as_str()) == Some("page"))
+
+    // Flatten contents — top-level pages + every chapter's nested pages.
+    let mut pages: Vec<Value> = Vec::new();
+    if let Some(contents) = book.get("contents").and_then(|v| v.as_array()) {
+        for item in contents {
+            let kind = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            match kind {
+                "page" => pages.push(item.clone()),
+                "chapter" => {
+                    if let Some(ch_pages) = item.get("pages").and_then(|p| p.as_array()) {
+                        for p in ch_pages {
+                            pages.push(p.clone());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Sort by updated_at descending (ISO-8601 strings sort lexicographically).
+    pages.sort_by(|a, b| {
+        let a_t = a.get("updated_at").and_then(|t| t.as_str()).unwrap_or("");
+        let b_t = b.get("updated_at").and_then(|t| t.as_str()).unwrap_or("");
+        b_t.cmp(a_t)
+    });
+
+    pages
+        .into_iter()
         .take(limit)
         .map(|p| json!({
             "page_id": p.get("id").cloned().unwrap_or(Value::Null),
             "name": p.get("name").cloned().unwrap_or(Value::Null),
-            "preview": p.get("preview_html").cloned().unwrap_or(Value::Null),
             "url": p.get("url").cloned().unwrap_or(Value::Null),
             "updated_at": p.get("updated_at").cloned().unwrap_or(Value::Null),
         }))

--- a/crates/bsmcp-server/src/remember/collection.rs
+++ b/crates/bsmcp-server/src/remember/collection.rs
@@ -160,26 +160,24 @@ async fn list_pages(
     parent: CollectionParent,
     ctx: &Context,
 ) -> Outcome {
-    let limit = ctx.body_count("limit", 25, 200) as i64;
-    let offset = ctx.body.get("offset").and_then(|v| v.as_i64()).unwrap_or(0);
-    let filter = parent_filter(parent);
-    let query = format!("{{type:page}} {filter}");
-    match ctx.client.search(&query, 1, limit + offset).await {
-        Ok(resp) => {
-            let data = resp
-                .get("data")
-                .and_then(|v| v.as_array())
-                .cloned()
-                .unwrap_or_default();
-            let pages: Vec<Value> = data
+    let limit = ctx.body_count("limit", 25, 200);
+    let offset = ctx.body.get("offset").and_then(|v| v.as_i64()).unwrap_or(0).max(0) as usize;
+    // Pull (limit + offset) most-recently-updated pages from the book and
+    // skip to the requested offset. Goes through the BookStackClient helper
+    // so we get database `updated_at` ordering, not search-relevance.
+    match ctx
+        .client
+        .list_book_pages_by_updated(parent, limit + offset)
+        .await
+    {
+        Ok(rows) => {
+            let pages: Vec<Value> = rows
                 .into_iter()
-                .filter(|item| item.get("type").and_then(|t| t.as_str()) == Some("page"))
-                .skip(offset as usize)
-                .take(limit as usize)
+                .skip(offset)
+                .take(limit)
                 .map(|p| json!({
                     "id": p.get("id").cloned().unwrap_or(Value::Null),
                     "name": p.get("name").cloned().unwrap_or(Value::Null),
-                    "preview": p.get("preview_html").cloned().unwrap_or(Value::Null),
                     "url": p.get("url").cloned().unwrap_or(Value::Null),
                     "updated_at": p.get("updated_at").cloned().unwrap_or(Value::Null),
                 }))
@@ -194,32 +192,24 @@ async fn list_pages(
     }
 }
 
-fn parent_filter(book_id: CollectionParent) -> String {
-    format!("{{in_book:{book_id}}}")
-}
-
 async fn find_page_by_name(
     parent: CollectionParent,
     name: &str,
     ctx: &Context,
 ) -> Result<Option<i64>, String> {
-    let filter = parent_filter(parent);
-    // BookStack's name filter does substring match; we verify exact name client-side.
-    let query = format!("{{type:page}} {{name:{name}}} {filter}");
-    let resp = ctx.client.search(&query, 1, 25).await?;
-    let data = resp.get("data").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    for item in data {
-        if item.get("type").and_then(|t| t.as_str()) != Some("page") {
-            continue;
-        }
-        let item_name = item.get("name").and_then(|n| n.as_str()).unwrap_or("");
-        if item_name.eq_ignore_ascii_case(name) {
-            if let Some(id) = item.get("id").and_then(|i| i.as_i64()) {
-                return Ok(Some(id));
-            }
-        }
+    // Goes through `get_book` + flatten — never `search` — so the book scope
+    // is honored. Exact-name match (case-insensitive) is done client-side.
+    match ctx.client.find_page_in_book(parent, name).await? {
+        Some(page) => Ok(page.get("id").and_then(|v| v.as_i64())),
+        None => Ok(None),
     }
-    Ok(None)
+}
+
+/// Used only by `handle_search`, which prepends a positive keyword term —
+/// so the filter is honored. Listing/lookup paths must NOT use this; go
+/// through `list_book_pages_by_updated` / `find_page_in_book` instead.
+fn parent_filter(book_id: CollectionParent) -> String {
+    format!("{{in_book:{book_id}}}")
 }
 
 // --- WRITE ---
@@ -355,18 +345,11 @@ async fn find_or_create_chapter(
     name: &str,
     ctx: &Context,
 ) -> Result<i64, String> {
-    let query = format!("{{type:chapter}} {{in_book:{book_id}}} {{name:{name}}}");
-    let resp = ctx.client.search(&query, 1, 25).await?;
-    let data = resp.get("data").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    for item in data {
-        if item.get("type").and_then(|t| t.as_str()) != Some("chapter") {
-            continue;
-        }
-        let item_name = item.get("name").and_then(|n| n.as_str()).unwrap_or("");
-        if item_name.eq_ignore_ascii_case(name) {
-            if let Some(id) = item.get("id").and_then(|i| i.as_i64()) {
-                return Ok(id);
-            }
+    // Look up via `get_book` + chapter list — never `search` — so we always
+    // see existing chapters and never create duplicates.
+    if let Some(existing) = ctx.client.find_chapter_in_book(book_id, name).await? {
+        if let Some(id) = existing.get("id").and_then(|v| v.as_i64()) {
+            return Ok(id);
         }
     }
     // Create with a generated description (server requires non-empty).

--- a/crates/bsmcp-server/src/remember/frontmatter.rs
+++ b/crates/bsmcp-server/src/remember/frontmatter.rs
@@ -119,6 +119,20 @@ fn yaml_scalar(s: &str) -> String {
     }
 }
 
+/// Current Unix timestamp in seconds.
+pub fn now_unix() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// Current UTC time as ISO 8601 (e.g., "2026-04-26T05:51:23Z").
+pub fn now_iso_utc() -> String {
+    iso_now()
+}
+
 /// Build today's date in YYYY-MM-DD format. Used as the natural key for journals.
 pub fn today_iso_date() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/bsmcp-server/src/remember/identity.rs
+++ b/crates/bsmcp-server/src/remember/identity.rs
@@ -57,23 +57,22 @@ async fn list(ctx: &Context) -> Outcome {
         .unwrap_or_default();
 
     // For each book, find the Identity manifest page (matches the naming convention).
-    // Run lookups in parallel.
+    // Run lookups in parallel. Goes through `list_book_pages_by_updated`
+    // (which uses `get_book`) so the book scope is honored — search would
+    // silently fall through to system-wide results without a positive
+    // keyword term.
     let mut handles = Vec::with_capacity(books.len());
     for (book_id, book_name) in books {
         let client = ctx.client.clone();
         handles.push(tokio::spawn(async move {
-            // Search for the manifest page within this book.
-            let q = format!("{{type:page}} {{in_book:{book_id}}}");
-            let resp = client.search(&q, 1, 50).await.ok();
-            let manifest = resp
-                .and_then(|r| r.get("data").and_then(|d| d.as_array()).cloned())
-                .unwrap_or_default()
-                .into_iter()
-                .filter(|p| p.get("type").and_then(|t| t.as_str()) == Some("page"))
-                .find(|p| {
-                    let n = p.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                    NamedResource::IdentityPage.matches(n)
-                });
+            let pages = client
+                .list_book_pages_by_updated(book_id, usize::MAX)
+                .await
+                .unwrap_or_default();
+            let manifest = pages.into_iter().find(|p| {
+                let n = p.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                NamedResource::IdentityPage.matches(n)
+            });
 
             (book_id, book_name, manifest)
         }));

--- a/crates/bsmcp-server/src/remember/singletons.rs
+++ b/crates/bsmcp-server/src/remember/singletons.rs
@@ -275,10 +275,20 @@ pub async fn write_config(ctx: &Context) -> Outcome {
             );
         }
 
-        // Enforce first-write-wins server-side: only fields that are currently
-        // null may be set; pre-existing values are preserved silently.
+        // Two policies merged in one pass:
+        //   - Shelf IDs are STRUCTURAL: first-write-wins. Once set they're
+        //     locked against change because the data hangs off of them and
+        //     swapping a shelf out from under it isn't supported.
+        //   - Org policy/instruction lists and house-identity defaults are
+        //     TUNABLE: admins can update them as policy evolves. The
+        //     proposed value replaces the existing one (no append; the list
+        //     is meant to be small and curated).
+        // A field omitted from `proposed` (None / empty Vec) is left alone —
+        // partial updates work without re-sending the whole struct.
         let existing = ctx.db.get_global_settings().await.unwrap_or_default();
         let mut merged = existing.clone();
+
+        // Shelf IDs — first-write-wins, warn on attempted change.
         if existing.hive_shelf_id.is_none() {
             if let Some(v) = proposed.hive_shelf_id {
                 merged.hive_shelf_id = Some(v);
@@ -302,6 +312,31 @@ pub async fn write_config(ctx: &Context) -> Outcome {
                 "global_locked",
                 "user_journals_shelf_id is already set; ignoring requested change (first-write-wins).",
             ));
+        }
+
+        // Tunable: house-identity defaults. Admins can re-point these.
+        if proposed.default_ai_identity_page_id.is_some() {
+            merged.default_ai_identity_page_id = proposed.default_ai_identity_page_id;
+        }
+        if proposed.default_ai_identity_name.is_some() {
+            merged.default_ai_identity_name = proposed.default_ai_identity_name.clone();
+        }
+        if proposed.default_ai_identity_ouid.is_some() {
+            merged.default_ai_identity_ouid = proposed.default_ai_identity_ouid.clone();
+        }
+
+        // Tunable: org-mandated instruction / policy page lists. A non-empty
+        // proposed list replaces the current one. To clear, callers can write
+        // a new empty list explicitly via the dedicated `clear_*` flags in a
+        // future API; for now an empty list is treated as "unchanged" so a
+        // partial update (e.g., changing only shelf IDs) doesn't wipe them.
+        if !proposed.org_required_instructions_page_ids.is_empty() {
+            merged.org_required_instructions_page_ids =
+                proposed.org_required_instructions_page_ids.clone();
+        }
+        if !proposed.org_ai_usage_policy_page_ids.is_empty() {
+            merged.org_ai_usage_policy_page_ids =
+                proposed.org_ai_usage_policy_page_ids.clone();
         }
 
         if let Err(e) = ctx.db.save_global_settings(&merged, &ctx.token_id_hash).await {

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -625,13 +625,14 @@ async fn probe_hive(client: &BookStackClient, hive_shelf_id: i64) -> Result<Prob
     out.collage_book = books_on_shelf.iter().find(|b| NamedResource::CollageBook.matches(&b.name)).cloned();
     out.shared_collage_book = books_on_shelf.iter().find(|b| NamedResource::SharedCollageBook.matches(&b.name)).cloned();
 
-    // Identity manifest page inside the Identity book
+    // Identity manifest page inside the Identity book.
+    // Goes through `list_book_pages_by_updated` (which uses `get_book`)
+    // rather than `search` — search silently returns system-wide results
+    // when the query has no positive keyword term, which would surface
+    // pages from outside the identity book.
     if let Some(ref ib) = out.identity_book {
-        let q = format!("{{type:page}} {{in_book:{}}}", ib.id);
-        if let Ok(resp) = client.search(&q, 1, 100).await {
-            let pages = resp.get("data").and_then(|d| d.as_array()).cloned().unwrap_or_default();
+        if let Ok(pages) = client.list_book_pages_by_updated(ib.id, usize::MAX).await {
             out.identity_page = pages.iter().find_map(|p| {
-                if p.get("type").and_then(|t| t.as_str()) != Some("page") { return None; }
                 let name = p.get("name").and_then(|n| n.as_str()).unwrap_or("");
                 if NamedResource::IdentityPage.matches(name) {
                     let id = p.get("id").and_then(|i| i.as_i64())?;

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -201,6 +201,7 @@ pub struct SettingsForm {
     pub recent_journal_count: Option<String>,
     pub active_collage_count: Option<String>,
     pub system_prompt_page_ids: Option<String>,
+    pub timezone: Option<String>,
 
     // Global shelves
     pub hive_shelf_id: Option<String>,
@@ -291,6 +292,7 @@ pub async fn handle_settings_post(
         recent_journal_count: parse_count(form.recent_journal_count, 3),
         active_collage_count: parse_count(form.active_collage_count, 10),
         system_prompt_page_ids: parse_id_list(form.system_prompt_page_ids),
+        timezone: empty_to_none(form.timezone),
         // Carry over the existing dismiss timestamp — saving via /settings
         // doesn't change the snooze. (The nudge auto-stops showing once
         // is_configured() is true.)
@@ -978,6 +980,11 @@ a.reauth:hover { color: #cbd5e1; text-decoration: underline; }
   <input type="text" name="system_prompt_page_ids" id="system_prompt_page_ids" value="{system_prompt_ids}" placeholder="e.g. 3281, 3299, 3402">
   <div class="hint">Page IDs whose full markdown is included in every briefing response. Best for SHORT durable context — writing style, communication preferences, formatting rules, ethical constraints. Long pages bloat every response. Comma- or space-separated.</div>
 </div>
+<div class="field" style="margin-top: 1rem;">
+  <label for="timezone">Timezone</label>
+  <input type="text" name="timezone" id="timezone" value="{timezone_input}" placeholder="America/New_York">
+  <div class="hint">IANA timezone name. Surfaced in the briefing's <code>time</code> block so the AI can format timestamps in your local time. Leave blank for UTC. <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones" target="_blank">List of tz names</a>.</div>
+</div>
 </div>
 
 <div class="card">
@@ -1023,6 +1030,7 @@ a.reauth:hover { color: #cbd5e1; text-decoration: underline; }
         recent_count = s.recent_journal_count,
         collage_count = s.active_collage_count,
         system_prompt_ids = html_escape(&format_id_list(&s.system_prompt_page_ids)),
+        timezone_input = html_escape(s.timezone.as_deref().unwrap_or("")),
 
         global_lock_note = match (g.updated_at > 0, is_admin) {
             (true, _) => "(set globally — locked)",


### PR DESCRIPTION
Sweep of the briefing + remember plumbing so every listing scopes correctly to its target book, every admin field actually saves, system prompts are delivered untruncated, and semantic search gets time + user context.

## Summary

- **Bug class fixed across the codebase**: BookStack's search API silently drops `{in_book:N}` / `{name:foo}` filters when the query has no positive keyword term. Six call sites were doing this and returning system-wide results instead of book-scoped ones — including the briefing's `journal_recent` / `collage_active` and the entire collection-resource read path.
- **`user_journal_recent`** added to the briefing — Nate's user journal (book 755 in BR) was structurally absent before. Both AI and user journals now surface their newest pages.
- **Global settings merge** was only handling `hive_shelf_id` + `user_journals_shelf_id`. Every other admin-tunable field (`org_required_instructions_page_ids`, `org_ai_usage_policy_page_ids`, `default_ai_identity_*`) was silently dropped on write. Now: shelf IDs stay first-write-wins (structural), the rest are tunable.
- **Semantic search query** now carries a `[Context: time=..., tz=..., user=..., ai=...]` preamble so both vector embedding and the hybrid keyword pass get richer signal — prompts like "what was I working on yesterday" can resolve relative to today's date.
- **No-truncation invariant** locked in on `fetch_pages_with_source`. System prompts and org policies are load-bearing — full markdown only.
- **Time block** on the briefing response (`now_unix`, `now_utc`, `timezone`, `timezone_source`) so AIs can place context in time without a separate shell call.

## What landed (commits)

- ` ba31f2c` — original branch fix: AI journal/collage path scoped via `get_book` + flatten + `updated_at` sort. Time block.
- ` 763731f` — three new `BookStackClient` helpers (`list_book_pages_by_updated`, `find_page_in_book`, `find_chapter_in_book`); five additional bug sites refactored (`collection.rs::list_pages` / `find_page_by_name` / `find_or_create_chapter`, `settings_ui.rs` probe, `identity.rs` manifest discovery); ` user_journal_recent` field; flatten unit tests.
- ` 04891ea` — global-settings merge handles all admin fields; ` build_semantic_query` helper; no-truncation invariant comment.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` passes (3 new flatten tests added)
- [ ] Deploy to production
- [ ] `remember_briefing` returns `journal_recent` from book 986 (not random books)
- [ ] `remember_briefing` returns `user_journal_recent` from book 755
- [ ] `remember_config action=write global_settings={"org_required_instructions_page_ids": [2021, 2022]}` actually persists (was silently dropped before this PR)
- [ ] Semantic search query in briefing response logs include the `[Context: ...]` preamble
- [ ] `system_prompt_additions` returns full markdown bodies for personal page 2030 + org pages 2021/2022

## Behavioral note

`/remember/v1/<resource>/read` listings drop the `preview` field — it came from search's `preview_html` and wasn't reliable since the underlying search call was returning wrong pages. Callers who need page content should `get_page` directly. All other fields preserved (`id`, `name`, `url`, `updated_at`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)