### PR TITLE
Timezone cache, human time block, and actionable setup errors (v0.7.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-common"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -323,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-postgres"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -339,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-sqlite"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -354,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-embedder"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -373,13 +382,15 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-server"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "axum",
  "base64 0.22.1",
  "bsmcp-common",
  "bsmcp-db-postgres",
  "bsmcp-db-sqlite",
+ "chrono",
+ "chrono-tz",
  "futures",
  "pgvector",
  "pulldown-cmark",
@@ -460,6 +471,27 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
 
 [[package]]
 name = "cipher"
@@ -1476,6 +1508,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2390,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3147,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -4104,6 +4184,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.7.2"
+version = "0.7.3"
 
 [profile.release]
 lto = true

--- a/crates/bsmcp-common/src/settings.rs
+++ b/crates/bsmcp-common/src/settings.rs
@@ -146,8 +146,21 @@ pub struct UserSettings {
     /// User's IANA timezone name (e.g., "America/New_York"). Surfaced in the
     /// briefing's `time` block so the AI can format timestamps in the user's
     /// local time. If unset, the briefing reports UTC.
+    ///
+    /// Auto-populated by the briefing when the client passes
+    /// `client_timezone`; manually editable on /settings; refreshed every
+    /// `TIMEZONE_REFRESH_SECS` so DST transitions and travel are picked up
+    /// without forcing the user to re-save settings.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
+
+    /// Unix epoch seconds the timezone was last set/refreshed by the client.
+    /// The briefing surfaces `timezone_refresh_due: true` when the cache is
+    /// older than 4h so the client knows to re-detect and pass `client_timezone`
+    /// on the next call. Manually-set values (via /settings) get a fresh
+    /// fetched_at too — no special casing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timezone_fetched_at: Option<i64>,
 
     /// Unix epoch seconds until which the briefing's "configure your settings"
     /// nudge is snoozed. When `now < this`, the nudge is suppressed. Set via

--- a/crates/bsmcp-server/Cargo.toml
+++ b/crates/bsmcp-server/Cargo.toml
@@ -25,3 +25,5 @@ pulldown-cmark = { version = "0.12", default-features = false, features = ["html
 rusqlite = { version = "0.32", features = ["bundled"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
 pgvector = { version = "0.4", features = ["sqlx"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono-tz = "0.10"

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -1872,7 +1872,16 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
                 "enum": actions,
                 "description": "Operation to perform on this resource",
                 "default": actions.first().copied().unwrap_or("read"),
-            }
+            },
+            // client_timezone is accepted by EVERY remember endpoint, not
+            // just briefing. The server caches it in user_settings and
+            // refreshes whenever the cache is stale (>4h) or the value
+            // changes. Pass it whenever `meta.time.timezone_refresh_due`
+            // was true on a previous response.
+            "client_timezone": {
+                "type": "string",
+                "description": "Optional IANA timezone (e.g. \"America/New_York\"). Cached server-side; refresh when `meta.time.timezone_refresh_due` is true. Detect via your client's local time API.",
+            },
         });
         if let Value::Object(extra) = extra_props {
             if let Value::Object(ref mut p) = props {
@@ -1889,7 +1898,9 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
              structured `error.fix` block with the exact MCP call to make. \
              Run `remember_briefing action=read` first — its `setup_nudge` enumerates \
              every pending field and `meta.setup_incomplete` flags partial config on \
-             every response."
+             every response. \
+             TIME: every response carries `meta.time` with now_unix/now_utc/now_local/now_human \
+             and `timezone_refresh_due`. Pass `client_timezone` on any call to refresh."
         );
         tool(
             &format!("remember_{resource}"),
@@ -1912,14 +1923,12 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
     // Singletons
     tools.push(remember_tool(
         "briefing",
-        "Reconstitution dossier — one structured pull replacing the multi-call AI bootstrap. Returns identity manifest, user identity, recent journals, active topics, semantic matches against the user_prompt, config metadata, and a `time` block with now_unix/now_utc/now_local/now_human + the user's timezone. \
-         When the response's `time.timezone_refresh_due` is true, detect the local timezone (IANA name like \"America/New_York\" via `Intl.DateTimeFormat().resolvedOptions().timeZone` or system equivalent) and pass it as `client_timezone` on the next briefing call to refresh the cache (~4h TTL).",
+        "Reconstitution dossier — one structured pull replacing the multi-call AI bootstrap. Returns identity manifest, user identity, recent journals, active topics, semantic matches against the user_prompt, and config metadata. The full setup_nudge surfaces here when settings are incomplete.",
         &["read"],
         json!({
             "user_prompt": { "type": "string", "description": "First user message — drives semantic prioritization" },
             "recent_journal_count": { "type": "integer", "description": "Override the configured recent_journal_count" },
             "active_collage_count": { "type": "integer", "description": "Override the configured active_collage_count" },
-            "client_timezone": { "type": "string", "description": "Client's detected IANA timezone (e.g. \"America/New_York\"). Cached in user_settings; refreshed every 4h. Pass when `time.timezone_refresh_due` was true on the previous response." },
         }),
     ));
 

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -1879,9 +1879,21 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
                 for (k, v) in extra { p.insert(k, v); }
             }
         }
+        // Every remember_* tool ends with the same setup pointer so the AI
+        // knows what to do when a call returns settings_not_configured.
+        // The pointer is identical across tools intentionally — repeating it
+        // beats hoping the AI noticed it once on a different tool.
+        let full_description = format!(
+            "{description}\n\nSETUP: All remember_* tools require user/global settings. \
+             If this returns `settings_not_configured`, the response includes a \
+             structured `error.fix` block with the exact MCP call to make. \
+             Run `remember_briefing action=read` first — its `setup_nudge` enumerates \
+             every pending field and `meta.setup_incomplete` flags partial config on \
+             every response."
+        );
         tool(
             &format!("remember_{resource}"),
-            description,
+            &full_description,
             json!({ "type": "object", "properties": props }),
         )
     }

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -1900,12 +1900,14 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
     // Singletons
     tools.push(remember_tool(
         "briefing",
-        "Reconstitution dossier — one structured pull replacing the multi-call AI bootstrap. Returns identity manifest, user identity, recent journals, active topics, semantic matches against the user_prompt, and config metadata.",
+        "Reconstitution dossier — one structured pull replacing the multi-call AI bootstrap. Returns identity manifest, user identity, recent journals, active topics, semantic matches against the user_prompt, config metadata, and a `time` block with now_unix/now_utc/now_local/now_human + the user's timezone. \
+         When the response's `time.timezone_refresh_due` is true, detect the local timezone (IANA name like \"America/New_York\" via `Intl.DateTimeFormat().resolvedOptions().timeZone` or system equivalent) and pass it as `client_timezone` on the next briefing call to refresh the cache (~4h TTL).",
         &["read"],
         json!({
             "user_prompt": { "type": "string", "description": "First user message — drives semantic prioritization" },
             "recent_journal_count": { "type": "integer", "description": "Override the configured recent_journal_count" },
             "active_collage_count": { "type": "integer", "description": "Override the configured active_collage_count" },
+            "client_timezone": { "type": "string", "description": "Client's detected IANA timezone (e.g. \"America/New_York\"). Cached in user_settings; refreshed every 4h. Pass when `time.timezone_refresh_due` was true on the previous response." },
         }),
     ));
 

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -12,6 +12,11 @@ use bsmcp_common::bookstack::BookStackClient;
 use super::envelope::ErrorCode;
 use super::{frontmatter, Context, Outcome};
 
+/// How long a client-pushed timezone is trusted before the briefing flags
+/// it for refresh. 4h covers DST transitions and most travel within a
+/// session; shorter would just churn the user_settings table.
+const TIMEZONE_REFRESH_SECS: i64 = 4 * 60 * 60;
+
 pub async fn read(ctx: &Context) -> Outcome {
     let user_prompt = ctx.body_str("user_prompt").unwrap_or_default();
     let recent_count = ctx
@@ -31,6 +36,33 @@ pub async fn read(ctx: &Context) -> Outcome {
     // their own ai_identity_page_id but the org has a default, use it.
     let globals = ctx.db.get_global_settings().await.unwrap_or_default();
     let resolved = globals.resolve_identity(&ctx.settings);
+
+    // Client-pushed timezone refresh. The AI client (Claude Code etc.)
+    // detects local timezone at session start and passes it as `client_timezone`.
+    // We persist it in user_settings + stamp `timezone_fetched_at` so the
+    // briefing's time block can later flag a refresh when the cache ages out.
+    // No-op when the client doesn't send one — the existing manually-set
+    // setting still works.
+    let client_tz = ctx
+        .body_str("client_timezone")
+        .filter(|tz| tz.parse::<chrono_tz::Tz>().is_ok());
+    let mut effective_settings = ctx.settings.clone();
+    if let Some(tz) = client_tz.clone() {
+        let now = frontmatter::now_unix();
+        let needs_save = effective_settings.timezone.as_deref() != Some(tz.as_str())
+            || effective_settings.timezone_fetched_at.unwrap_or(0) < now - TIMEZONE_REFRESH_SECS;
+        if needs_save {
+            effective_settings.timezone = Some(tz);
+            effective_settings.timezone_fetched_at = Some(now);
+            if let Err(e) = ctx
+                .db
+                .save_user_settings(&ctx.token_id_hash, &effective_settings)
+                .await
+            {
+                eprintln!("Briefing: failed to persist client_timezone (non-fatal): {e}");
+            }
+        }
+    }
 
     // Identity manifest (page) + user manifest (page) — fetch in parallel.
     let identity_fut = fetch_optional_page(&ctx.client, resolved.page_id);
@@ -347,12 +379,7 @@ pub async fn read(ctx: &Context) -> Outcome {
         "shared_collage_semantic_matches": semantic.shared_collage_matches,
         "kb_semantic_matches": kb_matches_envelope(ctx, &semantic.kb_matches),
         "system_prompt_additions": system_prompt,
-        "time": {
-            "now_unix": frontmatter::now_unix(),
-            "now_utc": frontmatter::now_iso_utc(),
-            "timezone": ctx.settings.timezone.clone().unwrap_or_else(|| "UTC".to_string()),
-            "timezone_source": if ctx.settings.timezone.is_some() { "user_settings" } else { "default_utc" },
-        },
+        "time": build_time_block(&effective_settings, client_tz.is_some()),
         "config": {
             "label": ctx.settings.label,
             "role": ctx.settings.role,
@@ -537,6 +564,57 @@ fn kb_matches_envelope(ctx: &Context, results: &[Value]) -> Value {
         "detail": "Top hits from the entire knowledge base, excluding pages already surfaced in per-book sections.",
         "results": results,
     })
+}
+
+/// Build the briefing's `time` block. Surfaces unix + UTC always, plus
+/// timezone-aware fields when the user's timezone is set: `now_local`
+/// (RFC 3339 with offset), `now_human` (e.g. "Saturday, April 26, 2026
+/// at 6:42 PM EDT"), and `timezone_refresh_due` so the client knows when
+/// to re-detect.
+///
+/// `tz_just_pushed` is true when this request carried a fresh
+/// `client_timezone` — the refresh-due flag stays false in that case
+/// even if the cache had been stale, since we just refreshed it.
+fn build_time_block(s: &bsmcp_common::settings::UserSettings, tz_just_pushed: bool) -> Value {
+    let now = chrono::Utc::now();
+    let now_unix = now.timestamp();
+    let now_utc = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+    let (timezone, source) = match s.timezone.as_deref() {
+        Some(tz) => (tz.to_string(), "user_settings"),
+        None => ("UTC".to_string(), "default_utc"),
+    };
+
+    let mut block = json!({
+        "now_unix": now_unix,
+        "now_utc": now_utc,
+        "timezone": timezone,
+        "timezone_source": source,
+    });
+
+    if let Ok(tz) = timezone.parse::<chrono_tz::Tz>() {
+        let local = now.with_timezone(&tz);
+        // RFC 3339 with the local offset, e.g. 2026-04-26T18:42:00-04:00.
+        block["now_local"] = json!(local.format("%Y-%m-%dT%H:%M:%S%:z").to_string());
+        // Human-friendly: "Saturday, April 26, 2026 at 6:42 PM EDT".
+        block["now_human"] = json!(local.format("%A, %B %-d, %Y at %-I:%M %p %Z").to_string());
+    }
+
+    let refresh_due = if tz_just_pushed {
+        false
+    } else {
+        match s.timezone_fetched_at {
+            None => s.timezone.is_some(), // tz set manually long ago — flag for refresh
+            Some(t) => now_unix - t > TIMEZONE_REFRESH_SECS,
+        }
+    };
+    block["timezone_refresh_due"] = json!(refresh_due);
+    block["timezone_refresh_hint"] = json!(
+        "Pass `client_timezone` (IANA name like \"America/New_York\") on the next \
+         remember_briefing call to refresh. Detect via your system's local time."
+    );
+
+    block
 }
 
 /// Per-user fields the setup nudge wants populated. Each entry is a

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -12,11 +12,6 @@ use bsmcp_common::bookstack::BookStackClient;
 use super::envelope::ErrorCode;
 use super::{frontmatter, Context, Outcome};
 
-/// How long a client-pushed timezone is trusted before the briefing flags
-/// it for refresh. 4h covers DST transitions and most travel within a
-/// session; shorter would just churn the user_settings table.
-const TIMEZONE_REFRESH_SECS: i64 = 4 * 60 * 60;
-
 pub async fn read(ctx: &Context) -> Outcome {
     let user_prompt = ctx.body_str("user_prompt").unwrap_or_default();
     let recent_count = ctx
@@ -34,35 +29,12 @@ pub async fn read(ctx: &Context) -> Outcome {
 
     // Resolve identity with org-default fallback. If the user hasn't set
     // their own ai_identity_page_id but the org has a default, use it.
+    //
+    // Note: `client_timezone` refresh is handled centrally by `dispatch`
+    // before this handler runs — `ctx.settings` already reflects any newly-
+    // pushed timezone. No per-handler logic needed here.
     let globals = ctx.db.get_global_settings().await.unwrap_or_default();
     let resolved = globals.resolve_identity(&ctx.settings);
-
-    // Client-pushed timezone refresh. The AI client (Claude Code etc.)
-    // detects local timezone at session start and passes it as `client_timezone`.
-    // We persist it in user_settings + stamp `timezone_fetched_at` so the
-    // briefing's time block can later flag a refresh when the cache ages out.
-    // No-op when the client doesn't send one — the existing manually-set
-    // setting still works.
-    let client_tz = ctx
-        .body_str("client_timezone")
-        .filter(|tz| tz.parse::<chrono_tz::Tz>().is_ok());
-    let mut effective_settings = ctx.settings.clone();
-    if let Some(tz) = client_tz.clone() {
-        let now = frontmatter::now_unix();
-        let needs_save = effective_settings.timezone.as_deref() != Some(tz.as_str())
-            || effective_settings.timezone_fetched_at.unwrap_or(0) < now - TIMEZONE_REFRESH_SECS;
-        if needs_save {
-            effective_settings.timezone = Some(tz);
-            effective_settings.timezone_fetched_at = Some(now);
-            if let Err(e) = ctx
-                .db
-                .save_user_settings(&ctx.token_id_hash, &effective_settings)
-                .await
-            {
-                eprintln!("Briefing: failed to persist client_timezone (non-fatal): {e}");
-            }
-        }
-    }
 
     // Identity manifest (page) + user manifest (page) — fetch in parallel.
     let identity_fut = fetch_optional_page(&ctx.client, resolved.page_id);
@@ -379,7 +351,10 @@ pub async fn read(ctx: &Context) -> Outcome {
         "shared_collage_semantic_matches": semantic.shared_collage_matches,
         "kb_semantic_matches": kb_matches_envelope(ctx, &semantic.kb_matches),
         "system_prompt_additions": system_prompt,
-        "time": build_time_block(&effective_settings, client_tz.is_some()),
+        // `time` is now in `meta.time` on every remember response (not just
+        // briefing). Kept here too — readers were already targeting
+        // `data.time` and we don't want to break them in a patch release.
+        "time": super::envelope::build_time_block(&ctx.settings, false),
         "config": {
             "label": ctx.settings.label,
             "role": ctx.settings.role,
@@ -566,56 +541,6 @@ fn kb_matches_envelope(ctx: &Context, results: &[Value]) -> Value {
     })
 }
 
-/// Build the briefing's `time` block. Surfaces unix + UTC always, plus
-/// timezone-aware fields when the user's timezone is set: `now_local`
-/// (RFC 3339 with offset), `now_human` (e.g. "Saturday, April 26, 2026
-/// at 6:42 PM EDT"), and `timezone_refresh_due` so the client knows when
-/// to re-detect.
-///
-/// `tz_just_pushed` is true when this request carried a fresh
-/// `client_timezone` — the refresh-due flag stays false in that case
-/// even if the cache had been stale, since we just refreshed it.
-fn build_time_block(s: &bsmcp_common::settings::UserSettings, tz_just_pushed: bool) -> Value {
-    let now = chrono::Utc::now();
-    let now_unix = now.timestamp();
-    let now_utc = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
-
-    let (timezone, source) = match s.timezone.as_deref() {
-        Some(tz) => (tz.to_string(), "user_settings"),
-        None => ("UTC".to_string(), "default_utc"),
-    };
-
-    let mut block = json!({
-        "now_unix": now_unix,
-        "now_utc": now_utc,
-        "timezone": timezone,
-        "timezone_source": source,
-    });
-
-    if let Ok(tz) = timezone.parse::<chrono_tz::Tz>() {
-        let local = now.with_timezone(&tz);
-        // RFC 3339 with the local offset, e.g. 2026-04-26T18:42:00-04:00.
-        block["now_local"] = json!(local.format("%Y-%m-%dT%H:%M:%S%:z").to_string());
-        // Human-friendly: "Saturday, April 26, 2026 at 6:42 PM EDT".
-        block["now_human"] = json!(local.format("%A, %B %-d, %Y at %-I:%M %p %Z").to_string());
-    }
-
-    let refresh_due = if tz_just_pushed {
-        false
-    } else {
-        match s.timezone_fetched_at {
-            None => s.timezone.is_some(), // tz set manually long ago — flag for refresh
-            Some(t) => now_unix - t > TIMEZONE_REFRESH_SECS,
-        }
-    };
-    block["timezone_refresh_due"] = json!(refresh_due);
-    block["timezone_refresh_hint"] = json!(
-        "Pass `client_timezone` (IANA name like \"America/New_York\") on the next \
-         remember_briefing call to refresh. Detect via your system's local time."
-    );
-
-    block
-}
 
 /// Per-user fields the setup nudge wants populated. Each entry is a
 /// `{field, why}` pair — `field` matches the UserSettings JSON key so the AI

--- a/crates/bsmcp-server/src/remember/collection.rs
+++ b/crates/bsmcp-server/src/remember/collection.rs
@@ -28,6 +28,11 @@ pub enum KeyKind {
 pub trait CollectionResource: Send + Sync {
     fn name(&self) -> &'static str;
 
+    /// UserSettings field name for the parent book — used by the
+    /// settings_not_configured error so the AI gets a real field name in
+    /// `error.fix` instead of the resource name.
+    fn setting_field(&self) -> &'static str;
+
     fn parent(&self, settings: &UserSettings) -> Option<CollectionParent>;
 
     fn key_kind(&self) -> KeyKind;
@@ -67,10 +72,13 @@ pub async fn handle(
     let parent = match resource.parent(&ctx.settings) {
         Some(p) => p,
         None => {
-            return Outcome::error(
-                ErrorCode::SettingsNotConfigured,
-                format!("{} parent not configured in settings", resource.name()),
-                Some(resource.name()),
+            return Outcome::settings_not_configured(
+                resource.setting_field(),
+                format!(
+                    "{} requires `{}` to be set. The collection has no parent book to read or write.",
+                    resource.name(),
+                    resource.setting_field()
+                ),
             );
         }
     };
@@ -568,6 +576,7 @@ pub mod resources {
     pub struct Journal;
     impl CollectionResource for Journal {
         fn name(&self) -> &'static str { "journal" }
+        fn setting_field(&self) -> &'static str { "ai_hive_journal_book_id" }
         fn parent(&self, s: &UserSettings) -> Option<CollectionParent> {
             s.ai_hive_journal_book_id        }
         fn key_kind(&self) -> KeyKind { KeyKind::Date }
@@ -580,6 +589,7 @@ pub mod resources {
     pub struct Collage;
     impl CollectionResource for Collage {
         fn name(&self) -> &'static str { "collage" }
+        fn setting_field(&self) -> &'static str { "ai_collage_book_id" }
         fn parent(&self, s: &UserSettings) -> Option<CollectionParent> {
             s.ai_collage_book_id        }
         fn key_kind(&self) -> KeyKind { KeyKind::Slug }
@@ -588,6 +598,7 @@ pub mod resources {
     pub struct SharedCollage;
     impl CollectionResource for SharedCollage {
         fn name(&self) -> &'static str { "shared_collage" }
+        fn setting_field(&self) -> &'static str { "ai_shared_collage_book_id" }
         fn parent(&self, s: &UserSettings) -> Option<CollectionParent> {
             s.ai_shared_collage_book_id        }
         fn key_kind(&self) -> KeyKind { KeyKind::Slug }
@@ -596,6 +607,7 @@ pub mod resources {
     pub struct UserJournal;
     impl CollectionResource for UserJournal {
         fn name(&self) -> &'static str { "user_journal" }
+        fn setting_field(&self) -> &'static str { "user_journal_book_id" }
         fn parent(&self, s: &UserSettings) -> Option<CollectionParent> {
             s.user_journal_book_id        }
         fn key_kind(&self) -> KeyKind { KeyKind::Date }

--- a/crates/bsmcp-server/src/remember/directory.rs
+++ b/crates/bsmcp-server/src/remember/directory.rs
@@ -32,20 +32,18 @@ pub async fn read(ctx: &Context) -> Outcome {
         "identities" => match globals.hive_shelf_id {
             Some(id) => id,
             None => {
-                return Outcome::error(
-                    ErrorCode::SettingsNotConfigured,
-                    "global hive_shelf_id is not set",
-                    Some("hive_shelf_id"),
+                return Outcome::settings_not_configured(
+                    "hive_shelf_id",
+                    "global hive_shelf_id is not set — admin must configure it before identities can be listed",
                 );
             }
         },
         "user_journals" => match globals.user_journals_shelf_id {
             Some(id) => id,
             None => {
-                return Outcome::error(
-                    ErrorCode::SettingsNotConfigured,
-                    "global user_journals_shelf_id is not set",
-                    Some("user_journals_shelf_id"),
+                return Outcome::settings_not_configured(
+                    "user_journals_shelf_id",
+                    "global user_journals_shelf_id is not set — admin must configure it before user journals can be listed",
                 );
             }
         },

--- a/crates/bsmcp-server/src/remember/envelope.rs
+++ b/crates/bsmcp-server/src/remember/envelope.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{json, Value};
 
-use bsmcp_common::settings::UserSettings;
+use bsmcp_common::settings::{GlobalSettings, UserSettings};
 
 /// Discriminated error codes — clients can switch on these.
 #[derive(Clone, Copy, Debug)]
@@ -48,9 +48,10 @@ pub fn build_meta(
     trace_id: &str,
     elapsed_ms: u64,
     settings: &UserSettings,
+    globals: &GlobalSettings,
     warnings: Vec<RememberWarning>,
 ) -> Value {
-    json!({
+    let mut meta = json!({
         "trace_id": trace_id,
         "elapsed_ms": elapsed_ms,
         "config": {
@@ -64,5 +65,152 @@ pub fn build_meta(
             "code": w.code,
             "message": w.message,
         })).collect::<Vec<_>>(),
-    })
+    });
+
+    // Compact setup-status pointer — surfaced on every response (not just
+    // briefing) so the AI notices misconfiguration even when calling
+    // unrelated tools. Only inflates the response when something's pending.
+    if let Some(status) = setup_incomplete_summary(settings, globals) {
+        meta["setup_incomplete"] = json!(true);
+        meta["setup_summary"] = status;
+    }
+
+    meta
+}
+
+/// Build a one-line setup status when anything's still missing. Returns
+/// None when the user + globals are fully configured (so meta stays slim).
+fn setup_incomplete_summary(s: &UserSettings, g: &GlobalSettings) -> Option<Value> {
+    let user_missing = pending_user_summary(s);
+    let global_missing = pending_global_summary(g);
+    if user_missing.is_empty() && global_missing.is_empty() {
+        return None;
+    }
+    Some(json!({
+        "user_pending": user_missing,
+        "global_pending": global_missing,
+        "next_step": "Call `remember_briefing action=read` for the full setup_nudge with per-field workflow guidance and pending counts. Each settings_not_configured error from a remember_* tool also includes an `error.fix` block with the exact MCP call to make.",
+    }))
+}
+
+fn pending_user_summary(s: &UserSettings) -> Vec<&'static str> {
+    let mut out = Vec::new();
+    if s.user_id.is_none() { out.push("user_id"); }
+    if s.ai_identity_page_id.is_none() { out.push("ai_identity_page_id"); }
+    if s.ai_hive_journal_book_id.is_none() { out.push("ai_hive_journal_book_id"); }
+    if s.user_journal_book_id.is_none() { out.push("user_journal_book_id"); }
+    if s.user_identity_page_id.is_none() { out.push("user_identity_page_id"); }
+    if s.domains.is_empty() { out.push("domains"); }
+    if s.bookstack_user_id.is_none() { out.push("bookstack_user_id"); }
+    out
+}
+
+fn pending_global_summary(g: &GlobalSettings) -> Vec<&'static str> {
+    let mut out = Vec::new();
+    if g.hive_shelf_id.is_none() { out.push("hive_shelf_id"); }
+    if g.user_journals_shelf_id.is_none() { out.push("user_journals_shelf_id"); }
+    if g.org_identity_page_id.is_none() { out.push("org_identity_page_id"); }
+    if g.org_domains.is_empty() { out.push("org_domains"); }
+    out
+}
+
+/// Per-field instructions for a settings_not_configured error. The AI gets
+/// this attached to the error envelope so it knows exactly which call to
+/// make next. Falls back to a generic pointer when the field isn't in the
+/// table (kept narrow so callers don't drift away from the helper).
+pub fn fix_for_field(field: &str) -> Value {
+    match field {
+        "ai_identity_page_id" => json!({
+            "summary": "AI identity manifest page is required. Without it the briefing falls back to the org default (if set) and whoami fails.",
+            "auto_provision_supported": false,
+            "how": [
+                "Quickest: visit /settings, pick from the dropdown.",
+                "Scaffold a fresh agent: `remember_identity action=create name=<your-agent-name>` creates the Identity book + manifest page in one call, returning the new ID.",
+                "Adopt an existing manifest: `remember_directory action=read kind=identities` lists what's on the global Hive shelf, then `remember_config action=write settings={\"ai_identity_page_id\": <id>}`.",
+            ],
+        }),
+        "user_identity_page_id" => json!({
+            "summary": "User identity page is required for remember_user write and the identity-refresh nudge.",
+            "auto_provision_supported": true,
+            "how": [
+                "Set `user_id` first via `remember_config action=write settings={\"user_id\": \"you@example.com\"}` (any stable identifier).",
+                "Then call `remember_user action=read` — auto-provisions the per-user Identity book + Identity page on the user-journals shelf, stamping the page ID into settings.",
+            ],
+        }),
+        "user_journal_book_id" => json!({
+            "summary": "User journal book is required for remember_user_journal read/write/search.",
+            "auto_provision_supported": true,
+            "how": [
+                "Set `user_id` first if not already set.",
+                "Call `remember_user action=read` — auto-provisions the journal book on the user-journals shelf alongside the identity page.",
+                "Or pick an existing book on /settings (dropdown) and save.",
+            ],
+        }),
+        "ai_hive_journal_book_id" => json!({
+            "summary": "AI journal book is required for remember_journal read/write/search/delete.",
+            "auto_provision_supported": false,
+            "how": [
+                "Visit /settings — \"AI Journal & Topics\" card has a dropdown plus a \"create if missing\" checkbox.",
+                "Or via MCP: `remember_config action=write settings={\"ai_hive_journal_book_id\": <id>}` if you already have a journal book to adopt.",
+            ],
+        }),
+        "ai_collage_book_id" => json!({
+            "summary": "AI topics/collage book is required for remember_collage read/write/search/delete.",
+            "auto_provision_supported": false,
+            "how": [
+                "Visit /settings — \"AI Journal & Topics\" card.",
+                "Or `remember_config action=write settings={\"ai_collage_book_id\": <id>}`.",
+            ],
+        }),
+        "ai_shared_collage_book_id" => json!({
+            "summary": "Cross-agent shared collage book is required for remember_shared_collage. Optional — only configure if multiple agents share topics.",
+            "auto_provision_supported": false,
+            "how": [
+                "Visit /settings — \"AI Journal & Topics\" card.",
+                "Or `remember_config action=write settings={\"ai_shared_collage_book_id\": <id>}`.",
+            ],
+        }),
+        "hive_shelf_id" => json!({
+            "summary": "Global Hive shelf is required for remember_directory kind=identities and remember_identity action=create. Admin-only, first-write-wins.",
+            "auto_provision_supported": false,
+            "admin_only": true,
+            "how": [
+                "Have an admin visit /settings — \"Global shelves\" card has a dropdown + \"Create Hive shelf\" checkbox.",
+                "Or admin-only MCP: `remember_config action=write global_settings={\"hive_shelf_id\": <id>}`.",
+            ],
+        }),
+        "user_journals_shelf_id" => json!({
+            "summary": "Global User Journals shelf is required for user auto-provisioning + remember_directory kind=user_journals. Admin-only, first-write-wins.",
+            "auto_provision_supported": false,
+            "admin_only": true,
+            "how": [
+                "Have an admin visit /settings — \"Global shelves\" card has a dropdown + \"Create User Journals shelf\" checkbox.",
+                "Or admin-only MCP: `remember_config action=write global_settings={\"user_journals_shelf_id\": <id>}`.",
+            ],
+        }),
+        "user_id" => json!({
+            "summary": "User ID is the stable identifier (typically email) used to name per-user resources and stamp journal frontmatter.",
+            "auto_provision_supported": false,
+            "how": [
+                "`remember_config action=write settings={\"user_id\": \"you@example.com\"}` — any stable identifier you control.",
+            ],
+        }),
+        "global_settings" => json!({
+            "summary": "Global settings can only be written by BookStack admins.",
+            "auto_provision_supported": false,
+            "admin_only": true,
+            "how": [
+                "Ask a BookStack admin to visit /settings (admins see additional cards) or to call `remember_config action=write global_settings={...}`.",
+            ],
+        }),
+        _ => json!({
+            "summary": format!("`{field}` is not configured."),
+            "auto_provision_supported": false,
+            "how": [
+                "Visit /settings to fill it in via the form.",
+                format!("Or via MCP: `remember_config action=write settings={{\"{field}\": <value>}}`."),
+                "Run `remember_briefing action=read` for the full setup_nudge with the suggested workflow.",
+            ],
+        }),
+    }
 }

--- a/crates/bsmcp-server/src/remember/envelope.rs
+++ b/crates/bsmcp-server/src/remember/envelope.rs
@@ -4,6 +4,11 @@ use serde_json::{json, Value};
 
 use bsmcp_common::settings::{GlobalSettings, UserSettings};
 
+/// How long a client-pushed timezone is trusted before the response flags
+/// it for refresh. 4h covers DST transitions and most travel within a
+/// session; shorter would just churn the user_settings table.
+pub const TIMEZONE_REFRESH_SECS: i64 = 4 * 60 * 60;
+
 /// Discriminated error codes — clients can switch on these.
 #[derive(Clone, Copy, Debug)]
 #[allow(dead_code)] // SemanticUnavailable reserved for explicit "semantic required" calls
@@ -50,6 +55,7 @@ pub fn build_meta(
     settings: &UserSettings,
     globals: &GlobalSettings,
     warnings: Vec<RememberWarning>,
+    tz_just_pushed: bool,
 ) -> Value {
     let mut meta = json!({
         "trace_id": trace_id,
@@ -65,6 +71,12 @@ pub fn build_meta(
             "code": w.code,
             "message": w.message,
         })).collect::<Vec<_>>(),
+        // Time block — surfaced on EVERY remember response (not just
+        // briefing) so the AI always knows the current time in the user's
+        // configured timezone without a separate roundtrip. Carries the
+        // refresh-due flag so any endpoint can prompt the client to push
+        // a fresh `client_timezone` on its next call.
+        "time": build_time_block(settings, tz_just_pushed),
     });
 
     // Compact setup-status pointer — surfaced on every response (not just
@@ -76,6 +88,55 @@ pub fn build_meta(
     }
 
     meta
+}
+
+/// Build the time block for a remember response. Surfaces unix + UTC
+/// always, plus timezone-aware fields when the user's timezone is set:
+/// `now_local` (RFC 3339 with offset), `now_human` (e.g. "Saturday,
+/// April 26, 2026 at 6:42 PM EDT"), and `timezone_refresh_due` so the
+/// client knows when to re-detect.
+///
+/// `tz_just_pushed` is true when the request carried a fresh
+/// `client_timezone` — the refresh-due flag stays false in that case
+/// even if the cache had been stale, since we just refreshed it.
+pub fn build_time_block(s: &UserSettings, tz_just_pushed: bool) -> Value {
+    let now = chrono::Utc::now();
+    let now_unix = now.timestamp();
+    let now_utc = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+    let (timezone, source) = match s.timezone.as_deref() {
+        Some(tz) => (tz.to_string(), "user_settings"),
+        None => ("UTC".to_string(), "default_utc"),
+    };
+
+    let mut block = json!({
+        "now_unix": now_unix,
+        "now_utc": now_utc,
+        "timezone": timezone,
+        "timezone_source": source,
+    });
+
+    if let Ok(tz) = timezone.parse::<chrono_tz::Tz>() {
+        let local = now.with_timezone(&tz);
+        block["now_local"] = json!(local.format("%Y-%m-%dT%H:%M:%S%:z").to_string());
+        block["now_human"] = json!(local.format("%A, %B %-d, %Y at %-I:%M %p %Z").to_string());
+    }
+
+    let refresh_due = if tz_just_pushed {
+        false
+    } else {
+        match s.timezone_fetched_at {
+            None => s.timezone.is_some(),
+            Some(t) => now_unix - t > TIMEZONE_REFRESH_SECS,
+        }
+    };
+    block["timezone_refresh_due"] = json!(refresh_due);
+    block["timezone_refresh_hint"] = json!(
+        "Pass `client_timezone` (IANA name like \"America/New_York\") on any \
+         remember_* call to refresh. Detect via your client's local time API."
+    );
+
+    block
 }
 
 /// Build a one-line setup status when anything's still missing. Returns

--- a/crates/bsmcp-server/src/remember/identity.rs
+++ b/crates/bsmcp-server/src/remember/identity.rs
@@ -33,10 +33,9 @@ async fn list(ctx: &Context) -> Outcome {
     let shelf_id = match globals.hive_shelf_id {
         Some(id) => id,
         None => {
-            return Outcome::error(
-                ErrorCode::SettingsNotConfigured,
-                "global hive_shelf_id is not set — configure it on /settings first",
-                Some("hive_shelf_id"),
+            return Outcome::settings_not_configured(
+                "hive_shelf_id",
+                "global hive_shelf_id is not set — only a BookStack admin can configure it via /settings or admin-only `remember_config action=write global_settings={hive_shelf_id: <id>}`",
             );
         }
     };
@@ -153,10 +152,9 @@ async fn create(ctx: &Context) -> Outcome {
     let hive_shelf_id = match globals.hive_shelf_id {
         Some(id) => id,
         None => {
-            return Outcome::error(
-                ErrorCode::SettingsNotConfigured,
-                "global hive_shelf_id is not set — configure it on /settings first",
-                Some("hive_shelf_id"),
+            return Outcome::settings_not_configured(
+                "hive_shelf_id",
+                "global hive_shelf_id is not set — admin must configure it before identities can be created",
             );
         }
     };

--- a/crates/bsmcp-server/src/remember/mod.rs
+++ b/crates/bsmcp-server/src/remember/mod.rs
@@ -102,7 +102,8 @@ pub async fn dispatch(
     }
 
     let elapsed_ms = ctx.started.elapsed().as_millis() as u64;
-    let meta = envelope::build_meta(&trace_id, elapsed_ms, &ctx.settings, outcome.warnings.clone());
+    let globals = db.get_global_settings().await.unwrap_or_default();
+    let meta = envelope::build_meta(&trace_id, elapsed_ms, &ctx.settings, &globals, outcome.warnings.clone());
 
     match outcome.result {
         Ok(data) => json!({
@@ -110,15 +111,21 @@ pub async fn dispatch(
             "data": data,
             "meta": meta,
         }),
-        Err(err) => json!({
-            "ok": false,
-            "error": {
+        Err(err) => {
+            let mut error_obj = json!({
                 "code": err.code.as_str(),
                 "message": err.message,
                 "field": err.field,
-            },
-            "meta": meta,
-        }),
+            });
+            if let Some(fix) = err.fix {
+                error_obj["fix"] = fix;
+            }
+            json!({
+                "ok": false,
+                "error": error_obj,
+                "meta": meta,
+            })
+        }
     }
 }
 
@@ -215,6 +222,25 @@ impl Outcome {
                 code,
                 message: message.into(),
                 field: field.map(|s| s.to_string()),
+                fix: None,
+            }),
+            warnings: Vec::new(),
+            target_page_id: None,
+            target_key: None,
+        }
+    }
+
+    /// Construct a `settings_not_configured` error with the per-field
+    /// `fix` block automatically attached. Prefer this over `error(...)`
+    /// for missing-config errors so the AI gets actionable guidance every
+    /// time, not just on briefing.
+    pub fn settings_not_configured(field: &str, message: impl Into<String>) -> Self {
+        Self {
+            result: Err(RememberError {
+                code: ErrorCode::SettingsNotConfigured,
+                message: message.into(),
+                field: Some(field.to_string()),
+                fix: Some(envelope::fix_for_field(field)),
             }),
             warnings: Vec::new(),
             target_page_id: None,
@@ -240,4 +266,8 @@ pub struct RememberError {
     pub code: ErrorCode,
     pub message: String,
     pub field: Option<String>,
+    /// Optional structured fix instructions — populated for
+    /// `settings_not_configured` errors so the AI knows exactly which
+    /// MCP call to make next. Surfaced as `error.fix` in the envelope.
+    pub fix: Option<serde_json::Value>,
 }

--- a/crates/bsmcp-server/src/remember/mod.rs
+++ b/crates/bsmcp-server/src/remember/mod.rs
@@ -57,7 +57,7 @@ pub async fn dispatch(
     let token_id_hash = hash_token_id(token_id);
 
     // Load user settings — None becomes default (everything disabled).
-    let settings = match db.get_user_settings(&token_id_hash).await {
+    let mut settings = match db.get_user_settings(&token_id_hash).await {
         Ok(Some(s)) => s,
         Ok(None) => UserSettings::default(),
         Err(e) => {
@@ -65,6 +65,36 @@ pub async fn dispatch(
             UserSettings::default()
         }
     };
+
+    // Client-pushed timezone refresh — accepted on every remember endpoint
+    // so the AI can keep the cache fresh from any call, not just briefing.
+    // No-op when the body doesn't carry one or when the cache is already
+    // recent and matches. We persist asynchronously and stamp the local
+    // `settings` immediately so the response's time block reflects the
+    // newly-pushed value.
+    let client_tz: Option<String> = body
+        .get("client_timezone")
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && s.parse::<chrono_tz::Tz>().is_ok());
+    let mut tz_just_pushed = false;
+    if let Some(ref tz) = client_tz {
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let needs_save = settings.timezone.as_deref() != Some(tz.as_str())
+            || settings.timezone_fetched_at.unwrap_or(0)
+                < now_unix - envelope::TIMEZONE_REFRESH_SECS;
+        if needs_save {
+            settings.timezone = Some(tz.clone());
+            settings.timezone_fetched_at = Some(now_unix);
+            if let Err(e) = db.save_user_settings(&token_id_hash, &settings).await {
+                eprintln!("Remember: failed to persist client_timezone (non-fatal): {e}");
+            }
+        }
+        tz_just_pushed = true;
+    }
 
     let ctx = Context {
         body,
@@ -103,7 +133,14 @@ pub async fn dispatch(
 
     let elapsed_ms = ctx.started.elapsed().as_millis() as u64;
     let globals = db.get_global_settings().await.unwrap_or_default();
-    let meta = envelope::build_meta(&trace_id, elapsed_ms, &ctx.settings, &globals, outcome.warnings.clone());
+    let meta = envelope::build_meta(
+        &trace_id,
+        elapsed_ms,
+        &ctx.settings,
+        &globals,
+        outcome.warnings.clone(),
+        tz_just_pushed,
+    );
 
     match outcome.result {
         Ok(data) => json!({

--- a/crates/bsmcp-server/src/remember/singletons.rs
+++ b/crates/bsmcp-server/src/remember/singletons.rs
@@ -22,10 +22,9 @@ pub async fn read_whoami(ctx: &Context) -> Outcome {
     let page_id = match resolved.page_id {
         Some(id) => id,
         None => {
-            return Outcome::error(
-                ErrorCode::SettingsNotConfigured,
+            return Outcome::settings_not_configured(
+                "ai_identity_page_id",
                 "ai_identity_page_id not configured (no user setting and no org default)",
-                Some("ai_identity_page_id"),
             );
         }
     };
@@ -64,10 +63,9 @@ pub async fn write_whoami(ctx: &Context) -> Outcome {
     let page_id = match ctx.settings.ai_identity_page_id {
         Some(id) => id,
         None => {
-            return Outcome::error(
-                ErrorCode::SettingsNotConfigured,
+            return Outcome::settings_not_configured(
+                "ai_identity_page_id",
                 "ai_identity_page_id not configured — set the manifest page in /settings first",
-                Some("ai_identity_page_id"),
             );
         }
     };
@@ -152,10 +150,9 @@ pub async fn read_user(ctx: &Context) -> Outcome {
                     "auto_provisioned": auto_provision_summary(&provision_result),
                 }));
             }
-            return Outcome::error(
-                ErrorCode::SettingsNotConfigured,
-                "user_identity_page_id not configured (and user_id not set, so auto-provisioning is skipped)",
-                Some("user_identity_page_id"),
+            return Outcome::settings_not_configured(
+                "user_identity_page_id",
+                "user_identity_page_id not configured (and user_id not set, so auto-provisioning is skipped — set user_id first)",
             );
         }
     };
@@ -229,10 +226,9 @@ pub async fn write_user(ctx: &Context) -> Outcome {
     let page_id = match working_settings.user_identity_page_id {
         Some(id) => id,
         None => {
-            return Outcome::error(
-                ErrorCode::SettingsNotConfigured,
-                "user_identity_page_id not configured (auto-provision needs `user_id` and `user_journals_shelf_id` to work)",
-                Some("user_identity_page_id"),
+            return Outcome::settings_not_configured(
+                "user_identity_page_id",
+                "user_identity_page_id not configured (auto-provision needs `user_id` and the global `user_journals_shelf_id` to work)",
             );
         }
     };

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -327,7 +327,14 @@ pub async fn handle_settings_post(
         recent_journal_count: parse_count(form.recent_journal_count, 3),
         active_collage_count: parse_count(form.active_collage_count, 10),
         system_prompt_page_ids: parse_id_list(form.system_prompt_page_ids),
-        timezone: empty_to_none(form.timezone),
+        timezone: empty_to_none(form.timezone.clone()),
+        // Manual /settings submit counts as a fresh fetch — stamp now so the
+        // briefing's refresh-due flag doesn't immediately fire afterwards.
+        timezone_fetched_at: if empty_to_none(form.timezone).is_some() {
+            Some(crate::remember::frontmatter::now_unix())
+        } else {
+            None
+        },
         // Carry over the existing dismiss timestamp — saving via /settings
         // doesn't change the snooze. (The nudge auto-stops showing once
         // is_configured() is true.)


### PR DESCRIPTION
## Summary

Three threaded improvements shipping under v0.7.3:

### Timezone cache + human-friendly time on every remember response
- Every `remember_*` endpoint accepts an optional `client_timezone` (IANA name like `America/New_York`); server caches in `user_settings.timezone` along with new `timezone_fetched_at` column.
- Every response (not just briefing) carries `meta.time` with `now_unix`, `now_utc`, `now_local` (RFC 3339 with offset), `now_human` (e.g. \"Saturday, April 26, 2026 at 6:42 PM EDT\"), `timezone_refresh_due` (true when cache is older than 4h or never set), and `timezone_refresh_hint`.
- The refresh logic lives in central `dispatch` — every endpoint parses `client_timezone`, validates via `chrono_tz`, persists, and stamps `ctx.settings` so the response reflects the just-pushed value.
- `chrono` + `chrono-tz` pulled in (default-features-off, small).
- `briefing.data.time` stays for backwards compatibility (callers reading `data.time` keep working).
- `/settings` save stamps `timezone_fetched_at` on manual entry too.

### Actionable setup errors + always-on setup status
- Every `settings_not_configured` error now carries a structured `error.fix` block: per-field summary, whether auto-provisioning works, admin-only flag, and the exact MCP call(s) to make.
- Every response (success or failure) carries `meta.setup_incomplete: true` + `meta.setup_summary` listing pending user + global fields when setup isn't done. Slim by design — meta stays unchanged when fully configured.
- Every `remember_*` tool description ends with a uniform SETUP + TIME pointer telling the AI to run `remember_briefing` first, to read `error.fix` on failures, and that `meta.time` carries the current local time.
- Internal: new `Outcome::settings_not_configured(field, msg)` helper auto-attaches the fix block; `CollectionResource` gained `setting_field()` so journal/collage/user_journal errors carry the actual UserSettings field name.

### Other
- Workspace version bumps to 0.7.3.
- Statusline (Claude Code-side) configured locally in `~/.claude/settings.json` — not in this PR.

## Test plan
- [ ] Briefing without `client_timezone` and no configured timezone — verify `meta.time.timezone` is `UTC`, no `now_local`/`now_human`, `timezone_refresh_due: false`
- [ ] Briefing with `client_timezone: \"America/New_York\"` — verify timezone persists, `now_local` and `now_human` populate, `timezone_refresh_due: false`
- [ ] Pass `client_timezone` to `remember_journal` / `remember_user_journal` / etc. — verify the cache updates from any endpoint, not just briefing
- [ ] Backdate `timezone_fetched_at` to >4h ago — next response from any endpoint flags `timezone_refresh_due: true`
- [ ] /settings: enter timezone manually — `timezone_fetched_at` is stamped (next briefing should not flag refresh)
- [ ] Call `remember_journal action=write` without `ai_hive_journal_book_id` set — verify error response includes `error.fix` with the correct MCP call to fix it
- [ ] Call any successful remember tool while pending fields exist — verify `meta.setup_incomplete: true`, `meta.setup_summary` lists pending fields, and `meta.time` carries the current local time

🤖 Generated with [Claude Code](https://claude.com/claude-code)