### PR TITLE
Add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: Gumbees
+custom: ["https://buy.stripe.com/8x214n0IjaoL0zwcsj4AU00"]


### PR DESCRIPTION
## Summary

- Adds `.github/FUNDING.yml` pointing the Sponsor button to `Gumbees` (personal GitHub Sponsors, payouts attributed to Bee's Roadhouse LLC) and the Bee's Roadhouse Stripe payment link
- Mirrors the existing immichsync FUNDING.yml so all bees-roadhouse public repos route Sponsor clicks to the same destinations

## Test plan

- [ ] After merge, confirm the Sponsor button shows up on https://github.com/bees-roadhouse/bookstack-mcp
- [ ] Confirm the dropdown lists both `@Gumbees` and the custom Stripe link