### PR TITLE
Permission ACL + per-user identity auto-provisioning + global org settings

### DIFF
--- a/crates/bsmcp-common/src/acl.rs
+++ b/crates/bsmcp-common/src/acl.rs
@@ -1,0 +1,289 @@
+//! Per-page ACL resolution.
+//!
+//! Walks BookStack's content-permissions inheritance chain
+//! (page → chapter → book → role-level defaults) and produces a `PageAcl`
+//! describing exactly which roles can view the page. Used by:
+//!   - The embedder, after each successful page embed → upsert into `page_view_acl`.
+//!   - The server's webhook handler, on `*_update` / role events → recompute.
+//!   - The daily reconciliation job, as a safety net for missed events.
+//!
+//! Why this matters: the cold-cache permission filter in semantic search makes
+//! one HTTP call per candidate page. Pre-resolving role-level visibility at
+//! embed time drops candidates the user can't view *before* the HTTP fan-out,
+//! so cold-cache search latency goes from O(candidates) HTTP calls to ~zero
+//! for users whose roles don't match restricted content.
+//!
+//! For the all-inheriting case (no overrides anywhere in the chain) we set
+//! `default_open=true` and leave `view_roles` empty — the consumer treats
+//! these as "candidate visible to anyone with system view permission" and
+//! still runs the HTTP fallback to handle role-level system perms.
+//!
+//! Per-user content_permissions overrides aren't exposed by the BookStack
+//! public API (only role_permissions + fallback_permissions), so they're
+//! not modelled here. The HTTP fallback in `semantic.rs` catches them.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+use crate::bookstack::{BookStackClient, ContentType};
+use crate::db::SemanticDb;
+use crate::types::PageAcl;
+
+/// Cached per-pipeline role state. Built once per pipeline run / webhook
+/// handling pass to avoid hammering `/api/roles` for every page.
+#[derive(Clone, Debug, Default)]
+pub struct RoleContext {
+    /// Every role ID known to BookStack.
+    pub all_role_ids: Vec<i64>,
+    /// Role IDs that hold the system-level `content-export` or `page-view-all`
+    /// style permission — i.e. the roles that can view content inherited from
+    /// instance defaults. When a page falls all the way through inheritance
+    /// without overrides, these are the roles considered to have access.
+    pub view_all_role_ids: Vec<i64>,
+}
+
+/// Build the role context by fetching `/api/roles` and inspecting each role's
+/// `permissions` list. Cheap (~10 roles), safe to call once per pipeline run.
+pub async fn build_role_context(client: &BookStackClient) -> Result<RoleContext, String> {
+    let mut all_role_ids = Vec::new();
+    let mut view_all_role_ids = Vec::new();
+
+    let mut offset = 0i64;
+    loop {
+        let resp = client.list_roles(100, offset).await?;
+        let data = resp.get("data").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+        if data.is_empty() {
+            break;
+        }
+        for role in &data {
+            let id = match role.get("id").and_then(|v| v.as_i64()) {
+                Some(id) => id,
+                None => continue,
+            };
+            all_role_ids.push(id);
+        }
+        let total = resp.get("total").and_then(|v| v.as_i64()).unwrap_or(0);
+        offset += 100;
+        if offset >= total {
+            break;
+        }
+    }
+
+    // Per-role detail fetch — needed because `list_roles` doesn't include the
+    // `permissions` array. Small N (typically ≤ 10).
+    for role_id in &all_role_ids {
+        let detail = match client.get_role(*role_id).await {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("ACL: failed to fetch role {role_id} detail (skipping): {e}");
+                continue;
+            }
+        };
+        if has_view_all_permission(&detail) {
+            view_all_role_ids.push(*role_id);
+        }
+    }
+
+    eprintln!(
+        "ACL: built role context — {} total roles, {} have system-level page view",
+        all_role_ids.len(),
+        view_all_role_ids.len()
+    );
+    Ok(RoleContext { all_role_ids, view_all_role_ids })
+}
+
+/// True when the role detail JSON includes any of BookStack's system-level
+/// "view all content" permissions. Conservative: include `content-export`
+/// because export-capable roles by definition see everything.
+fn has_view_all_permission(role: &Value) -> bool {
+    let perms = match role.get("permissions").and_then(|v| v.as_array()) {
+        Some(p) => p,
+        None => return false,
+    };
+    for perm in perms {
+        if let Some(name) = perm.as_str() {
+            if matches!(name, "page-view-all" | "chapter-view-all" | "book-view-all" | "content-export") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Resolve effective view roles for a page by walking up the inheritance
+/// chain (page → chapter → book) until a non-inheriting permission level is
+/// found. Falls back to `RoleContext::view_all_role_ids` when nothing in the
+/// chain has overrides — these pages are flagged `default_open=true` so the
+/// query path can short-circuit role checks for them.
+pub async fn resolve_page_acl(
+    client: &BookStackClient,
+    page_id: i64,
+    chapter_id: Option<i64>,
+    book_id: i64,
+    role_ctx: &RoleContext,
+) -> Result<PageAcl, String> {
+    let now = now_secs();
+
+    // Page-level override?
+    let page_perms = client
+        .get_content_permissions(ContentType::Page, page_id)
+        .await
+        .ok();
+    if let Some(p) = page_perms.as_ref() {
+        if !is_inheriting(p) {
+            return Ok(PageAcl {
+                page_id,
+                view_roles: compute_effective_view(p, &role_ctx.all_role_ids),
+                default_open: false,
+                computed_at: now,
+            });
+        }
+    }
+
+    // Chapter-level override?
+    if let Some(cid) = chapter_id {
+        if let Ok(cp) = client.get_content_permissions(ContentType::Chapter, cid).await {
+            if !is_inheriting(&cp) {
+                return Ok(PageAcl {
+                    page_id,
+                    view_roles: compute_effective_view(&cp, &role_ctx.all_role_ids),
+                    default_open: false,
+                    computed_at: now,
+                });
+            }
+        }
+    }
+
+    // Book-level override?
+    if let Ok(bp) = client.get_content_permissions(ContentType::Book, book_id).await {
+        if !is_inheriting(&bp) {
+            return Ok(PageAcl {
+                page_id,
+                view_roles: compute_effective_view(&bp, &role_ctx.all_role_ids),
+                default_open: false,
+                computed_at: now,
+            });
+        }
+    }
+
+    // All inheriting — page is visible to roles with system-level view perm.
+    Ok(PageAcl {
+        page_id,
+        view_roles: role_ctx.view_all_role_ids.clone(),
+        default_open: true,
+        computed_at: now,
+    })
+}
+
+fn is_inheriting(perms: &Value) -> bool {
+    perms
+        .get("fallback_permissions")
+        .and_then(|f| f.get("inheriting"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
+}
+
+/// Iterate every known role; for each, decide view access based on the
+/// content_permissions response. Roles with explicit entries use that entry's
+/// `view` flag; roles without entries fall back to `fallback_permissions.view`.
+fn compute_effective_view(perms: &Value, all_role_ids: &[i64]) -> Vec<i64> {
+    let role_perms = perms
+        .get("role_permissions")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let fallback_view = perms
+        .get("fallback_permissions")
+        .and_then(|f| f.get("view"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let mut explicit_view: std::collections::HashMap<i64, bool> = std::collections::HashMap::new();
+    for rp in &role_perms {
+        let role_id = match rp.get("role_id").and_then(|v| v.as_i64()) {
+            Some(id) => id,
+            None => continue,
+        };
+        let view = rp.get("view").and_then(|v| v.as_bool()).unwrap_or(false);
+        explicit_view.insert(role_id, view);
+    }
+
+    let mut out = Vec::new();
+    for &rid in all_role_ids {
+        let allowed = match explicit_view.get(&rid) {
+            Some(&v) => v,
+            None => fallback_view,
+        };
+        if allowed {
+            out.push(rid);
+        }
+    }
+    out
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// Recompute ACL for every page in the embedding store. Called by the daily
+/// reconciliation job and by the webhook handler on role_* / bookshelf_update
+/// events that may have changed effective visibility for a broad set of pages.
+///
+/// Returns `(processed, failed)`. Best-effort: per-page failures are logged
+/// but don't abort the run.
+pub async fn reconcile_all_pages(
+    client: &BookStackClient,
+    db: &Arc<dyn SemanticDb>,
+) -> Result<(usize, usize), String> {
+    let role_ctx = build_role_context(client).await?;
+    let page_ids = db.list_acl_page_ids().await?;
+    let mut processed = 0usize;
+    let mut failed = 0usize;
+    for page_id in page_ids {
+        let meta = match db.get_page_meta(page_id).await {
+            Ok(Some(m)) => m,
+            Ok(None) => continue,
+            Err(e) => {
+                eprintln!("ACL reconcile: get_page_meta({page_id}) failed: {e}");
+                failed += 1;
+                continue;
+            }
+        };
+        match resolve_page_acl(client, page_id, meta.chapter_id, meta.book_id, &role_ctx).await {
+            Ok(acl) => {
+                if let Err(e) = db.upsert_page_acl(&acl).await {
+                    eprintln!("ACL reconcile: upsert page {page_id} failed: {e}");
+                    failed += 1;
+                } else {
+                    processed += 1;
+                }
+            }
+            Err(e) => {
+                eprintln!("ACL reconcile: resolve page {page_id} failed: {e}");
+                failed += 1;
+            }
+        }
+    }
+    Ok((processed, failed))
+}
+
+/// Recompute ACL for a single page. Called by the webhook handler on
+/// page/chapter/book content_permissions changes.
+pub async fn reconcile_page(
+    client: &BookStackClient,
+    db: &Arc<dyn SemanticDb>,
+    page_id: i64,
+    role_ctx: &RoleContext,
+) -> Result<(), String> {
+    let meta = match db.get_page_meta(page_id).await? {
+        Some(m) => m,
+        None => return Ok(()),
+    };
+    let acl = resolve_page_acl(client, page_id, meta.chapter_id, meta.book_id, role_ctx).await?;
+    db.upsert_page_acl(&acl).await
+}

--- a/crates/bsmcp-common/src/db.rs
+++ b/crates/bsmcp-common/src/db.rs
@@ -211,4 +211,9 @@ pub trait SemanticDb: Send + Sync + 'static {
         bookstack_user_id: i64,
         role_ids: &[i64],
     ) -> Result<(), String>;
+
+    /// Drop every cached entry for the given BookStack user. Called by the
+    /// webhook handler on `user_update` (role assignments may have changed)
+    /// and `user_delete` (account is gone).
+    async fn delete_user_role_cache_by_bs_id(&self, bookstack_user_id: i64) -> Result<(), String>;
 }

--- a/crates/bsmcp-common/src/db.rs
+++ b/crates/bsmcp-common/src/db.rs
@@ -128,12 +128,20 @@ pub trait SemanticDb: Send + Sync + 'static {
     /// `book_ids`: when `Some(&[..])`, restrict candidates to chunks whose
     /// parent page lives in one of those books. When `None` or an empty slice,
     /// search across the entire embedded corpus.
+    ///
+    /// `user_role_ids`: when `Some(&[..])`, additionally restrict candidates
+    /// to pages whose `page_view_acl` row matches one of the user's roles.
+    /// Pages with no ACL row are always included (the HTTP fallback path
+    /// in `semantic.rs` still verifies them) so search recall stays correct
+    /// while the embedded ACL eliminates fan-out for pages we already know
+    /// the user can or cannot access.
     async fn vector_search(
         &self,
         query_embedding: &[f32],
         limit: usize,
         threshold: f32,
         book_ids: Option<&[i64]>,
+        user_role_ids: Option<&[i64]>,
     ) -> Result<Vec<SearchHit>, String>;
 
     /// Look up the `book_id` for each requested page in one roundtrip.
@@ -166,4 +174,41 @@ pub trait SemanticDb: Send + Sync + 'static {
 
     /// Set a metadata value by key.
     async fn set_meta(&self, key: &str, value: &str) -> Result<(), String>;
+
+    // --- Permission ACL (page-level role visibility) ---
+
+    /// Replace the ACL row for one page. Deletes any prior `page_view_acl`
+    /// entries for `page_id` then inserts the new role list. `default_open`
+    /// is stored on the `pages` row (`acl_default_open` column) so the
+    /// query path can short-circuit role checks for fully-open pages.
+    async fn upsert_page_acl(&self, acl: &PageAcl) -> Result<(), String>;
+
+    /// Drop a page from the ACL store. Called on `page_delete` events.
+    async fn delete_page_acl(&self, page_id: i64) -> Result<(), String>;
+
+    /// Drop one role from every page's ACL. Called on `role_delete` events.
+    async fn delete_role_from_acl(&self, role_id: i64) -> Result<(), String>;
+
+    /// List page IDs that have a stored ACL. Used by the daily reconciliation
+    /// job to know which pages to refresh.
+    async fn list_acl_page_ids(&self) -> Result<Vec<i64>, String>;
+
+    // --- User role cache (token → BookStack user id → role IDs) ---
+
+    /// Look up cached roles for a token-user. Returns `None` when the
+    /// cache entry is missing or older than `max_age_secs`.
+    async fn get_cached_user_roles(
+        &self,
+        token_id_hash: &str,
+        max_age_secs: i64,
+    ) -> Result<Option<(i64, Vec<i64>)>, String>;
+
+    /// Cache the roles list for a token-user. `bookstack_user_id` is stored
+    /// alongside so callers can use it for per-user permission overrides.
+    async fn set_cached_user_roles(
+        &self,
+        token_id_hash: &str,
+        bookstack_user_id: i64,
+        role_ids: &[i64],
+    ) -> Result<(), String>;
 }

--- a/crates/bsmcp-common/src/lib.rs
+++ b/crates/bsmcp-common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod acl;
 pub mod bookstack;
 pub mod chunking;
 pub mod config;

--- a/crates/bsmcp-common/src/settings.rs
+++ b/crates/bsmcp-common/src/settings.rs
@@ -65,13 +65,39 @@ pub struct UserSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
 
+    /// BookStack user row ID for the calling token's owner. Set automatically
+    /// at /authorize when an admin token can resolve it via `/api/users`, or
+    /// manually via /settings. When set, semantic search resolves the user's
+    /// role IDs once per session (cached in `user_role_cache`) and applies a
+    /// role-level ACL filter to vector candidates — eliminating the per-page
+    /// HTTP fan-out for pages we already know the user can or cannot view.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bookstack_user_id: Option<i64>,
+
     /// BookStack page ID of the user's identity page.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_identity_page_id: Option<i64>,
 
+    /// BookStack book ID of the user's per-user identity book (where the
+    /// identity page + journal-agent definition page live). Auto-provisioned
+    /// on the user-journals shelf when the user first calls `remember_user`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_identity_book_id: Option<i64>,
+
+    /// BookStack page ID of the auto-provisioned `{user_id}-journal-agent`
+    /// agent definition page (lives in the user's identity book).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_journal_agent_page_id: Option<i64>,
+
     /// BookStack book ID of the user's personal journal.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_journal_book_id: Option<i64>,
+
+    /// Domains owned by the user (e.g. `["example.com"]`). Surfaced in the
+    /// briefing's `system_prompt_additions` so the AI can distinguish "ours"
+    /// (URLs/emails on these domains) from external content.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub domains: Vec<String>,
 
     // --- Semantic search toggles (default true except full_kb) ---
 
@@ -211,6 +237,19 @@ pub struct GlobalSettings {
     /// "instructions" (how to act). Admin-only. Page IDs only.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub org_ai_usage_policy_page_ids: Vec<i64>,
+
+    /// Single page describing the organization itself (mission, structure,
+    /// people, conventions). Pulled verbatim into every briefing's
+    /// `system_prompt_additions` under an `## Organization` section. Pairs
+    /// with `org_domains` to give every agent on the instance a shared baseline.
+    /// Admin-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub org_identity_page_id: Option<i64>,
+
+    /// Domains owned by the org (e.g. `["example.com", "example.net"]`).
+    /// Surfaced in every briefing's `system_prompt_additions`. Admin-only.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub org_domains: Vec<String>,
 
     /// Hash of the first token_id that set these values (informational; does
     /// not gate writes — UI handles the lock-after-set semantics).

--- a/crates/bsmcp-common/src/types.rs
+++ b/crates/bsmcp-common/src/types.rs
@@ -69,6 +69,26 @@ pub struct EmbedStats {
     pub latest_job: Option<EmbedJob>,
 }
 
+/// Effective access-control snapshot for a single page. Populated at embed
+/// time by walking BookStack's content-permissions inheritance chain
+/// (page → chapter → book → role-level defaults). Used by `vector_search` to
+/// filter out pages the requesting user can't view, eliminating the per-page
+/// `GET /api/pages/{id}` HTTP fan-out that dominated cold-cache search latency.
+#[derive(Clone, Debug, Default)]
+pub struct PageAcl {
+    pub page_id: i64,
+    /// Role IDs that can view the page. Empty means "explicitly restricted —
+    /// no roles" (only page owner + admins via system permissions).
+    pub view_roles: Vec<i64>,
+    /// True when the resolved permission level is "all-inheriting from book"
+    /// AND no explicit role overrides exist anywhere in the chain. The HTTP
+    /// fallback path uses this to skip the cache-hit short-circuit for
+    /// system-level role permissions that BookStack evaluates dynamically.
+    pub default_open: bool,
+    /// Unix epoch seconds the ACL was computed.
+    pub computed_at: i64,
+}
+
 /// One write/read record from the /remember protocol audit log.
 #[derive(Clone, Debug)]
 pub struct AuditEntry {

--- a/crates/bsmcp-db-postgres/src/lib.rs
+++ b/crates/bsmcp-db-postgres/src/lib.rs
@@ -30,6 +30,17 @@ fn decode_id_list(value: Option<String>) -> Vec<i64> {
     }
 }
 
+fn encode_str_list(values: &[String]) -> Option<String> {
+    if values.is_empty() { None } else { serde_json::to_string(values).ok() }
+}
+
+fn decode_str_list(value: Option<String>) -> Vec<String> {
+    match value {
+        Some(s) if !s.is_empty() => serde_json::from_str(&s).unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
 pub struct PostgresDb {
     pool: PgPool,
     encryption_key: Zeroizing<[u8; 32]>,
@@ -129,6 +140,8 @@ impl PostgresDb {
                 default_ai_identity_ouid TEXT,
                 org_required_instructions_page_ids TEXT,
                 org_ai_usage_policy_page_ids TEXT,
+                org_identity_page_id BIGINT,
+                org_domains TEXT,
                 set_by_token_hash TEXT,
                 updated_at BIGINT NOT NULL DEFAULT 0
             )"
@@ -147,6 +160,8 @@ impl PostgresDb {
             "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS default_ai_identity_ouid TEXT",
             "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS org_required_instructions_page_ids TEXT",
             "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS org_ai_usage_policy_page_ids TEXT",
+            "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS org_identity_page_id BIGINT",
+            "ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS org_domains TEXT",
         ] {
             sqlx::query(sql).execute(&pool).await.ok();
         }
@@ -427,6 +442,7 @@ impl DbBackend for PostgresDb {
                     default_ai_identity_page_id, default_ai_identity_name, default_ai_identity_ouid,
                     org_required_instructions_page_ids,
                     org_ai_usage_policy_page_ids,
+                    org_identity_page_id, org_domains,
                     set_by_token_hash, updated_at
              FROM global_settings WHERE id = 1"
         )
@@ -442,6 +458,8 @@ impl DbBackend for PostgresDb {
             default_ai_identity_ouid: r.get("default_ai_identity_ouid"),
             org_required_instructions_page_ids: decode_id_list(r.get("org_required_instructions_page_ids")),
             org_ai_usage_policy_page_ids: decode_id_list(r.get("org_ai_usage_policy_page_ids")),
+            org_identity_page_id: r.get("org_identity_page_id"),
+            org_domains: decode_str_list(r.get("org_domains")),
             set_by_token_hash: r.get("set_by_token_hash"),
             updated_at: r.get("updated_at"),
         }).unwrap_or_default())
@@ -470,8 +488,10 @@ impl DbBackend for PostgresDb {
                  default_ai_identity_ouid = $5,
                  org_required_instructions_page_ids = $6,
                  org_ai_usage_policy_page_ids = $7,
-                 set_by_token_hash = $8,
-                 updated_at = $9
+                 org_identity_page_id = $8,
+                 org_domains = $9,
+                 set_by_token_hash = $10,
+                 updated_at = $11
              WHERE id = 1"
         )
         .bind(settings.hive_shelf_id)
@@ -481,6 +501,8 @@ impl DbBackend for PostgresDb {
         .bind(&settings.default_ai_identity_ouid)
         .bind(encode_id_list(&settings.org_required_instructions_page_ids))
         .bind(encode_id_list(&settings.org_ai_usage_policy_page_ids))
+        .bind(settings.org_identity_page_id)
+        .bind(encode_str_list(&settings.org_domains))
         .bind(&final_setter)
         .bind(Self::now_secs())
         .execute(&self.pool)
@@ -594,6 +616,44 @@ impl SemanticDb for PostgresDb {
         // Schema migration: add updated_at column if missing
         sqlx::query("ALTER TABLE pages ADD COLUMN IF NOT EXISTS updated_at TEXT")
             .execute(&self.pool).await.ok();
+
+        // Permission ACL: per-page role visibility, populated at embed time
+        // by walking BookStack content_permissions inheritance.
+        sqlx::query("ALTER TABLE pages ADD COLUMN IF NOT EXISTS acl_default_open BOOLEAN")
+            .execute(&self.pool).await.ok();
+        sqlx::query("ALTER TABLE pages ADD COLUMN IF NOT EXISTS acl_computed_at BIGINT")
+            .execute(&self.pool).await.ok();
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS page_view_acl (
+                page_id BIGINT NOT NULL,
+                role_id BIGINT NOT NULL,
+                PRIMARY KEY (page_id, role_id)
+            )"
+        ).execute(&self.pool).await
+            .map_err(|e| format!("Failed to create page_view_acl: {e}"))?;
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_page_view_acl_role ON page_view_acl(role_id, page_id)")
+            .execute(&self.pool).await.ok();
+
+        // Cache: BookStack user id + role IDs per token. Refreshed lazily by
+        // semantic.rs on first vector_search per session, ~15 min TTL.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS user_role_cache (
+                token_id_hash TEXT PRIMARY KEY,
+                bookstack_user_id BIGINT NOT NULL,
+                role_ids TEXT NOT NULL,
+                fetched_at BIGINT NOT NULL
+            )"
+        ).execute(&self.pool).await
+            .map_err(|e| format!("Failed to create user_role_cache: {e}"))?;
+
+        // Reconciliation tracker — single-row table for the daily ACL refresh job.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS acl_reconcile_state (
+                scope TEXT PRIMARY KEY,
+                last_full_run BIGINT NOT NULL DEFAULT 0
+            )"
+        ).execute(&self.pool).await
+            .map_err(|e| format!("Failed to create acl_reconcile_state: {e}"))?;
 
         eprintln!("Semantic: PostgreSQL tables initialized");
         Ok(())
@@ -1097,6 +1157,7 @@ impl SemanticDb for PostgresDb {
         limit: usize,
         threshold: f32,
         book_ids: Option<&[i64]>,
+        user_role_ids: Option<&[i64]>,
     ) -> Result<Vec<SearchHit>, String> {
         // Sanity check: detect garbage embeddings (all zeros, NaN, etc.)
         let magnitude: f32 = query_embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -1120,9 +1181,43 @@ impl SemanticDb for PostgresDb {
             Some(ids) if !ids.is_empty() => Some(ids.to_vec()),
             _ => None,
         };
+        // Optional ACL filter. The predicate keeps chunks whose page is either:
+        //   - default-open (no explicit role restrictions anywhere in the
+        //     inheritance chain; HTTP fallback resolves system-level perms),
+        //   - has no ACL row computed yet (HTTP fallback in semantic.rs),
+        //   - has a `page_view_acl` row matching one of the user's roles.
+        // This eliminates pages we already know the user can't view from the
+        // candidate pool without losing recall on as-yet-uncomputed pages.
+        let role_filter: Option<Vec<i64>> = match user_role_ids {
+            Some(ids) if !ids.is_empty() => Some(ids.to_vec()),
+            _ => None,
+        };
 
-        let rows = if let Some(ids) = book_filter {
-            sqlx::query(
+        let rows = match (book_filter, role_filter) {
+            (Some(books), Some(roles)) => sqlx::query(
+                "SELECT c.id, c.page_id, (1 - (c.embedding <=> $1::vector))::FLOAT4 AS score
+                 FROM chunks c
+                 JOIN pages p ON c.page_id = p.page_id
+                 WHERE 1 - (c.embedding <=> $1::vector) > $2::FLOAT8
+                   AND p.book_id = ANY($4)
+                   AND (
+                        p.acl_computed_at IS NULL
+                        OR COALESCE(p.acl_default_open, FALSE) = TRUE
+                        OR EXISTS (
+                            SELECT 1 FROM page_view_acl a
+                            WHERE a.page_id = p.page_id AND a.role_id = ANY($5)
+                        )
+                   )
+                 ORDER BY c.embedding <=> $1::vector
+                 LIMIT $3"
+            )
+            .bind(&vec)
+            .bind(threshold)
+            .bind(limit as i64)
+            .bind(&books)
+            .bind(&roles)
+            .fetch_all(&mut *tx).await,
+            (Some(books), None) => sqlx::query(
                 "SELECT c.id, c.page_id, (1 - (c.embedding <=> $1::vector))::FLOAT4 AS score
                  FROM chunks c
                  JOIN pages p ON c.page_id = p.page_id
@@ -1134,12 +1229,30 @@ impl SemanticDb for PostgresDb {
             .bind(&vec)
             .bind(threshold)
             .bind(limit as i64)
-            .bind(&ids)
-            .fetch_all(&mut *tx)
-            .await
-            .map_err(|e| format!("vector_search (scoped) failed: {e}"))?
-        } else {
-            sqlx::query(
+            .bind(&books)
+            .fetch_all(&mut *tx).await,
+            (None, Some(roles)) => sqlx::query(
+                "SELECT c.id, c.page_id, (1 - (c.embedding <=> $1::vector))::FLOAT4 AS score
+                 FROM chunks c
+                 JOIN pages p ON c.page_id = p.page_id
+                 WHERE 1 - (c.embedding <=> $1::vector) > $2::FLOAT8
+                   AND (
+                        p.acl_computed_at IS NULL
+                        OR COALESCE(p.acl_default_open, FALSE) = TRUE
+                        OR EXISTS (
+                            SELECT 1 FROM page_view_acl a
+                            WHERE a.page_id = p.page_id AND a.role_id = ANY($4)
+                        )
+                   )
+                 ORDER BY c.embedding <=> $1::vector
+                 LIMIT $3"
+            )
+            .bind(&vec)
+            .bind(threshold)
+            .bind(limit as i64)
+            .bind(&roles)
+            .fetch_all(&mut *tx).await,
+            (None, None) => sqlx::query(
                 "SELECT id, page_id, (1 - (embedding <=> $1::vector))::FLOAT4 AS score
                  FROM chunks
                  WHERE 1 - (embedding <=> $1::vector) > $2::FLOAT8
@@ -1149,10 +1262,9 @@ impl SemanticDb for PostgresDb {
             .bind(&vec)
             .bind(threshold)
             .bind(limit as i64)
-            .fetch_all(&mut *tx)
-            .await
-            .map_err(|e| format!("vector_search failed: {e}"))?
+            .fetch_all(&mut *tx).await,
         };
+        let rows = rows.map_err(|e| format!("vector_search failed: {e}"))?;
 
         tx.commit().await.ok();
 
@@ -1278,6 +1390,114 @@ impl SemanticDb for PostgresDb {
             .execute(&self.pool)
             .await
             .map_err(|e| format!("set_meta: {e}"))?;
+        Ok(())
+    }
+
+    async fn upsert_page_acl(&self, acl: &PageAcl) -> Result<(), String> {
+        let mut tx = self.pool.begin().await
+            .map_err(|e| format!("upsert_page_acl tx: {e}"))?;
+        sqlx::query("DELETE FROM page_view_acl WHERE page_id = $1")
+            .bind(acl.page_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| format!("upsert_page_acl delete: {e}"))?;
+        for &role_id in &acl.view_roles {
+            sqlx::query(
+                "INSERT INTO page_view_acl (page_id, role_id) VALUES ($1, $2)
+                 ON CONFLICT (page_id, role_id) DO NOTHING"
+            )
+            .bind(acl.page_id)
+            .bind(role_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| format!("upsert_page_acl insert: {e}"))?;
+        }
+        sqlx::query(
+            "UPDATE pages SET acl_default_open = $1, acl_computed_at = $2 WHERE page_id = $3"
+        )
+        .bind(acl.default_open)
+        .bind(acl.computed_at)
+        .bind(acl.page_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| format!("upsert_page_acl flag: {e}"))?;
+        tx.commit().await.map_err(|e| format!("upsert_page_acl commit: {e}"))?;
+        Ok(())
+    }
+
+    async fn delete_page_acl(&self, page_id: i64) -> Result<(), String> {
+        sqlx::query("DELETE FROM page_view_acl WHERE page_id = $1")
+            .bind(page_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| format!("delete_page_acl: {e}"))?;
+        Ok(())
+    }
+
+    async fn delete_role_from_acl(&self, role_id: i64) -> Result<(), String> {
+        sqlx::query("DELETE FROM page_view_acl WHERE role_id = $1")
+            .bind(role_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| format!("delete_role_from_acl: {e}"))?;
+        Ok(())
+    }
+
+    async fn list_acl_page_ids(&self) -> Result<Vec<i64>, String> {
+        let rows: Vec<(i64,)> = sqlx::query_as(
+            "SELECT page_id FROM pages WHERE acl_computed_at IS NOT NULL"
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| format!("list_acl_page_ids: {e}"))?;
+        Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
+    async fn get_cached_user_roles(
+        &self,
+        token_id_hash: &str,
+        max_age_secs: i64,
+    ) -> Result<Option<(i64, Vec<i64>)>, String> {
+        let cutoff = Self::now_secs() - max_age_secs;
+        let row: Option<(i64, String, i64)> = sqlx::query_as(
+            "SELECT bookstack_user_id, role_ids, fetched_at
+             FROM user_role_cache WHERE token_id_hash = $1"
+        )
+        .bind(token_id_hash)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| format!("get_cached_user_roles: {e}"))?;
+        match row {
+            Some((uid, json, fetched)) if fetched > cutoff => {
+                let roles: Vec<i64> = serde_json::from_str(&json).unwrap_or_default();
+                Ok(Some((uid, roles)))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    async fn set_cached_user_roles(
+        &self,
+        token_id_hash: &str,
+        bookstack_user_id: i64,
+        role_ids: &[i64],
+    ) -> Result<(), String> {
+        let json = serde_json::to_string(role_ids).unwrap_or_else(|_| "[]".to_string());
+        sqlx::query(
+            "INSERT INTO user_role_cache (token_id_hash, bookstack_user_id, role_ids, fetched_at)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (token_id_hash) DO UPDATE SET
+                bookstack_user_id = EXCLUDED.bookstack_user_id,
+                role_ids = EXCLUDED.role_ids,
+                fetched_at = EXCLUDED.fetched_at"
+        )
+        .bind(token_id_hash)
+        .bind(bookstack_user_id)
+        .bind(&json)
+        .bind(Self::now_secs())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| format!("set_cached_user_roles: {e}"))?;
         Ok(())
     }
 }

--- a/crates/bsmcp-db-postgres/src/lib.rs
+++ b/crates/bsmcp-db-postgres/src/lib.rs
@@ -1500,4 +1500,13 @@ impl SemanticDb for PostgresDb {
         .map_err(|e| format!("set_cached_user_roles: {e}"))?;
         Ok(())
     }
+
+    async fn delete_user_role_cache_by_bs_id(&self, bookstack_user_id: i64) -> Result<(), String> {
+        sqlx::query("DELETE FROM user_role_cache WHERE bookstack_user_id = $1")
+            .bind(bookstack_user_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| format!("delete_user_role_cache_by_bs_id: {e}"))?;
+        Ok(())
+    }
 }

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -1608,6 +1608,20 @@ impl SemanticDb for SqliteDb {
         .await
         .map_err(|e| format!("Task failed: {e}"))?
     }
+
+    async fn delete_user_role_cache_by_bs_id(&self, bookstack_user_id: i64) -> Result<(), String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            conn.execute(
+                "DELETE FROM user_role_cache WHERE bookstack_user_id = ?1",
+                params![bookstack_user_id],
+            ).map_err(|e| format!("delete_user_role_cache_by_bs_id: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
 }
 
 /// Encode a Vec<i64> as a JSON array string (or NULL when empty so the column

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -75,6 +75,8 @@ impl SqliteDb {
                  default_ai_identity_ouid TEXT,
                  org_required_instructions_page_ids TEXT,
                  org_ai_usage_policy_page_ids TEXT,
+                 org_identity_page_id INTEGER,
+                 org_domains TEXT,
                  set_by_token_hash TEXT,
                  updated_at INTEGER NOT NULL DEFAULT 0
              );
@@ -96,6 +98,8 @@ impl SqliteDb {
             "ALTER TABLE global_settings ADD COLUMN default_ai_identity_ouid TEXT",
             "ALTER TABLE global_settings ADD COLUMN org_required_instructions_page_ids TEXT",
             "ALTER TABLE global_settings ADD COLUMN org_ai_usage_policy_page_ids TEXT",
+            "ALTER TABLE global_settings ADD COLUMN org_identity_page_id INTEGER",
+            "ALTER TABLE global_settings ADD COLUMN org_domains TEXT",
         ] {
             conn.execute_batch(sql).ok();
         }
@@ -421,6 +425,7 @@ impl DbBackend for SqliteDb {
                         default_ai_identity_page_id, default_ai_identity_name, default_ai_identity_ouid,
                         org_required_instructions_page_ids,
                         org_ai_usage_policy_page_ids,
+                        org_identity_page_id, org_domains,
                         set_by_token_hash, updated_at
                  FROM global_settings WHERE id = 1",
                 [],
@@ -432,8 +437,10 @@ impl DbBackend for SqliteDb {
                     default_ai_identity_ouid: row.get::<_, Option<String>>(4)?,
                     org_required_instructions_page_ids: decode_id_list(row.get::<_, Option<String>>(5)?),
                     org_ai_usage_policy_page_ids: decode_id_list(row.get::<_, Option<String>>(6)?),
-                    set_by_token_hash: row.get::<_, Option<String>>(7)?,
-                    updated_at: row.get::<_, i64>(8)?,
+                    org_identity_page_id: row.get::<_, Option<i64>>(7)?,
+                    org_domains: decode_str_list(row.get::<_, Option<String>>(8)?),
+                    set_by_token_hash: row.get::<_, Option<String>>(9)?,
+                    updated_at: row.get::<_, i64>(10)?,
                 }),
             ).unwrap_or_default();
             Ok(row)
@@ -467,8 +474,10 @@ impl DbBackend for SqliteDb {
                      default_ai_identity_ouid = ?5,
                      org_required_instructions_page_ids = ?6,
                      org_ai_usage_policy_page_ids = ?7,
-                     set_by_token_hash = ?8,
-                     updated_at = ?9
+                     org_identity_page_id = ?8,
+                     org_domains = ?9,
+                     set_by_token_hash = ?10,
+                     updated_at = ?11
                  WHERE id = 1",
                 params![
                     s.hive_shelf_id,
@@ -478,6 +487,8 @@ impl DbBackend for SqliteDb {
                     s.default_ai_identity_ouid,
                     encode_id_list(&s.org_required_instructions_page_ids),
                     encode_id_list(&s.org_ai_usage_policy_page_ids),
+                    s.org_identity_page_id,
+                    encode_str_list(&s.org_domains),
                     final_setter,
                     SqliteDb::now_secs(),
                 ],
@@ -629,6 +640,32 @@ impl SemanticDb for SqliteDb {
             conn.execute_batch(
                 "ALTER TABLE pages ADD COLUMN updated_at TEXT;"
             ).ok();
+
+            // Permission ACL: per-page role visibility populated at embed time.
+            conn.execute_batch(
+                "ALTER TABLE pages ADD COLUMN acl_default_open INTEGER;"
+            ).ok();
+            conn.execute_batch(
+                "ALTER TABLE pages ADD COLUMN acl_computed_at INTEGER;"
+            ).ok();
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS page_view_acl (
+                     page_id INTEGER NOT NULL,
+                     role_id INTEGER NOT NULL,
+                     PRIMARY KEY (page_id, role_id)
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_page_view_acl_role ON page_view_acl(role_id, page_id);
+                 CREATE TABLE IF NOT EXISTS user_role_cache (
+                     token_id_hash TEXT PRIMARY KEY,
+                     bookstack_user_id INTEGER NOT NULL,
+                     role_ids TEXT NOT NULL,
+                     fetched_at INTEGER NOT NULL
+                 );
+                 CREATE TABLE IF NOT EXISTS acl_reconcile_state (
+                     scope TEXT PRIMARY KEY,
+                     last_full_run INTEGER NOT NULL DEFAULT 0
+                 );"
+            ).map_err(|e| format!("Failed to create ACL tables: {e}"))?;
 
             eprintln!("Semantic: tables initialized");
             Ok(())
@@ -1240,6 +1277,7 @@ impl SemanticDb for SqliteDb {
         limit: usize,
         threshold: f32,
         book_ids: Option<&[i64]>,
+        user_role_ids: Option<&[i64]>,
     ) -> Result<Vec<SearchHit>, String> {
         let conn = self.conn.clone();
         let query_embedding = query_embedding.to_vec();
@@ -1249,27 +1287,54 @@ impl SemanticDb for SqliteDb {
             Some(ids) if !ids.is_empty() => Some(ids.to_vec()),
             _ => None,
         };
+        let role_filter: Option<Vec<i64>> = match user_role_ids {
+            Some(ids) if !ids.is_empty() => Some(ids.to_vec()),
+            _ => None,
+        };
 
         tokio::task::spawn_blocking(move || {
             let conn = conn.lock().unwrap();
 
-            // Note: each branch binds `out` to a Vec before yielding it from
-            // the block. The borrow checker rejects returning the .collect()
-            // expression directly because the temporary MappedRows borrows
-            // `stmt`, and `stmt` is dropped at the end of the block.
-            let all_chunks: Vec<(i64, i64, Vec<u8>)> = if let Some(ids) = book_filter {
-                // Build a parameterized IN list — rusqlite doesn't expand &[i64]
-                // automatically, so we generate "?, ?, ?" placeholders and bind
-                // each id individually.
+            // Build the WHERE clause incrementally based on which filters are
+            // active. ACL semantics match Postgres: a chunk's page is kept iff
+            //   - its ACL hasn't been computed yet (HTTP fallback in semantic.rs), OR
+            //   - it's flagged default-open, OR
+            //   - the user's role list intersects page_view_acl.role_id.
+            let mut where_clauses: Vec<String> = Vec::new();
+            let mut params_dyn: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+            let need_pages_join = book_filter.is_some() || role_filter.is_some();
+
+            if let Some(ref ids) = book_filter {
                 let placeholders = std::iter::repeat("?").take(ids.len()).collect::<Vec<_>>().join(",");
+                where_clauses.push(format!("p.book_id IN ({placeholders})"));
+                for id in ids {
+                    params_dyn.push(Box::new(*id));
+                }
+            }
+            if let Some(ref roles) = role_filter {
+                let placeholders = std::iter::repeat("?").take(roles.len()).collect::<Vec<_>>().join(",");
+                where_clauses.push(format!(
+                    "(p.acl_computed_at IS NULL
+                      OR COALESCE(p.acl_default_open, 0) = 1
+                      OR EXISTS (SELECT 1 FROM page_view_acl a
+                                 WHERE a.page_id = p.page_id AND a.role_id IN ({placeholders})))"
+                ));
+                for r in roles {
+                    params_dyn.push(Box::new(*r));
+                }
+            }
+
+            let all_chunks: Vec<(i64, i64, Vec<u8>)> = if need_pages_join {
+                let where_sql = if where_clauses.is_empty() { String::new() }
+                    else { format!("WHERE {}", where_clauses.join(" AND ")) };
                 let sql = format!(
                     "SELECT c.id, c.page_id, c.embedding
                      FROM chunks c JOIN pages p ON c.page_id = p.page_id
-                     WHERE p.book_id IN ({placeholders})"
+                     {where_sql}"
                 );
                 let mut stmt = conn.prepare(&sql).map_err(|e| format!("Prepare failed: {e}"))?;
                 let params_vec: Vec<&dyn rusqlite::ToSql> =
-                    ids.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
+                    params_dyn.iter().map(|b| b.as_ref() as &dyn rusqlite::ToSql).collect();
                 let out: Vec<(i64, i64, Vec<u8>)> = stmt
                     .query_map(params_vec.as_slice(), |row| {
                         Ok((row.get(0)?, row.get(1)?, row.get(2)?))
@@ -1422,6 +1487,127 @@ impl SemanticDb for SqliteDb {
         .await
         .map_err(|e| format!("Task failed: {e}"))?
     }
+
+    async fn upsert_page_acl(&self, acl: &PageAcl) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let acl = acl.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            let tx = conn.unchecked_transaction()
+                .map_err(|e| format!("upsert_page_acl tx: {e}"))?;
+            tx.execute("DELETE FROM page_view_acl WHERE page_id = ?1", params![acl.page_id])
+                .map_err(|e| format!("upsert_page_acl delete: {e}"))?;
+            for &role_id in &acl.view_roles {
+                tx.execute(
+                    "INSERT OR IGNORE INTO page_view_acl (page_id, role_id) VALUES (?1, ?2)",
+                    params![acl.page_id, role_id],
+                ).map_err(|e| format!("upsert_page_acl insert: {e}"))?;
+            }
+            let default_open: i64 = if acl.default_open { 1 } else { 0 };
+            tx.execute(
+                "UPDATE pages SET acl_default_open = ?1, acl_computed_at = ?2 WHERE page_id = ?3",
+                params![default_open, acl.computed_at, acl.page_id],
+            ).map_err(|e| format!("upsert_page_acl flag: {e}"))?;
+            tx.commit().map_err(|e| format!("upsert_page_acl commit: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
+
+    async fn delete_page_acl(&self, page_id: i64) -> Result<(), String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            conn.execute("DELETE FROM page_view_acl WHERE page_id = ?1", params![page_id])
+                .map_err(|e| format!("delete_page_acl: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
+
+    async fn delete_role_from_acl(&self, role_id: i64) -> Result<(), String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            conn.execute("DELETE FROM page_view_acl WHERE role_id = ?1", params![role_id])
+                .map_err(|e| format!("delete_role_from_acl: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
+
+    async fn list_acl_page_ids(&self) -> Result<Vec<i64>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            let mut stmt = conn
+                .prepare("SELECT page_id FROM pages WHERE acl_computed_at IS NOT NULL")
+                .map_err(|e| format!("Prepare failed: {e}"))?;
+            let out: Vec<i64> = stmt
+                .query_map([], |row| row.get::<_, i64>(0))
+                .map_err(|e| format!("Query failed: {e}"))?
+                .filter_map(|r| r.ok())
+                .collect();
+            Ok(out)
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
+
+    async fn get_cached_user_roles(
+        &self,
+        token_id_hash: &str,
+        max_age_secs: i64,
+    ) -> Result<Option<(i64, Vec<i64>)>, String> {
+        let conn = self.conn.clone();
+        let key = token_id_hash.to_string();
+        tokio::task::spawn_blocking(move || {
+            let cutoff = SqliteDb::now_secs() - max_age_secs;
+            let conn = conn.lock().unwrap();
+            let row: Option<(i64, String, i64)> = conn.query_row(
+                "SELECT bookstack_user_id, role_ids, fetched_at
+                 FROM user_role_cache WHERE token_id_hash = ?1",
+                params![key],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            ).ok();
+            Ok(row.and_then(|(uid, json, fetched)| {
+                if fetched > cutoff {
+                    let roles: Vec<i64> = serde_json::from_str(&json).unwrap_or_default();
+                    Some((uid, roles))
+                } else {
+                    None
+                }
+            }))
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
+
+    async fn set_cached_user_roles(
+        &self,
+        token_id_hash: &str,
+        bookstack_user_id: i64,
+        role_ids: &[i64],
+    ) -> Result<(), String> {
+        let conn = self.conn.clone();
+        let key = token_id_hash.to_string();
+        let json = serde_json::to_string(role_ids).unwrap_or_else(|_| "[]".to_string());
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO user_role_cache
+                    (token_id_hash, bookstack_user_id, role_ids, fetched_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![key, bookstack_user_id, json, SqliteDb::now_secs()],
+            ).map_err(|e| format!("set_cached_user_roles: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
 }
 
 /// Encode a Vec<i64> as a JSON array string (or NULL when empty so the column
@@ -1431,6 +1617,17 @@ fn encode_id_list(ids: &[i64]) -> Option<String> {
 }
 
 fn decode_id_list(value: Option<String>) -> Vec<i64> {
+    match value {
+        Some(s) if !s.is_empty() => serde_json::from_str(&s).unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+fn encode_str_list(values: &[String]) -> Option<String> {
+    if values.is_empty() { None } else { serde_json::to_string(values).ok() }
+}
+
+fn decode_str_list(value: Option<String>) -> Vec<String> {
     match value {
         Some(s) if !s.is_empty() => serde_json::from_str(&s).unwrap_or_default(),
         _ => Vec::new(),

--- a/crates/bsmcp-embedder/src/pipeline.rs
+++ b/crates/bsmcp-embedder/src/pipeline.rs
@@ -9,6 +9,7 @@ use fastembed::{
     TokenizerFiles, UserDefinedEmbeddingModel,
 };
 
+use bsmcp_common::acl::{build_role_context, reconcile_all_pages, resolve_page_acl, RoleContext};
 use bsmcp_common::bookstack::BookStackClient;
 use bsmcp_common::chunking;
 use bsmcp_common::db::SemanticDb;
@@ -253,8 +254,42 @@ pub async fn run_pipeline(
 ) -> Result<PipelineResult, String> {
     eprintln!("Pipeline: starting (scope={scope}, job_id={job_id})");
 
+    // ACL-only reconciliation path. Triggered by webhooks for role events or
+    // by the daily reconciliation cron — no embedding work, just refresh
+    // page_view_acl for every previously-stored page.
+    if scope == "acl_reconcile" {
+        match reconcile_all_pages(client, db).await {
+            Ok((processed, failed)) => {
+                eprintln!("Pipeline: ACL reconcile complete — {processed} ok, {failed} failed");
+                db.update_job_progress(job_id, processed as i64, (processed + failed) as i64).await?;
+                return Ok(PipelineResult {
+                    total_pages: processed + failed,
+                    succeeded: processed,
+                    failed_pages: Vec::new(),
+                    aborted: false,
+                });
+            }
+            Err(e) => {
+                eprintln!("Pipeline: ACL reconcile failed: {e}");
+                return Err(e);
+            }
+        }
+    }
+
     // Build shelf lookup for context prefix injection
     let shelf_lookup = build_shelf_lookup(client).await;
+
+    // Resolve role context once per pipeline run for ACL stamping. If the
+    // BookStack token can't list roles (rare — system-level perm), ACL
+    // population is skipped for the whole run; semantic search falls back to
+    // its existing per-page HTTP permission check.
+    let role_ctx = match build_role_context(client).await {
+        Ok(rc) => Some(rc),
+        Err(e) => {
+            eprintln!("Pipeline: role context unavailable, ACL stamping disabled this run: {e}");
+            None
+        }
+    };
 
     // Collect page IDs to embed
     let mut offset = 0i64;
@@ -318,7 +353,7 @@ pub async fn run_pipeline(
     let mut aborted = false;
 
     for (i, page_id) in all_page_ids.iter().enumerate() {
-        match embed_single_page(db, embedder, client, *page_id, force, &shelf_lookup).await {
+        match embed_single_page(db, embedder, client, *page_id, force, &shelf_lookup, role_ctx.as_ref()).await {
             Ok(()) => {
                 succeeded += 1;
                 consecutive_failures = 0;
@@ -373,6 +408,7 @@ async fn embed_single_page(
     page_id: i64,
     force: bool,
     shelf_lookup: &HashMap<i64, String>,
+    role_ctx: Option<&RoleContext>,
 ) -> Result<(), String> {
     let page = client.get_page(page_id).await?;
 
@@ -489,6 +525,23 @@ async fn embed_single_page(
 
     // Store final page metadata with real content_hash — this is the commit marker.
     db.upsert_page(&meta).await?;
+
+    // Stamp the per-page ACL. Best-effort: a failure here doesn't fail the
+    // embed (the page is already searchable), it just means the page falls
+    // through to the HTTP permission check at query time until the next
+    // pipeline run or webhook recompute.
+    if let Some(rc) = role_ctx {
+        match resolve_page_acl(client, page_id, chapter_id, book_id, rc).await {
+            Ok(acl) => {
+                if let Err(e) = db.upsert_page_acl(&acl).await {
+                    eprintln!("Pipeline: page {page_id} ACL upsert failed (non-fatal): {e}");
+                }
+            }
+            Err(e) => {
+                eprintln!("Pipeline: page {page_id} ACL resolve failed (non-fatal): {e}");
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/bsmcp-server/src/main.rs
+++ b/crates/bsmcp-server/src/main.rs
@@ -159,11 +159,13 @@ async fn main() {
                     None
                 } else {
                     eprintln!("Semantic: enabled (embedder_url={embedder_url})");
-                    Some(Arc::new(semantic::SemanticState::new(
+                    let state = Arc::new(semantic::SemanticState::new(
                         sdb.clone(),
                         embedder_url,
                         webhook_secret,
-                    )))
+                    ));
+                    state.clone().spawn_acl_reconcile();
+                    Some(state)
                 }
             }
             None => {

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -131,7 +131,11 @@ async fn execute_tool(
             let default_threshold = if hybrid { 0.45 } else { 0.50 };
             let threshold = args.get("threshold").and_then(|v| v.as_f64()).unwrap_or(default_threshold) as f32;
             let verbose = args.get("verbose").and_then(|v| v.as_bool()).unwrap_or(false);
-            let result = sem.search(&query, limit, threshold, hybrid, verbose, client, None).await?;
+            // ACL filter is left disabled at the raw `semantic_search` tool
+            // entry point — it has no UserSettings context to look up the
+            // caller's `bookstack_user_id`. The HTTP `filter_by_permission`
+            // fallback inside `sem.search` still enforces access control.
+            let result = sem.search(&query, limit, threshold, hybrid, verbose, client, None, None).await?;
             format_json(&result)
         }
         "reembed" => {
@@ -1916,7 +1920,8 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
 
     tools.push(remember_tool(
         "user",
-        "Human user identity. read returns the user's identity page + journal pointer. write replaces the user identity page body.",
+        "Human user identity. read auto-provisions missing structure (per-user Identity book on the user-journals shelf, Identity page, Agent: {user_id}-journal-agent page, journal book) when `user_id` is set, returning what was created in `auto_provisioned`. write replaces the user identity page body. \
+         IMPORTANT: as you work with the user, learn what they care about, how they prefer to collaborate, and update the identity page to reflect that — the briefing surfaces a refresh reminder after 30 days of inactivity.",
         &["read", "write"],
         json!({
             "body": { "type": "string", "description": "New user identity markdown for write" },
@@ -1925,11 +1930,14 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
 
     tools.push(remember_tool(
         "config",
-        "Per-user settings AND (admin-only) global shelves. read returns both `{settings, global_settings}`. write accepts `settings` (per-user — any user) and/or `global_settings` (admin-only, server-side first-write-wins; pre-set fields cannot be changed and trigger a `global_locked` warning). dismiss_setup_nudge snoozes the briefing's setup reminder for `days` days (default 7, max 365).",
+        "Per-user settings AND (admin-only) global shelves. read returns both `{settings, global_settings}`. write accepts `settings` (per-user — any user) and/or `global_settings` (admin-only, server-side first-write-wins for shelf and org_identity_page IDs; org_domains and org-default identity are tunable). \
+         Per-user fields the AI typically maintains: `domains` (list of strings — owned domains for ours/external classification), `bookstack_user_id` (numeric BookStack user id, enables ACL-filtered semantic search), `user_id` (stable identifier, drives auto-provisioning naming), plus the ai_*/user_* book/page IDs. \
+         Admin-only globals: `hive_shelf_id`, `user_journals_shelf_id`, `org_identity_page_id` (first-write-wins), `org_domains` (replaces on write), and the org-default identity fields. \
+         dismiss_setup_nudge snoozes the briefing's setup reminder for `days` days (default 7, max 365).",
         &["read", "write", "dismiss_setup_nudge"],
         json!({
             "settings": { "type": "object", "description": "Full UserSettings object for per-user write" },
-            "global_settings": { "type": "object", "description": "GlobalSettings object (admin-only). Only null fields are written; set fields are preserved." },
+            "global_settings": { "type": "object", "description": "GlobalSettings object (admin-only). Only null fields are written; set fields are preserved (except org_domains which replaces)." },
             "days": { "type": "integer", "description": "For dismiss_setup_nudge: how many days to snooze (default 7, max 365)" },
         }),
     ));

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -89,6 +89,8 @@ pub async fn read(ctx: &Context) -> Outcome {
     let configured_book_ids = configured_semantic_book_ids(&ctx.settings);
     let full_kb = ctx.settings.semantic_against_full_kb;
     let configured_books_for_kb_exclusion = configured_book_ids.clone();
+    let bookstack_user_id = ctx.settings.bookstack_user_id;
+    let token_id_hash = ctx.token_id_hash.clone();
     let semantic_fut = async {
         if user_prompt.is_empty() {
             return SemanticSlice::default();
@@ -114,8 +116,24 @@ pub async fn read(ctx: &Context) -> Outcome {
             Some(configured_book_ids.as_slice())
         };
 
+        // Resolve the user's BookStack roles for ACL filtering. None when
+        // `bookstack_user_id` isn't configured; sem.search then falls through
+        // to the existing HTTP per-page permission check.
+        let user_roles = sem
+            .resolve_user_roles(&token_id_hash, bookstack_user_id, &ctx.client)
+            .await;
+
         let raw = match sem
-            .search(&prompt_for_semantic, 40, 0.40, true, false, &ctx.client, book_filter)
+            .search(
+                &prompt_for_semantic,
+                40,
+                0.40,
+                true,
+                false,
+                &ctx.client,
+                book_filter,
+                user_roles.as_deref(),
+            )
             .await
         {
             Ok(v) => v.get("results").and_then(|r| r.as_array()).cloned().unwrap_or_default(),
@@ -155,10 +173,11 @@ pub async fn read(ctx: &Context) -> Outcome {
         slice
     };
 
-    // Always-on context pages — three sources, all run in parallel:
+    // Always-on context pages — four sources, all run in parallel:
     //   - user-configured (system_prompt_page_ids)
     //   - org-required instructions (admin-mandated page IDs)
     //   - org-required AI usage policy (admin-mandated page IDs)
+    //   - org identity page (single admin-mandated page describing the org)
     let user_pages_fut = fetch_pages_with_source(
         &ctx.client,
         &ctx.settings.system_prompt_page_ids,
@@ -174,8 +193,17 @@ pub async fn read(ctx: &Context) -> Outcome {
         &globals.org_ai_usage_policy_page_ids,
         "org_policy",
     );
+    let org_identity_page_ids: Vec<i64> = globals
+        .org_identity_page_id
+        .map(|id| vec![id])
+        .unwrap_or_default();
+    let org_identity_fut = fetch_pages_with_source(
+        &ctx.client,
+        &org_identity_page_ids,
+        "org_identity",
+    );
 
-    let (identity, user_page, recent_journals, recent_user_journal, active_collage, shared_collage, semantic, user_pages, org_instructions, org_policy) = tokio::join!(
+    let (identity, user_page, recent_journals, recent_user_journal, active_collage, shared_collage, semantic, user_pages, org_instructions, org_policy, org_identity) = tokio::join!(
         identity_fut,
         user_fut,
         recent_journals_fut,
@@ -186,40 +214,77 @@ pub async fn read(ctx: &Context) -> Outcome {
         user_pages_fut,
         org_instructions_fut,
         org_policy_fut,
+        org_identity_fut,
     );
 
-    // Merge the three sources into one flat array. Each entry carries its
-    // `source` field so callers can group/filter as needed.
+    // Merge sources into one flat array. Each entry carries its `source`
+    // field so callers can group/filter as needed. Synthetic entries
+    // (domains list, identity refresh nudge) get a stable virtual page_id
+    // sentinel of 0 so consumers can branch on `page_id == 0` to skip
+    // anything that isn't a real BookStack page.
     let mut system_prompt: Vec<Value> = Vec::with_capacity(
-        user_pages.len() + org_instructions.len() + org_policy.len(),
+        user_pages.len() + org_instructions.len() + org_policy.len() + org_identity.len() + 2,
     );
+    system_prompt.extend(org_identity);
     system_prompt.extend(user_pages);
     system_prompt.extend(org_instructions);
     system_prompt.extend(org_policy);
 
-    // Setup nudge — show when the user hasn't configured anything AND hasn't
-    // snoozed the reminder. Suppressed once they save anything to /settings or
-    // explicitly dismiss via remember_config.
+    // Domains block — merged user + org domains. Surfaced as a synthetic
+    // system_prompt_additions entry so the AI's "owned vs external" check
+    // is always in context, not buried in a config dump.
+    let merged_domains = merge_domains(&ctx.settings.domains, &globals.org_domains);
+    if !merged_domains.is_empty() {
+        system_prompt.push(json!({
+            "page_id": 0,
+            "name": "Owned domains",
+            "markdown": format_domains_block(&merged_domains),
+            "url": Value::Null,
+            "source": "domains",
+        }));
+    }
+
+    // Identity refresh nudge — fires when the user's identity page hasn't
+    // been updated in 30+ days. Skipped silently if no identity page is
+    // configured, or the updated_at can't be parsed.
+    if let Some(stale) = identity_refresh_block(&user_page, ctx.settings.user_identity_page_id) {
+        system_prompt.push(stale);
+    }
+
+    // Setup nudge — show until everything's configured AND not snoozed. The
+    // nudge now lists exactly which user + global fields are still missing
+    // so the AI / user can address them one at a time instead of "your
+    // settings aren't done."
     let now_unix = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
     let snoozed = ctx.settings.settings_nudge_dismissed_until.map(|t| now_unix < t).unwrap_or(false);
-    let setup_nudge = if !ctx.settings.is_configured() && !snoozed {
+    let pending_user = pending_user_fields(&ctx.settings);
+    let pending_global = pending_global_fields(&globals);
+    let any_pending = !pending_user.is_empty() || !pending_global.is_empty();
+    let setup_nudge = if any_pending && !snoozed {
         Some(json!({
             "show": true,
-            "summary": "Your Hive memory settings aren't configured yet. Briefing is running on org defaults (where set) or empty sections.",
+            "summary": format!(
+                "Setup incomplete: {} user field(s), {} global field(s) still need values. Briefing falls back where possible but some sections will be empty until configured.",
+                pending_user.len(), pending_global.len()
+            ),
+            "pending_user": pending_user,
+            "pending_global": pending_global,
             "two_paths": {
                 "ui": "Visit the MCP server's /settings page in a browser — fill in dropdowns or use 'Probe existing Hive' to auto-detect.",
                 "mcp_guided": "Have the AI walk you through it via tool calls (recommended for chat-driven setups). See `suggested_workflow` below."
             },
             "suggested_workflow": [
-                "1. Ask the user what they want: a fresh identity, or to adopt an existing agent/structure that's already in this BookStack.",
-                "2. If existing: call `remember_directory action=read kind=identities` to see what's already on the global Hive shelf, and `remember_directory action=read kind=user_journals` for journals. If those return settings_not_configured, the global shelves themselves aren't set — surface that to the user (only an admin can fix).",
-                "3. Use `search_content` with queries like '{type:book} Identity', '{type:book} Journal', '{type:book} Topics' to find candidate content that may be elsewhere in BookStack and should belong on the Hive shelf.",
-                "4. For each match, propose to the user whether to (a) adopt it as-is by writing the ID into config, or (b) move it onto the Hive shelf first using `move_book_to_shelf` / `move_chapter` / `move_page`, then write the ID.",
-                "5. For brand-new structure, use `remember_identity action=create name=...` to scaffold a full Identity book + manifest + standard chapters in one call.",
-                "6. Save the resolved IDs with `remember_config action=write` and a `settings` object. The next briefing will reflect the new config and the nudge will stop showing."
+                "1. Per-user settings: ask the user what they want — fresh identity, or adopt an existing agent already in this BookStack.",
+                "2. For existing structure: `remember_directory action=read kind=identities` lists Hive-shelf identities; `kind=user_journals` lists journals. settings_not_configured here means the global shelves aren't set (admin task).",
+                "3. Discover candidates anywhere: `search_content` with queries like '{type:book} Identity', '{type:book} Journal', '{type:book} Topics'.",
+                "4. Adopt or relocate: write IDs directly with `remember_config action=write`, OR move the books with `move_book_to_shelf` / `move_chapter` / `move_page` first.",
+                "5. Brand-new structure: `remember_identity action=create name=...` scaffolds Identity book + manifest + chapters in one call.",
+                "6. Domains + identity: fill in the user's `domains` array (their owned domains) — the AI uses it to decide what's ours vs external.",
+                "7. Admin-only globals: org_identity_page_id and org_domains describe the org for every user on the instance. Admins set them once via /settings.",
+                "8. After each save the next briefing reflects the new config; the nudge stops once nothing's pending."
             ],
             "key_tools": [
                 "remember_directory  — discover what's on the global shelves",
@@ -472,6 +537,186 @@ fn kb_matches_envelope(ctx: &Context, results: &[Value]) -> Value {
         "detail": "Top hits from the entire knowledge base, excluding pages already surfaced in per-book sections.",
         "results": results,
     })
+}
+
+/// Per-user fields the setup nudge wants populated. Each entry is a
+/// `{field, why}` pair — `field` matches the UserSettings JSON key so the AI
+/// can write directly via `remember_config action=write settings={...}`.
+fn pending_user_fields(s: &bsmcp_common::settings::UserSettings) -> Vec<Value> {
+    let mut out = Vec::new();
+    if s.user_id.is_none() {
+        out.push(json!({
+            "field": "user_id",
+            "why": "Stable identifier (typically email) — drives per-user resource naming and journal frontmatter.",
+        }));
+    }
+    if s.ai_identity_page_id.is_none() {
+        out.push(json!({
+            "field": "ai_identity_page_id",
+            "why": "AI agent's manifest page. The briefing falls back to org default if set, otherwise identity is empty.",
+        }));
+    }
+    if s.ai_hive_journal_book_id.is_none() {
+        out.push(json!({
+            "field": "ai_hive_journal_book_id",
+            "why": "AI's journal book. `remember_journal action=write` won't work without it.",
+        }));
+    }
+    if s.user_journal_book_id.is_none() {
+        out.push(json!({
+            "field": "user_journal_book_id",
+            "why": "User's personal journal. Auto-provisioned on first `remember_user action=read` once `user_id` is set.",
+        }));
+    }
+    if s.user_identity_page_id.is_none() {
+        out.push(json!({
+            "field": "user_identity_page_id",
+            "why": "User's identity manifest. Auto-provisioned on first `remember_user action=read` once `user_id` is set.",
+        }));
+    }
+    if s.domains.is_empty() {
+        out.push(json!({
+            "field": "domains",
+            "why": "User's owned domains (array of strings). Surfaced in system_prompt_additions so the AI can distinguish ours vs external content.",
+        }));
+    }
+    if s.bookstack_user_id.is_none() {
+        out.push(json!({
+            "field": "bookstack_user_id",
+            "why": "BookStack user row ID — required for ACL-based semantic search filtering. Without it the search falls back to per-page HTTP permission checks (slower).",
+        }));
+    }
+    out
+}
+
+/// Global fields the setup nudge surfaces. Visible to all users in the
+/// briefing response so anyone can flag missing globals to the admin, but
+/// only an admin can actually persist them.
+fn pending_global_fields(g: &bsmcp_common::settings::GlobalSettings) -> Vec<Value> {
+    let mut out = Vec::new();
+    if g.hive_shelf_id.is_none() {
+        out.push(json!({
+            "field": "hive_shelf_id",
+            "why": "Shared shelf containing every AI agent's Identity book. Admin-only, first-write-wins.",
+            "admin_only": true,
+        }));
+    }
+    if g.user_journals_shelf_id.is_none() {
+        out.push(json!({
+            "field": "user_journals_shelf_id",
+            "why": "Shared shelf containing each human user's journal book + identity book. Admin-only, first-write-wins.",
+            "admin_only": true,
+        }));
+    }
+    if g.org_identity_page_id.is_none() {
+        out.push(json!({
+            "field": "org_identity_page_id",
+            "why": "Single page describing the organization (mission, structure, conventions). Pulled into every briefing's system_prompt_additions. Admin-only.",
+            "admin_only": true,
+        }));
+    }
+    if g.org_domains.is_empty() {
+        out.push(json!({
+            "field": "org_domains",
+            "why": "Domains the organization owns. Pairs with org_identity to give every agent a shared baseline of 'where am I'. Admin-only.",
+            "admin_only": true,
+        }));
+    }
+    out
+}
+
+/// Merge user-owned and org-owned domains into a deduplicated list. Order:
+/// user domains first (more specific to the calling user), then org-wide
+/// domains the user hasn't already listed.
+fn merge_domains(user_domains: &[String], org_domains: &[String]) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::with_capacity(user_domains.len() + org_domains.len());
+    for d in user_domains.iter().chain(org_domains.iter()) {
+        let v = d.trim().to_lowercase();
+        if v.is_empty() {
+            continue;
+        }
+        if seen.insert(v.clone()) {
+            out.push(v);
+        }
+    }
+    out
+}
+
+/// Render the domains list as a markdown block destined for system_prompt_additions.
+fn format_domains_block(domains: &[String]) -> String {
+    let mut s = String::new();
+    s.push_str("## Owned domains\n\n");
+    s.push_str(&domains.join(", "));
+    s.push_str(
+        "\n\n(Treat URLs and email addresses on these domains as ours; \
+         everything else is external. Use this when deciding whether to \
+         redact, share, or treat content as trusted.)\n",
+    );
+    s
+}
+
+/// Build a "refresh due" reminder block when the user's identity page is
+/// older than 30 days. Returns `None` when the page is recent, missing, or
+/// the timestamp can't be parsed.
+fn identity_refresh_block(user_page: &Option<Value>, page_id: Option<i64>) -> Option<Value> {
+    let pid = page_id?;
+    let page = user_page.as_ref()?;
+    let updated = page.get("updated_at").and_then(|v| v.as_str())?;
+    let days = days_since_iso_date(updated)?;
+    if days < 30 {
+        return None;
+    }
+    let body = format!(
+        "## Identity refresh due\n\n\
+         The user's identity page (page {pid}) hasn't been updated in {days} days. \
+         If you've learned anything about how this user works, what they care \
+         about, or how to collaborate with them better, append or replace the \
+         relevant section before the session ends.\n\n\
+         Update via `remember_user action=write` with the full new body."
+    );
+    Some(json!({
+        "page_id": 0,
+        "name": "Identity refresh due",
+        "markdown": body,
+        "url": Value::Null,
+        "source": "identity_refresh_due",
+    }))
+}
+
+/// Parse the YYYY-MM-DD prefix of an ISO 8601 timestamp and return the
+/// number of whole days between that date and today (UTC). Avoids pulling
+/// in chrono for what's effectively a 30-day staleness check.
+fn days_since_iso_date(iso: &str) -> Option<i64> {
+    let date_prefix = iso.get(0..10)?;
+    let mut parts = date_prefix.split('-');
+    let y: i64 = parts.next()?.parse().ok()?;
+    let m: u32 = parts.next()?.parse().ok()?;
+    let d: u32 = parts.next()?.parse().ok()?;
+    let then = ymd_to_unix_days(y, m, d)?;
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs() as i64;
+    let now_days = now_secs / 86_400;
+    Some(now_days - then)
+}
+
+/// Convert a (year, month, day) triple to days-since-Unix-epoch using the
+/// civil-from-days algorithm (Hinnant 2014). Pure arithmetic; no calendar
+/// libraries required.
+fn ymd_to_unix_days(y: i64, m: u32, d: u32) -> Option<i64> {
+    if m < 1 || m > 12 || d < 1 || d > 31 {
+        return None;
+    }
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = y.div_euclid(400);
+    let yoe = (y - era * 400) as i64;
+    let mp = if m > 2 { m - 3 } else { m + 9 };
+    let doy = (153 * mp as i64 + 2) / 5 + d as i64 - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    Some(era * 146_097 + doe - 719_468)
 }
 
 // Suppress unused-import warning when this module is built with other features.

--- a/crates/bsmcp-server/src/remember/collection.rs
+++ b/crates/bsmcp-server/src/remember/collection.rs
@@ -4,10 +4,11 @@
 
 use serde_json::{json, Value};
 
-use bsmcp_common::settings::UserSettings;
+use bsmcp_common::settings::{GlobalSettings, UserSettings};
 
 use super::envelope::{ErrorCode, RememberWarning};
 use super::frontmatter;
+use super::provision;
 use super::{Context, Outcome};
 
 /// Book ID where a resource's pages live. Pages may be distributed across
@@ -47,6 +48,14 @@ pub trait CollectionResource: Send + Sync {
     /// from the AI's perspective in a future revision; for v1 all are writable.
     fn writable(&self) -> bool {
         true
+    }
+
+    /// When set, every successful write to this resource ensures the parent
+    /// book lives on the named global shelf — books that have drifted off
+    /// the shelf are reattached on each write. Currently only `user_journal`
+    /// uses this; other collections aren't shelf-pinned.
+    fn shelf_pin(&self, _globals: &GlobalSettings) -> Option<i64> {
+        None
     }
 }
 
@@ -219,6 +228,16 @@ async fn handle_write(
     parent: CollectionParent,
     ctx: &Context,
 ) -> Outcome {
+    // Self-healing shelf pin: if the resource is shelf-pinned (currently
+    // user_journal), reattach the parent book to the configured shelf on
+    // every write. Idempotent — `ensure_book_on_shelf` is a no-op when the
+    // book is already there. Runs before the page write so the new entry
+    // lands in a correctly-attached book.
+    let globals = ctx.db.get_global_settings().await.unwrap_or_default();
+    if let Some(shelf_id) = resource.shelf_pin(&globals) {
+        provision::ensure_book_on_shelf(&ctx.client, parent, shelf_id).await;
+    }
+
     let body_text = match ctx.body_str("body") {
         Some(b) => b,
         None => {
@@ -403,7 +422,22 @@ async fn handle_search(
     // semantic backend doesn't accept book/chapter filters yet.
     let mut warnings = Vec::new();
     let semantic_hits: Vec<Value> = if let Some(sem) = &ctx.semantic {
-        match sem.search(&query, limit * 4, 0.45, true, false, &ctx.client, None).await {
+        let user_roles = sem
+            .resolve_user_roles(&ctx.token_id_hash, ctx.settings.bookstack_user_id, &ctx.client)
+            .await;
+        match sem
+            .search(
+                &query,
+                limit * 4,
+                0.45,
+                true,
+                false,
+                &ctx.client,
+                None,
+                user_roles.as_deref(),
+            )
+            .await
+        {
             Ok(v) => {
                 let results = v.get("results").and_then(|r| r.as_array()).cloned().unwrap_or_default();
                 results.into_iter().filter(|hit| matches_parent(hit, parent)).take(limit).collect()
@@ -567,6 +601,11 @@ pub mod resources {
         fn key_kind(&self) -> KeyKind { KeyKind::Date }
         fn sub_chapter_for_key(&self, key: &str) -> Option<String> {
             if key.len() >= 7 { Some(key[..7].to_string()) } else { None }
+        }
+        fn shelf_pin(&self, globals: &GlobalSettings) -> Option<i64> {
+            // Force every user-journal write to reattach the book to the
+            // global User Journals shelf — self-healing if the book drifts off.
+            globals.user_journals_shelf_id
         }
     }
 }

--- a/crates/bsmcp-server/src/remember/mod.rs
+++ b/crates/bsmcp-server/src/remember/mod.rs
@@ -20,6 +20,7 @@ pub mod naming;
 pub mod provision;
 pub mod search;
 pub mod singletons;
+pub mod user_provision;
 
 use std::sync::Arc;
 

--- a/crates/bsmcp-server/src/remember/naming.rs
+++ b/crates/bsmcp-server/src/remember/naming.rs
@@ -19,6 +19,10 @@ pub enum NamedResource {
     JournalBook,
     CollageBook,
     SharedCollageBook,
+    UserIdentityBook,
+    UserIdentityPage,
+    UserJournalBook,
+    UserJournalAgentPage,
 }
 
 impl NamedResource {
@@ -32,6 +36,25 @@ impl NamedResource {
             Self::JournalBook => "Journal",
             Self::CollageBook => "Topics",
             Self::SharedCollageBook => "Shared Topics",
+            // Per-user names default to placeholder text — `default_name_for_user`
+            // returns the actual personalized name when a user_id is known.
+            Self::UserIdentityBook => "User Identity",
+            Self::UserIdentityPage => "Identity",
+            Self::UserJournalBook => "Journal",
+            Self::UserJournalAgentPage => "Agent: journal-agent",
+        }
+    }
+
+    /// Personalized name for per-user resources. The non-personalized variants
+    /// just delegate to `default_name`. Stable across runs as long as `user_id`
+    /// is unchanged — used so probe + auto-create can find existing books.
+    pub fn default_name_for_user(self, user_id: &str) -> String {
+        match self {
+            Self::UserIdentityBook => format!("{user_id} — Identity"),
+            Self::UserIdentityPage => "Identity".to_string(),
+            Self::UserJournalBook => format!("{user_id} — Journal"),
+            Self::UserJournalAgentPage => format!("Agent: {user_id}-journal-agent"),
+            _ => self.default_name().to_string(),
         }
     }
 
@@ -52,6 +75,14 @@ impl NamedResource {
                 "AI agent's active topics / collage entries. Auto-created by /remember.",
             Self::SharedCollageBook =>
                 "Cross-agent shared topics. Auto-created by /remember.",
+            Self::UserIdentityBook =>
+                "Per-user identity container — holds the human user's identity page + their personal sub-agent definitions. Auto-created by /remember.",
+            Self::UserIdentityPage =>
+                "Identity page describing the human user — preferences, role, communication style. Keep it updated as you learn more. Auto-created by /remember.",
+            Self::UserJournalBook =>
+                "User's personal journal entries, organized by YYYY-MM chapters. Auto-created by /remember.",
+            Self::UserJournalAgentPage =>
+                "Agent definition for the user's per-user journal-agent. Auto-created by /remember.",
         }
     }
 
@@ -67,6 +98,12 @@ impl NamedResource {
             Self::JournalBook => n == "journal",
             Self::CollageBook => matches!(n.as_str(), "topics" | "collage"),
             Self::SharedCollageBook => matches!(n.as_str(), "shared topics" | "shared collage"),
+            // Per-user resources match by suffix because the prefix is the
+            // user_id which can't be encoded statically.
+            Self::UserIdentityBook => n.ends_with("— identity") || n.ends_with("- identity"),
+            Self::UserIdentityPage => matches!(n.as_str(), "identity" | "about me" | "who am i"),
+            Self::UserJournalBook => n.ends_with("— journal") || n.ends_with("- journal") || n == "journal",
+            Self::UserJournalAgentPage => n.starts_with("agent:") && n.contains("journal-agent"),
         }
     }
 }

--- a/crates/bsmcp-server/src/remember/provision.rs
+++ b/crates/bsmcp-server/src/remember/provision.rs
@@ -214,6 +214,78 @@ pub async fn lock_to_admin_only(
     }
 }
 
+/// Ensure a book sits on a shelf. Idempotent — no-op if it's already there.
+/// Best-effort: failures are logged and swallowed since shelf attachment is
+/// always recoverable via the BookStack UI.
+pub async fn ensure_book_on_shelf(
+    client: &BookStackClient,
+    book_id: i64,
+    shelf_id: i64,
+) {
+    let shelf = match client.get_shelf(shelf_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Provision: ensure_book_on_shelf({book_id} → {shelf_id}) — get_shelf failed (non-fatal): {e}");
+            return;
+        }
+    };
+    let mut existing: Vec<i64> = shelf
+        .get("books")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|b| b.get("id").and_then(|i| i.as_i64())).collect())
+        .unwrap_or_default();
+    if existing.contains(&book_id) {
+        return;
+    }
+    existing.push(book_id);
+    let payload = json!({ "books": existing });
+    if let Err(e) = client.update_shelf(shelf_id, &payload).await {
+        eprintln!("Provision: ensure_book_on_shelf({book_id} → {shelf_id}) — update_shelf failed (non-fatal): {e}");
+    }
+}
+
+/// Create a book with a personalized name (used by per-user provisioning).
+pub async fn create_named_book(
+    client: &BookStackClient,
+    name: &str,
+    description: &str,
+    parent_shelf_id: Option<i64>,
+) -> ProvisionResult {
+    let book = match client.create_book(name, description).await {
+        Ok(v) => v,
+        Err(e) => return classify_error(&e),
+    };
+    let book_id = match book.get("id").and_then(|i| i.as_i64()) {
+        Some(id) => id,
+        None => return ProvisionResult::Failed { reason: "create_book returned no id".to_string() },
+    };
+    if let Some(shelf_id) = parent_shelf_id {
+        ensure_book_on_shelf(client, book_id, shelf_id).await;
+    }
+    ProvisionResult::Created { id: book_id, name: name.to_string() }
+}
+
+/// Create a page with an arbitrary name + body inside a book.
+pub async fn create_named_page(
+    client: &BookStackClient,
+    name: &str,
+    parent_book_id: i64,
+    markdown: &str,
+) -> ProvisionResult {
+    let payload = json!({
+        "name": name,
+        "book_id": parent_book_id,
+        "markdown": markdown,
+    });
+    match client.create_page(&payload).await {
+        Ok(v) => match v.get("id").and_then(|i| i.as_i64()) {
+            Some(id) => ProvisionResult::Created { id, name: name.to_string() },
+            None => ProvisionResult::Failed { reason: "create_page returned no id".to_string() },
+        },
+        Err(e) => classify_error(&e),
+    }
+}
+
 /// Create a page inside a book or chapter, with the given markdown body.
 #[allow(dead_code)] // reserved for future identity/whoami auto-creation paths
 pub async fn create_page(

--- a/crates/bsmcp-server/src/remember/search.rs
+++ b/crates/bsmcp-server/src/remember/search.rs
@@ -43,7 +43,22 @@ pub async fn read(ctx: &Context) -> Outcome {
     // One big semantic search, then partition results by scope.
     let mut warnings = Vec::new();
     let raw_hits: Vec<Value> = if let Some(sem) = &ctx.semantic {
-        match sem.search(&query, limit * (scope_targets.len().max(1)) * 2, 0.40, true, false, &ctx.client, None).await {
+        let user_roles = sem
+            .resolve_user_roles(&ctx.token_id_hash, ctx.settings.bookstack_user_id, &ctx.client)
+            .await;
+        match sem
+            .search(
+                &query,
+                limit * (scope_targets.len().max(1)) * 2,
+                0.40,
+                true,
+                false,
+                &ctx.client,
+                None,
+                user_roles.as_deref(),
+            )
+            .await
+        {
             Ok(v) => v.get("results").and_then(|r| r.as_array()).cloned().unwrap_or_default(),
             Err(e) => {
                 warnings.push(RememberWarning::new(

--- a/crates/bsmcp-server/src/remember/singletons.rs
+++ b/crates/bsmcp-server/src/remember/singletons.rs
@@ -11,6 +11,7 @@ use bsmcp_common::settings::{GlobalSettings, UserSettings};
 use super::envelope::ErrorCode;
 use super::frontmatter;
 use super::provision;
+use super::user_provision;
 use super::{Context, Outcome};
 
 // --- whoami ---
@@ -108,20 +109,52 @@ pub async fn write_whoami(ctx: &Context) -> Outcome {
 // --- user ---
 
 pub async fn read_user(ctx: &Context) -> Outcome {
-    let page_id = match ctx.settings.user_identity_page_id {
+    // Auto-provision missing per-user structure (Identity book, identity page,
+    // journal book, journal-agent page). No-op when everything's already in
+    // settings or when `user_id` isn't configured. The first read_user call
+    // after a user is set up populates the per-user shelf in one shot, and
+    // subsequent calls are cheap idempotent shelf-membership checks.
+    let globals = ctx.db.get_global_settings().await.unwrap_or_default();
+    let mut working_settings = ctx.settings.clone();
+    let provision_result = user_provision::auto_provision_user_identity(
+        &ctx.client,
+        globals.user_journals_shelf_id,
+        &mut working_settings,
+    )
+    .await;
+    if provision_result.any_changes() {
+        if let Err(e) = ctx
+            .db
+            .save_user_settings(&ctx.token_id_hash, &working_settings)
+            .await
+        {
+            eprintln!("read_user: failed to persist auto-provisioned IDs (non-fatal): {e}");
+        }
+        // Lock the freshly-created journal to owner-only on the same pass,
+        // matching the existing settings-save behavior.
+        provision::lock_journal_books_to_owner(
+            &ctx.client,
+            working_settings.ai_hive_journal_book_id,
+            working_settings.user_journal_book_id,
+        )
+        .await;
+    }
+
+    let page_id = match working_settings.user_identity_page_id {
         Some(id) => id,
         None => {
             // user_id alone is enough for a partial response.
-            if ctx.settings.user_id.is_some() {
+            if working_settings.user_id.is_some() {
                 return Outcome::ok(json!({
-                    "user_id": ctx.settings.user_id,
+                    "user_id": working_settings.user_id,
                     "identity_page": Value::Null,
-                    "journal_book_id": ctx.settings.user_journal_book_id,
+                    "journal_book_id": working_settings.user_journal_book_id,
+                    "auto_provisioned": auto_provision_summary(&provision_result),
                 }));
             }
             return Outcome::error(
                 ErrorCode::SettingsNotConfigured,
-                "user_identity_page_id not configured",
+                "user_identity_page_id not configured (and user_id not set, so auto-provisioning is skipped)",
                 Some("user_identity_page_id"),
             );
         }
@@ -135,7 +168,7 @@ pub async fn read_user(ctx: &Context) -> Outcome {
     let body = frontmatter::strip(raw_md).to_string();
 
     Outcome::ok(json!({
-        "user_id": ctx.settings.user_id,
+        "user_id": working_settings.user_id,
         "identity_page": {
             "page_id": page_id,
             "name": page.get("name").cloned().unwrap_or(Value::Null),
@@ -143,17 +176,62 @@ pub async fn read_user(ctx: &Context) -> Outcome {
             "url": page.get("url").cloned().unwrap_or(Value::Null),
             "updated_at": page.get("updated_at").cloned().unwrap_or(Value::Null),
         },
-        "journal_book_id": ctx.settings.user_journal_book_id,
+        "journal_book_id": working_settings.user_journal_book_id,
+        "identity_book_id": working_settings.user_identity_book_id,
+        "journal_agent_page_id": working_settings.user_journal_agent_page_id,
+        "auto_provisioned": auto_provision_summary(&provision_result),
     }))
 }
 
+/// Summarize a provisioning pass into JSON for the user response. Returns
+/// `Null` when nothing changed so consumers can treat the field as a "did
+/// anything happen" flag.
+fn auto_provision_summary(r: &user_provision::UserProvisionResult) -> Value {
+    if !r.any_changes() && r.warnings.is_empty() {
+        return Value::Null;
+    }
+    json!({
+        "created_identity_book": r.created_identity_book,
+        "created_identity_page": r.created_identity_page,
+        "created_journal_book": r.created_journal_book,
+        "created_journal_agent_page": r.created_journal_agent_page,
+        "moved_to_shelf": r.moved_to_shelf,
+        "warnings": r.warnings,
+    })
+}
+
 pub async fn write_user(ctx: &Context) -> Outcome {
-    let page_id = match ctx.settings.user_identity_page_id {
+    // Auto-provision identical to read_user — guarantees write_user works on
+    // a freshly-configured user without forcing a separate read first.
+    let globals = ctx.db.get_global_settings().await.unwrap_or_default();
+    let mut working_settings = ctx.settings.clone();
+    let provision_result = user_provision::auto_provision_user_identity(
+        &ctx.client,
+        globals.user_journals_shelf_id,
+        &mut working_settings,
+    )
+    .await;
+    if provision_result.any_changes() {
+        if let Err(e) = ctx
+            .db
+            .save_user_settings(&ctx.token_id_hash, &working_settings)
+            .await
+        {
+            eprintln!("write_user: failed to persist auto-provisioned IDs (non-fatal): {e}");
+        }
+        provision::lock_journal_books_to_owner(
+            &ctx.client,
+            working_settings.ai_hive_journal_book_id,
+            working_settings.user_journal_book_id,
+        )
+        .await;
+    }
+    let page_id = match working_settings.user_identity_page_id {
         Some(id) => id,
         None => {
             return Outcome::error(
                 ErrorCode::SettingsNotConfigured,
-                "user_identity_page_id not configured",
+                "user_identity_page_id not configured (auto-provision needs `user_id` and `user_journals_shelf_id` to work)",
                 Some("user_identity_page_id"),
             );
         }

--- a/crates/bsmcp-server/src/remember/user_provision.rs
+++ b/crates/bsmcp-server/src/remember/user_provision.rs
@@ -1,0 +1,228 @@
+//! Per-user identity auto-provisioning.
+//!
+//! The Hive's AI side has Identity books on a shared "Hive" shelf with the
+//! manifest page + sub-agent definition pages inside. This module mirrors that
+//! layout for the human user side: a per-user "Identity" book on the
+//! `user_journals_shelf`, containing
+//!   - an `Identity` page (the user's manifest), and
+//!   - an `Agent: {user_id}-journal-agent` page (the user's personal journal
+//!     agent definition the AI bootstrap protocol fetches into local cache).
+//!
+//! Idempotent — every step checks the persisted user_settings IDs first and
+//! creates only what's missing. Called from `singletons::read_user`, so the
+//! first `remember_user action=read` after configuring `user_id` provisions
+//! everything in one shot.
+//!
+//! Force-to-shelf semantics: when the global `user_journals_shelf_id` is set,
+//! every per-user book auto-created here lands on that shelf, AND existing
+//! books referenced by user_settings get moved onto it on every provisioning
+//! pass. That's how Task #9 (force user_journal to shelf) is enforced.
+
+use bsmcp_common::bookstack::BookStackClient;
+use bsmcp_common::settings::UserSettings;
+
+use super::naming::NamedResource;
+use super::provision;
+
+/// What changed during a provisioning pass. Returned so the caller (typically
+/// `singletons::read_user`) can persist the new IDs and surface a human
+/// summary in the response.
+#[derive(Default, Debug)]
+pub struct UserProvisionResult {
+    pub created_identity_book: Option<i64>,
+    pub created_identity_page: Option<i64>,
+    pub created_journal_book: Option<i64>,
+    pub created_journal_agent_page: Option<i64>,
+    pub moved_to_shelf: Vec<i64>,
+    pub warnings: Vec<String>,
+}
+
+impl UserProvisionResult {
+    pub fn any_changes(&self) -> bool {
+        self.created_identity_book.is_some()
+            || self.created_identity_page.is_some()
+            || self.created_journal_book.is_some()
+            || self.created_journal_agent_page.is_some()
+            || !self.moved_to_shelf.is_empty()
+    }
+}
+
+/// Auto-provision missing user identity structure. Mutates `settings` in
+/// place with the newly-created IDs. Caller is responsible for persisting
+/// the updated settings via `db.save_user_settings`.
+///
+/// Skips entirely when `user_id` is None — we need a stable identifier to
+/// name the per-user resources. The caller surfaces this as "settings
+/// incomplete" rather than crashing.
+pub async fn auto_provision_user_identity(
+    client: &BookStackClient,
+    user_journals_shelf_id: Option<i64>,
+    settings: &mut UserSettings,
+) -> UserProvisionResult {
+    let mut result = UserProvisionResult::default();
+
+    let user_id = match settings.user_id.as_ref() {
+        Some(uid) if !uid.is_empty() => uid.clone(),
+        _ => {
+            // No user_id → can't name per-user resources. Quietly skip.
+            return result;
+        }
+    };
+
+    // Step 1: per-user Identity book (on the user-journals shelf if configured).
+    if settings.user_identity_book_id.is_none() {
+        let name = NamedResource::UserIdentityBook.default_name_for_user(&user_id);
+        let desc = NamedResource::UserIdentityBook.default_description();
+        let book = provision::create_named_book(client, &name, desc, user_journals_shelf_id).await;
+        if let Some(id) = book.id() {
+            settings.user_identity_book_id = Some(id);
+            result.created_identity_book = Some(id);
+        } else {
+            result.warnings.push(book.human(NamedResource::UserIdentityBook));
+        }
+    } else if let (Some(book_id), Some(shelf_id)) = (settings.user_identity_book_id, user_journals_shelf_id) {
+        // Force existing identity book onto the shelf — idempotent.
+        provision::ensure_book_on_shelf(client, book_id, shelf_id).await;
+    }
+
+    // Step 2: identity page inside the identity book.
+    if let Some(book_id) = settings.user_identity_book_id {
+        if settings.user_identity_page_id.is_none() {
+            let body = identity_page_template(&user_id);
+            let page_name = NamedResource::UserIdentityPage.default_name_for_user(&user_id);
+            let page = provision::create_named_page(client, &page_name, book_id, &body).await;
+            if let Some(id) = page.id() {
+                settings.user_identity_page_id = Some(id);
+                result.created_identity_page = Some(id);
+            } else {
+                result.warnings.push(page.human(NamedResource::UserIdentityPage));
+            }
+        }
+    }
+
+    // Step 3: per-user journal book (on the user-journals shelf if configured).
+    if settings.user_journal_book_id.is_none() {
+        let name = NamedResource::UserJournalBook.default_name_for_user(&user_id);
+        let desc = NamedResource::UserJournalBook.default_description();
+        let book = provision::create_named_book(client, &name, desc, user_journals_shelf_id).await;
+        if let Some(id) = book.id() {
+            settings.user_journal_book_id = Some(id);
+            result.created_journal_book = Some(id);
+        } else {
+            result.warnings.push(book.human(NamedResource::UserJournalBook));
+        }
+    } else if let (Some(book_id), Some(shelf_id)) = (settings.user_journal_book_id, user_journals_shelf_id) {
+        // Force existing journal book onto the shelf. Track in the result so
+        // callers can surface "moved to shelf" in their response — the
+        // ensure call itself is idempotent, but distinguishing "was created"
+        // from "was reattached" is useful in logs.
+        provision::ensure_book_on_shelf(client, book_id, shelf_id).await;
+        result.moved_to_shelf.push(book_id);
+    }
+
+    // Step 4: journal-agent definition page inside the identity book.
+    if let (Some(book_id), Some(journal_book_id)) = (
+        settings.user_identity_book_id,
+        settings.user_journal_book_id,
+    ) {
+        if settings.user_journal_agent_page_id.is_none() {
+            let body = journal_agent_template(&user_id, journal_book_id);
+            let page_name = NamedResource::UserJournalAgentPage.default_name_for_user(&user_id);
+            let page = provision::create_named_page(client, &page_name, book_id, &body).await;
+            if let Some(id) = page.id() {
+                settings.user_journal_agent_page_id = Some(id);
+                result.created_journal_agent_page = Some(id);
+            } else {
+                result.warnings.push(page.human(NamedResource::UserJournalAgentPage));
+            }
+        }
+    }
+
+    result
+}
+
+/// Starter content for a new user identity page. Headings cover what the AI
+/// is encouraged to keep updated as the user works with it.
+fn identity_page_template(user_id: &str) -> String {
+    format!(
+        r#"# About {user_id}
+
+(Stub — agents update this page as they learn about the user.)
+
+## Communication style
+
+(How does this user prefer to receive information? Terse vs. detailed,
+written vs. visual, formal vs. conversational.)
+
+## Working preferences
+
+(Tooling, workflow, time-of-day patterns, decision-making style.)
+
+## Domains and identities
+
+(Email addresses, GitHub handles, owned domains. Cross-reference the
+`domains` field in user settings.)
+
+## Recurring topics
+
+(Active projects, ongoing initiatives, frequent collaborators.)
+
+## Notes
+
+(Anything else worth remembering across sessions.)
+
+---
+
+> AI: keep this page updated. As you learn new things about how this user
+> prefers to work or what they care about, append/replace the relevant
+> section above. The briefing surfaces a stale-page reminder if this page
+> hasn't been touched in 30+ days — refresh it before the reminder fires.
+"#,
+        user_id = user_id
+    )
+}
+
+/// Starter agent definition for the user's per-user journal agent. The
+/// bootstrap protocol fetches this page into a local agent file and the
+/// surrounding orchestration layer invokes it after meaningful conversations.
+fn journal_agent_template(user_id: &str, journal_book_id: i64) -> String {
+    format!(
+        r#"# Agent: {user_id}-journal-agent
+
+This agent writes journal entries from {user_id}'s perspective into book
+{journal_book_id} ({user_id}'s personal journal). Spawned after meaningful
+conversations or decisions. Pass context describing what happened and what
+matters.
+
+## Definition
+
+```yaml
+---
+name: {user_id}-journal-agent
+description: Writes journal entries from {user_id}'s perspective into journal book {journal_book_id}. Call after meaningful conversations, decisions, or reflections. Pass context describing what happened and what matters.
+tools:
+  - mcp__remember_user_journal
+---
+```
+
+## Body
+
+You are {user_id}'s journal voice — first person, candid, unedited. You
+write to BookStack book {journal_book_id} via `remember_user_journal action=write`.
+
+Discipline:
+
+- One entry per meaningful exchange. Skip routine status updates.
+- Stamp the day's chapter (auto-created YYYY-MM by `remember_user_journal`).
+- Lead with the moment, not the meta. "We decided X" beats "I had a
+  conversation about X".
+- Keep entries short — a paragraph or three.
+- Note open threads at the end so the next session can pick them up.
+
+> AI: this page is the canonical source. The bootstrap protocol pulls it into
+> a local agent definition file. Edit here, not the file.
+"#,
+        user_id = user_id,
+        journal_book_id = journal_book_id
+    )
+}

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -54,6 +54,40 @@ impl SemanticState {
         &self.webhook_secret
     }
 
+    /// Spawn the daily ACL reconciliation cron. Wakes every
+    /// `BSMCP_ACL_RECONCILE_HOURS` (default 24) and queues an `acl_reconcile`
+    /// embed job — the embedder pipeline picks it up and refreshes
+    /// `page_view_acl` for every stored page. This is the safety net for
+    /// permission changes that webhook events miss (e.g., webhook drops, role
+    /// detail edits that don't fire `role_update` for some reason).
+    pub fn spawn_acl_reconcile(self: Arc<Self>) {
+        let interval_hours: u64 = std::env::var("BSMCP_ACL_RECONCILE_HOURS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(24);
+        if interval_hours == 0 {
+            eprintln!("Semantic: ACL reconciliation disabled (BSMCP_ACL_RECONCILE_HOURS=0)");
+            return;
+        }
+        let interval = Duration::from_secs(interval_hours * 3600);
+        eprintln!("Semantic: ACL reconcile cron active — every {interval_hours}h");
+        tokio::spawn(async move {
+            // Stagger initial run so server startup isn't immediately followed
+            // by a heavy reconcile. 5 minutes is enough for the embedder to
+            // come up and pull pending jobs first.
+            tokio::time::sleep(Duration::from_secs(5 * 60)).await;
+            loop {
+                match self.db.create_embed_job("acl_reconcile").await {
+                    Ok((job_id, is_new)) => eprintln!(
+                        "Semantic: ACL reconcile cron — queued job {job_id} (new={is_new})"
+                    ),
+                    Err(e) => eprintln!("Semantic: ACL reconcile cron — queue failed: {e}"),
+                }
+                tokio::time::sleep(interval).await;
+            }
+        });
+    }
+
     /// Embed a query by calling the external embedder service.
     /// Retries once on transient failures (connection errors, timeouts, 5xx).
     async fn embed_query(&self, query: &str) -> Result<Vec<f32>, String> {
@@ -192,6 +226,56 @@ impl SemanticState {
         accessible
     }
 
+    /// Resolve the calling user's BookStack roles. Cached per token (15 min
+    /// TTL) so the role list is fetched once per session.
+    ///
+    /// Returns `None` (skip ACL filtering, fall back to HTTP per-page check)
+    /// when we can't determine the user's roles — e.g. settings haven't stamped
+    /// `bookstack_user_id` yet, or `/api/users/{id}` returned an error.
+    pub async fn resolve_user_roles(
+        &self,
+        token_id_hash: &str,
+        bookstack_user_id: Option<i64>,
+        client: &BookStackClient,
+    ) -> Option<Vec<i64>> {
+        // 15-minute cache window — short enough that a role grant or revoke
+        // applied during a working session takes effect on the next search,
+        // long enough to amortize the user fetch across the cache TTL.
+        const ROLE_CACHE_TTL_SECS: i64 = 15 * 60;
+
+        if let Ok(Some((_uid, roles))) = self
+            .db
+            .get_cached_user_roles(token_id_hash, ROLE_CACHE_TTL_SECS)
+            .await
+        {
+            return Some(roles);
+        }
+
+        let user_id = bookstack_user_id?;
+        let user = match client.get_user(user_id).await {
+            Ok(u) => u,
+            Err(e) => {
+                eprintln!("ACL: failed to fetch /api/users/{user_id} for role resolution: {e}");
+                return None;
+            }
+        };
+        let roles: Vec<i64> = user
+            .get("roles")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|r| r.get("id").and_then(|i| i.as_i64())).collect())
+            .unwrap_or_default();
+        if roles.is_empty() {
+            // Empty roles list means BookStack returned the user but they're
+            // role-less — skip ACL filtering rather than blocking everything.
+            eprintln!("ACL: user {user_id} has no roles; skipping ACL filter for this session");
+            return None;
+        }
+        if let Err(e) = self.db.set_cached_user_roles(token_id_hash, user_id, &roles).await {
+            eprintln!("ACL: failed to cache user roles (non-fatal): {e}");
+        }
+        Some(roles)
+    }
+
     /// Hybrid search: vector + keyword + blanket re-ranking.
     ///
     /// `book_filter`: when `Some(&[..])`, restricts the vector pass to chunks
@@ -200,6 +284,10 @@ impl SemanticState {
     /// just smaller from the outset, which proportionally shrinks the
     /// permission filter and per-result fan-out. `None` keeps the old
     /// whole-corpus behavior.
+    ///
+    /// `user_role_ids`: when `Some(&[..])`, applies a role-level ACL filter
+    /// to candidates via `page_view_acl`. Pages whose ACL hasn't been
+    /// computed are still included (the HTTP fallback below verifies them).
     pub async fn search(
         &self,
         query: &str,
@@ -209,6 +297,7 @@ impl SemanticState {
         verbose: bool,
         client: &BookStackClient,
         book_filter: Option<&[i64]>,
+        user_role_ids: Option<&[i64]>,
     ) -> Result<Value, String> {
         let start = Instant::now();
 
@@ -219,6 +308,9 @@ impl SemanticState {
         let book_filter_owned: Option<Vec<i64>> = book_filter
             .filter(|s| !s.is_empty())
             .map(|s| s.to_vec());
+        let role_filter_owned: Option<Vec<i64>> = user_role_ids
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_vec());
         let vector_future = async {
             let query_vec = self.embed_query(query).await?;
             self.db
@@ -227,6 +319,7 @@ impl SemanticState {
                     limit * 2,
                     threshold,
                     book_filter_owned.as_deref(),
+                    role_filter_owned.as_deref(),
                 )
                 .await
         };
@@ -629,8 +722,12 @@ impl SemanticState {
             }
             "page_delete" => {
                 if let Some(pid) = item_id {
+                    // delete_page CASCADE-removes chunks + relationships;
+                    // page_view_acl rows are explicitly cleared so the per-role
+                    // index doesn't accumulate dead entries.
                     self.db.delete_page(pid).await?;
-                    eprintln!("Semantic: deleted embeddings for page {pid}");
+                    let _ = self.db.delete_page_acl(pid).await;
+                    eprintln!("Semantic: deleted embeddings + ACL for page {pid}");
                 }
             }
 
@@ -679,10 +776,30 @@ impl SemanticState {
             // --- Shelf events (full re-embed) ---
             // Shelf changes affect the context prefix for all pages on that shelf.
             // We can't efficiently determine which books belong to a shelf from
-            // the webhook payload, so trigger a full re-embed.
+            // the webhook payload, so trigger a full re-embed. The re-embed
+            // pipeline restamps page_view_acl as a side-effect, so shelf-level
+            // permission changes propagate naturally.
             "bookshelf_create_from_book" | "bookshelf_update" | "bookshelf_delete" => {
                 let (job_id, is_new) = self.db.create_embed_job("all").await?;
                 eprintln!("Semantic: {event} — queued full re-embed job {job_id} (new={is_new})");
+            }
+
+            // --- Role events (ACL-only reconciliation) ---
+            // Role permission changes don't affect embeddings — they only
+            // change which roles can view existing content. Queue an
+            // `acl_reconcile` job (handled by the embedder pipeline) so the
+            // ACL store is refreshed without paying the cost of re-embedding.
+            "role_create" | "role_update" => {
+                let (job_id, is_new) = self.db.create_embed_job("acl_reconcile").await?;
+                eprintln!("Semantic: {event} — queued ACL reconcile job {job_id} (new={is_new})");
+            }
+            "role_delete" => {
+                if let Some(rid) = item_id {
+                    let _ = self.db.delete_role_from_acl(rid).await;
+                    eprintln!("Semantic: role_delete — purged role {rid} from page_view_acl");
+                }
+                let (job_id, is_new) = self.db.create_embed_job("acl_reconcile").await?;
+                eprintln!("Semantic: role_delete — queued ACL reconcile job {job_id} (new={is_new})");
             }
 
             _ => {

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -802,6 +802,34 @@ impl SemanticState {
                 eprintln!("Semantic: role_delete — queued ACL reconcile job {job_id} (new={is_new})");
             }
 
+            // --- Permission change on a specific entity ---
+            // Fired by BookStack's PermissionsUpdater whenever role/fallback
+            // permissions are edited on a page/chapter/book/shelf. Queue a
+            // full ACL reconcile because the change can cascade to descendants
+            // (book perm change affects every page in it). Cheaper than
+            // computing the cascade ourselves and the cron-style reconcile
+            // path is already battle-tested.
+            "permissions_update" => {
+                let (job_id, is_new) = self.db.create_embed_job("acl_reconcile").await?;
+                eprintln!("Semantic: permissions_update (item={item_id:?}) — queued ACL reconcile job {job_id} (new={is_new})");
+            }
+
+            // --- User events ---
+            // Role assignments live on the user, so updates can change which
+            // roles a token's owner holds. Drop their cached entry so the
+            // next semantic_search re-fetches `/api/users/{id}` and picks up
+            // the new role list.
+            "user_update" | "user_delete" => {
+                if let Some(uid) = item_id {
+                    let _ = self.db.delete_user_role_cache_by_bs_id(uid).await;
+                    eprintln!("Semantic: {event} — invalidated user_role_cache for bookstack_user_id={uid}");
+                }
+            }
+            "user_create" => {
+                // No-op — new users have no cache entry yet, no token mapping
+                // exists until they authorize through the OAuth flow.
+            }
+
             _ => {
                 eprintln!("Semantic: ignoring webhook event {event}");
             }

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -190,8 +190,12 @@ pub struct SettingsForm {
     pub ai_shared_collage_book_id: Option<String>,
     pub ai_hive_journal_book_id: Option<String>,
     pub user_id: Option<String>,
+    pub bookstack_user_id: Option<String>,
     pub user_identity_page_id: Option<String>,
+    pub user_identity_book_id: Option<String>,
+    pub user_journal_agent_page_id: Option<String>,
     pub user_journal_book_id: Option<String>,
+    pub domains: Option<String>,
     pub semantic_against_journal: Option<String>,
     pub semantic_against_collage: Option<String>,
     pub semantic_against_shared_collage: Option<String>,
@@ -220,6 +224,11 @@ pub struct SettingsForm {
     pub default_ai_identity_page_id: Option<String>,
     pub default_ai_identity_name: Option<String>,
     pub default_ai_identity_ouid: Option<String>,
+
+    // Org identity + domains (admins only). org_identity_page_id is
+    // first-write-wins like the shelves; org_domains is tunable.
+    pub org_identity_page_id: Option<String>,
+    pub org_domains: Option<String>,
 }
 
 fn empty_to_none(s: Option<String>) -> Option<String> {
@@ -242,6 +251,28 @@ fn parse_id_list(s: Option<String>) -> Vec<i64> {
     raw.split(|c: char| !c.is_ascii_digit())
         .filter_map(|tok| tok.parse::<i64>().ok())
         .collect()
+}
+
+/// Parse a free-form list of domains / strings. Splits on commas and
+/// whitespace, trims, drops empties, deduplicates.
+fn parse_str_list(s: Option<String>) -> Vec<String> {
+    let Some(raw) = empty_to_none(s) else { return Vec::new(); };
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for tok in raw.split(|c: char| c == ',' || c.is_whitespace()) {
+        let v = tok.trim().to_lowercase();
+        if v.is_empty() {
+            continue;
+        }
+        if seen.insert(v.clone()) {
+            out.push(v);
+        }
+    }
+    out
+}
+
+fn format_str_list(values: &[String]) -> String {
+    values.join(", ")
 }
 
 fn format_id_list(ids: &[i64]) -> String {
@@ -281,8 +312,12 @@ pub async fn handle_settings_post(
         ai_shared_collage_book_id: parse_id(form.ai_shared_collage_book_id),
         ai_hive_journal_book_id: parse_id(form.ai_hive_journal_book_id),
         user_id: empty_to_none(form.user_id.clone()),
+        bookstack_user_id: parse_id(form.bookstack_user_id.clone()),
         user_identity_page_id: parse_id(form.user_identity_page_id),
+        user_identity_book_id: parse_id(form.user_identity_book_id.clone()),
+        user_journal_agent_page_id: parse_id(form.user_journal_agent_page_id.clone()),
         user_journal_book_id: parse_id(form.user_journal_book_id),
+        domains: parse_str_list(form.domains.clone()),
         semantic_against_journal: checkbox_on(form.semantic_against_journal),
         semantic_against_collage: checkbox_on(form.semantic_against_collage),
         semantic_against_shared_collage: checkbox_on(form.semantic_against_shared_collage),
@@ -361,6 +396,39 @@ pub async fn handle_settings_post(
     } else if proposed_default_id.is_some() || proposed_default_name.is_some() || proposed_default_ouid.is_some() {
         global_warnings.push(
             "Ignoring org-default identity submission — only BookStack admins can set the org default.".into()
+        );
+    }
+
+    // Org identity page — first-write-wins (the page itself is structural;
+    // an admin can change its content but the page ID stays put).
+    let proposed_org_identity_page = parse_id(form.org_identity_page_id);
+    if existing_globals.org_identity_page_id.is_none() {
+        if let Some(new_id) = proposed_org_identity_page {
+            if is_admin {
+                globals.org_identity_page_id = Some(new_id);
+            } else {
+                global_warnings.push(
+                    "Ignoring org_identity_page_id submission — only BookStack admins can set org identity.".into()
+                );
+            }
+        }
+    } else if proposed_org_identity_page.is_some()
+        && proposed_org_identity_page != existing_globals.org_identity_page_id
+    {
+        global_warnings.push(
+            "Ignoring org_identity_page_id change — first-write-wins; current value preserved.".into()
+        );
+    }
+
+    // Org domains — admin-editable, replaces the existing list when provided.
+    let proposed_org_domains = parse_str_list(form.org_domains);
+    if is_admin {
+        // Empty list means "user cleared the textarea" — honor the clear.
+        // Non-empty replaces the old list outright.
+        globals.org_domains = proposed_org_domains;
+    } else if !proposed_org_domains.is_empty() {
+        global_warnings.push(
+            "Ignoring org_domains submission — only BookStack admins can edit org domains.".into()
         );
     }
 
@@ -767,6 +835,16 @@ fn render_id_input(name: &str, value: Option<i64>) -> String {
     )
 }
 
+fn render_textarea(name: &str, value: &str, placeholder: &str, rows: usize) -> String {
+    format!(
+        r#"<textarea name="{name}" id="{name}" rows="{rows}" placeholder="{ph}" style="width:100%;padding:0.55rem 0.7rem;border:1px solid #2a3a5c;border-radius:6px;background:#0f1a30;color:#e0e0e0;font-size:0.9rem;font-family:inherit;resize:vertical;">{value}</textarea>"#,
+        name = html_escape(name),
+        rows = rows,
+        ph = html_escape(placeholder),
+        value = html_escape(value),
+    )
+}
+
 fn render_checkbox(name: &str, checked: bool, label: &str) -> String {
     let chk = if checked { " checked" } else { "" };
     format!(
@@ -842,6 +920,21 @@ a.reauth:hover { color: #cbd5e1; text-decoration: underline; }
   <div class="hint">Contains every human user's journal book.</div>
   {user_journals_shelf_create}
 </div>
+</div>
+</div>
+
+<div class="card">
+<h2>Org identity &amp; domains <span style="font-weight:400;font-size:.78rem;color:#94a3b8;">{org_identity_note}</span></h2>
+<p class="subtitle" style="margin-bottom:.75rem;">Page describing the organization itself + the domains it owns. Pulled into every briefing's <code>system_prompt_additions</code> so every agent on the instance has a shared baseline. Page ID is first-write-wins; domains list is editable.</p>
+<div class="field">
+  <label for="org_identity_page_id">Org identity page ID</label>
+  {org_identity_page_input}
+  <div class="hint">Single page describing the org (mission, structure, conventions). First-write-wins.</div>
+</div>
+<div class="field">
+  <label for="org_domains">Org-owned domains</label>
+  {org_domains_input}
+  <div class="hint">One per line, or comma-separated. Merged with each user's <code>domains</code> in the briefing.</div>
 </div>
 </div>
 
@@ -940,16 +1033,42 @@ a.reauth:hover { color: #cbd5e1; text-decoration: underline; }
 <div class="field">
   <label for="user_id">User ID</label>
   {user_id_input}
-  <div class="hint">e.g., your email. Echoed back in the response.</div>
+  <div class="hint">e.g., your email. Echoed back in the response and used as the prefix for auto-provisioned per-user resource names.</div>
 </div>
+<div class="field">
+  <label for="bookstack_user_id">BookStack user row ID</label>
+  {bookstack_user_id_input}
+  <div class="hint">Numeric row ID for your BookStack user. Required for ACL-filtered semantic search — without it, search falls back to per-page HTTP permission checks (slower). Find via <code>/api/users</code> if you're an admin, or ask one to look it up.</div>
+</div>
+</div>
+<div class="row2">
 <div class="field">
   <label for="user_identity_page_id">Your identity page ID</label>
   {user_page_input}
+  <div class="hint">Auto-provisioned on first <code>remember_user action=read</code> once <code>user_id</code> is set.</div>
+</div>
+<div class="field">
+  <label for="user_identity_book_id">Your identity book ID</label>
+  {user_identity_book_id_input}
+  <div class="hint">Container book holding your identity page + per-user agent definitions. Auto-provisioned.</div>
 </div>
 </div>
+<div class="row2">
 <div class="field">
   <label for="user_journal_book_id">Your journal book</label>
   {user_journal_select}
+  <div class="hint">Auto-provisioned and force-attached to the User Journals shelf on every write.</div>
+</div>
+<div class="field">
+  <label for="user_journal_agent_page_id">Your journal-agent page ID</label>
+  {user_journal_agent_page_id_input}
+  <div class="hint">Auto-provisioned page (Agent: {{user_id}}-journal-agent) — fetched into the local agent cache by the bootstrap protocol.</div>
+</div>
+</div>
+<div class="field">
+  <label for="domains">Your owned domains</label>
+  {domains_input}
+  <div class="hint">One per line, or comma-separated. Surfaced in every briefing's <code>system_prompt_additions</code> so the AI can distinguish ours vs external content (URLs, emails). E.g.: <code>example.com</code></div>
 </div>
 </div>
 
@@ -1020,8 +1139,17 @@ a.reauth:hover { color: #cbd5e1; text-decoration: underline; }
         ai_shared_collage_select = render_select("ai_shared_collage_book_id", books, s.ai_shared_collage_book_id, true),
         ai_identity_book_select = render_select("ai_identity_book_id", books, s.ai_identity_book_id, true),
         user_id_input = render_text("user_id", s.user_id.as_deref(), "you@example.com"),
+        bookstack_user_id_input = render_id_input("bookstack_user_id", s.bookstack_user_id),
         user_page_input = render_id_input("user_identity_page_id", s.user_identity_page_id),
+        user_identity_book_id_input = render_id_input("user_identity_book_id", s.user_identity_book_id),
+        user_journal_agent_page_id_input = render_id_input("user_journal_agent_page_id", s.user_journal_agent_page_id),
         user_journal_select = render_select("user_journal_book_id", books, s.user_journal_book_id, true),
+        domains_input = render_textarea(
+            "domains",
+            &format_str_list(&s.domains),
+            "example.com\nexample.net",
+            3,
+        ),
         cb_journal = render_checkbox("semantic_against_journal", s.semantic_against_journal, "AI journal"),
         cb_collage = render_checkbox("semantic_against_collage", s.semantic_against_collage, "Topics / collage"),
         cb_shared_collage = render_checkbox("semantic_against_shared_collage", s.semantic_against_shared_collage, "Shared collage"),
@@ -1044,6 +1172,32 @@ a.reauth:hover { color: #cbd5e1; text-decoration: underline; }
         // Only show the create checkboxes for admins setting unset globals.
         hive_shelf_create = if g.hive_shelf_id.is_none() && is_admin { create_inline("create_hive_shelf", "Create \"Hive\" shelf if missing") } else { String::new() },
         user_journals_shelf_create = if g.user_journals_shelf_id.is_none() && is_admin { create_inline("create_user_journals_shelf", "Create \"User Journals\" shelf if missing") } else { String::new() },
+
+        org_identity_note = match (g.org_identity_page_id.is_some(), is_admin) {
+            (true, true) => "(set globally; page ID is locked, domains list editable)",
+            (false, true) => "(unset — you are an admin and may set this)",
+            (true, false) => "(set globally — read-only)",
+            (false, false) => "(unset — only a BookStack admin can configure)",
+        },
+        org_identity_page_input = if is_admin && g.org_identity_page_id.is_none() {
+            render_id_input("org_identity_page_id", g.org_identity_page_id)
+        } else {
+            render_locked_value(g.org_identity_page_id.map(|v| v.to_string()))
+        },
+        org_domains_input = if is_admin {
+            render_textarea(
+                "org_domains",
+                &format_str_list(&g.org_domains),
+                "example.com\nexample.net",
+                3,
+            )
+        } else {
+            render_locked_value(if g.org_domains.is_empty() {
+                None
+            } else {
+                Some(format_str_list(&g.org_domains))
+            })
+        },
 
         org_default_note = if is_admin { "(admin-editable)" } else { "(read-only — admin only)" },
         default_id_input = if is_admin {


### PR DESCRIPTION
## Summary

Three threaded enhancements that all land together because they share schema and briefing surface area:

1. **Permission ACL** — pre-resolves per-page role visibility at embed time so `vector_search` can drop pages the user can't view before the HTTP permission fan-out, instead of doing one `GET /api/pages/{id}` per candidate cold.
2. **Per-user identity auto-provisioning** — on first `remember_user action=read`, creates the user's Identity book + Identity page + `Agent: {user_id}-journal-agent` page on the user-journals shelf, mirroring how the AI side works. Force-attaches the user-journal book to the shelf on every write.
3. **Global org settings + briefing surfacing** — `org_identity_page_id` (single page describing the org) + `org_domains` (admin-only) feed every briefing's `system_prompt_additions` alongside a per-user `domains` field, plus a 30-day stale-identity nudge.

## What changed

### Schema
- `global_settings`: `org_identity_page_id`, `org_domains`
- `user_settings`: `bookstack_user_id`, `user_identity_book_id`, `user_journal_agent_page_id`, `domains`
- New tables: `page_view_acl`, `user_role_cache`, `acl_reconcile_state`
- New columns on `pages`: `acl_default_open`, `acl_computed_at`

### ACL pipeline
- `bsmcp-common/src/acl.rs` — `build_role_context` + `resolve_page_acl` walks BookStack content-permissions inheritance (page → chapter → book → role-level defaults). Stamps explicit role view-list when overrides exist, falls back to `default_open=true` for fully-inheriting pages.
- Embedder pipeline calls it after every successful page embed. New `acl_reconcile` scope handles ACL-only refreshes without re-embedding.
- `vector_search` (Postgres + SQLite) gained `user_role_ids: Option<&[i64]>`. Predicate: pass when ACL uncomputed OR `default_open` OR user role ∈ `view_roles`.
- `semantic.rs::resolve_user_roles` — 15-min cache via `user_role_cache`, fetches `/api/users/{id}` for the user's role list, returns `None` (skip ACL filter) when `bookstack_user_id` isn't configured.
- Webhook handler: `role_create`/`role_update` queue `acl_reconcile`; `role_delete` purges from `page_view_acl` then queues reconcile; `page_delete` clears its ACL row.
- Daily cron `BSMCP_ACL_RECONCILE_HOURS` (default 24) as the safety net.
- HTTP `filter_by_permission` retained as fallback for `default_open` pages, uncomputed pages, and per-user override pages (BookStack's public API doesn't expose user-level content_permissions).

### Webhooks to add in BookStack admin
| Event | Why |
|---|---|
| `role_create` | New role might gain system-level page-view-all |
| `role_update` | Role permission changes affect ACLs |
| `role_delete` | Drop the role from `page_view_acl` |

`book_update` / `chapter_update` / `page_update` already fire when content_permissions change since BookStack treats those as entity updates.

### User auto-provisioning (`remember/user_provision.rs`)
On `remember_user action=read|write` when `user_id` is set:
- `{user_id} — Identity` book on the user-journals shelf
- `Identity` page (starter template covering communication style, working preferences, owned domains, recurring topics)
- `Agent: {user_id}-journal-agent` page with the standard `## Definition` block — the bootstrap protocol pulls it into the local agent cache
- User journal book if missing

`collection.rs` user_journal writes now self-heal — every write reattaches the book to the user-journals shelf if it's drifted off.

### Briefing
- `system_prompt_additions` includes the org_identity page, an `Owned domains` synthetic block (user.domains ∪ org_domains, deduplicated), and an `Identity refresh due` block when the user identity page is older than 30 days.
- `setup_nudge` rewritten: enumerates every missing field individually with `{field, why}` entries; `admin_only: true` flags fields only an admin can persist. Stays active until everything's filled in.

### Settings UI
- "Your Identity" card: new `bookstack_user_id` field, `domains` textarea, plus read-only auto-provisioned IDs
- New "Org identity & domains" card (admin-only): `org_identity_page_id` first-write-wins, `org_domains` editable

### Tool descriptions
- `remember_config` documents the new fields, admin-only globals
- `remember_user` reminds the AI to keep the user identity page updated as it learns

## Test plan
- [ ] Fresh deploy on SQLite — verify schema migrations create the new columns and tables without error
- [ ] Fresh deploy on PostgreSQL — same
- [ ] Existing deploy (both backends) — verify `ALTER TABLE` migrations run cleanly on the existing global_settings + pages tables
- [ ] Run a full re-embed — confirm `page_view_acl` populates and `acl_computed_at` is non-null
- [ ] Set `bookstack_user_id` in /settings, run semantic_search — confirm restricted pages are dropped at SQL level (check `vector_search` logs / EXPLAIN)
- [ ] Configure a new user with just `user_id` — call `remember_user action=read` — verify Identity book + Identity page + journal-agent page are created on the user-journals shelf
- [ ] Move user journal book off the shelf manually — write a journal entry — confirm it's reattached
- [ ] Add the four new webhooks in BookStack admin, change a role — confirm `acl_reconcile` job fires and updates `page_view_acl`
- [ ] Verify the briefing surfaces org_identity, owned domains, and the stale-identity nudge after backdating a user identity page
- [ ] Verify `setup_nudge` lists pending fields correctly for both an unconfigured user and an admin missing org_identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)