### PR TITLE
v0.7.4 cleanup: artifact gating + chunk trim + doc sync

### DIFF
--- a/.github/workflows/generate-artifacts.yml
+++ b/.github/workflows/generate-artifacts.yml
@@ -1,31 +1,45 @@
 name: Generate Repo Artifacts
 
+# Regenerates SBOM.md and STRUCTURE.md and commits any diff back to the PR
+# source branch. Fires on the same trigger family as the image build:
+# `pull_request: opened/synchronize/reopened` against development or release.
+# That way the regenerated artifacts are part of the PR being reviewed/merged
+# — not retroactively dropped onto development after the fact.
+#
+# The auto-commit uses `[skip ci]` to avoid a trigger loop. It will not
+# re-fire either this workflow or `release.yml`.
+#
+# For external fork PRs, GITHUB_TOKEN cannot push back to the fork; the
+# job is skipped in that case (the contributor regenerates locally).
+
 on:
-  push:
-    branches:
-      - development
-      - release
+  pull_request:
+    branches: [development, release]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - 'SBOM.md'
       - 'STRUCTURE.md'
-  schedule:
-    # Weekly refresh catches upstream license/version metadata changes
-    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  group: artifacts-${{ github.ref }}
+  group: artifacts-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   generate:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          # PR triggers: check out the PR head so the auto-commit lands on
+          # the PR source branch. Other triggers fall back to the workflow ref.
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install tooling
         run: sudo apt-get install -y tree jq

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,31 @@
 name: Build and Release
 
+# Artifact-before-merge model:
+#
+#   1. PR opened/updated against development or release  ->  `build` jobs
+#      build & push images tagged with the PR's branch slug. This is the
+#      artifact the merge gate requires. The PR cannot merge until both
+#      builds succeed (enforced via branch protection: require status checks
+#      "build-server" and "build-embedder").
+#
+#   2. PR merged                                          ->  `promote` job
+#      retags the existing per-PR image as the appropriate stream tag
+#      (`dev`/`{version}-dev` for development merges; `{version}`/`release`/
+#      `latest` for release merges). No rebuild — the merge commit shares
+#      the source tree of the PR head.
+#
+#   3. PR merged into release                             ->  `github-release`
+#      creates a GitHub Release entry with image refs in the body.
+#
+#   4. v* tag push (emergency hotfix path)                ->  `tag-release`
+#      builds & pushes semver-tagged images and creates a GitHub Release.
+#      Prefer the PR-into-release flow above for normal releases.
+
 on:
+  pull_request:
+    branches: [development, release]
+    types: [opened, synchronize, reopened, closed]
   push:
-    branches:
-      - development
-      - release
     tags:
       - 'v*'
 
@@ -12,25 +33,26 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  server:
+  build-server:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract version from Cargo.toml
-        id: version
+      - name: Resolve version + branch slug
+        id: vars
         run: |
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
           SHORT_SHA=${GITHUB_SHA::7}
+          SLUG=$(echo "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
-
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -38,25 +60,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server
-          tags: |
-            # development branch: dev tags
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/development' }}
-            type=raw,value=${{ steps.version.outputs.version }}-dev,enable=${{ github.ref == 'refs/heads/development' }}
-            type=raw,value=${{ steps.version.outputs.version }}-dev-${{ steps.version.outputs.short_sha }},enable=${{ github.ref == 'refs/heads/development' }}
-            # release branch: production tags
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/release' }}
-            type=raw,value=release,enable=${{ github.ref == 'refs/heads/release' }}
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ github.ref == 'refs/heads/release' }}
-            # semver from v* tags
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
 
       - name: Build and push server image
         uses: docker/build-push-action@v6
@@ -65,30 +68,192 @@ jobs:
           file: docker/Dockerfile.server
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.slug }}-${{ steps.vars.outputs.short_sha }}
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.slug }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
           cache-from: type=gha,scope=server
           cache-to: type=gha,mode=max,scope=server
 
-  embedder:
+  build-embedder:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract version from Cargo.toml
-        id: version
+      - name: Resolve version + branch slug
+        id: vars
         run: |
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
           SHORT_SHA=${GITHUB_SHA::7}
+          SLUG=$(echo "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
 
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push embedder image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.embedder
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.slug }}-${{ steps.vars.outputs.short_sha }}
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.slug }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          cache-from: type=gha,scope=embedder
+          cache-to: type=gha,mode=max,scope=embedder
+
+  promote:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version + branch slug
+        id: vars
+        run: |
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
+          SLUG=$(echo "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
+          echo "base_ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag for development merges
+        if: steps.vars.outputs.base_ref == 'development'
+        run: |
+          for IMAGE in bsmcp-server bsmcp-embedder; do
+            SRC="${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.slug }}"
+            docker buildx imagetools create \
+              --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:dev" \
+              --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${{ steps.vars.outputs.version }}-dev" \
+              "$SRC"
+          done
+
+      - name: Retag for release merges
+        if: steps.vars.outputs.base_ref == 'release'
+        run: |
+          for IMAGE in bsmcp-server bsmcp-embedder; do
+            SRC="${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.slug }}"
+            docker buildx imagetools create \
+              --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${{ steps.vars.outputs.version }}" \
+              --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:release" \
+              --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:latest" \
+              "$SRC"
+          done
+
+  github-release-on-merge:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'release'
+    needs: [promote]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version + tag
+        id: vars
+        run: |
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
+          TAG="v${VERSION}"
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+            NEEDS_TAG=false
+          else
+            NEEDS_TAG=true
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "needs_tag=${NEEDS_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: steps.vars.outputs.needs_tag == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.vars.outputs.tag }}" -m "Release ${{ steps.vars.outputs.tag }}"
+          git push origin "${{ steps.vars.outputs.tag }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: bookstack-mcp ${{ steps.vars.outputs.tag }}
+          tag_name: ${{ steps.vars.outputs.tag }}
+          generate_release_notes: true
+          body: |
+            ## Container images
+
+            ```
+            docker pull ghcr.io/bees-roadhouse/bsmcp-server:${{ steps.vars.outputs.version }}
+            docker pull ghcr.io/bees-roadhouse/bsmcp-embedder:${{ steps.vars.outputs.version }}
+            ```
+
+            Or pin to the rolling release tag:
+
+            ```
+            docker pull ghcr.io/bees-roadhouse/bsmcp-server:release
+            docker pull ghcr.io/bees-roadhouse/bsmcp-embedder:release
+            ```
+
+  tag-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - image: bsmcp-server
+            dockerfile: docker/Dockerfile.server
+            scope: server
+          - image: bsmcp-embedder
+            dockerfile: docker/Dockerfile.embedder
+            scope: embedder
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify tag matches manifest version
+        id: vars
+        run: |
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$TAG_VERSION" != "$VERSION" ]]; then
+            echo "::error::Tag $TAG_VERSION does not match Cargo.toml version $VERSION"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -101,29 +266,51 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder
+          images: ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}
           tags: |
-            # development branch: dev tags
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/development' }}
-            type=raw,value=${{ steps.version.outputs.version }}-dev,enable=${{ github.ref == 'refs/heads/development' }}
-            type=raw,value=${{ steps.version.outputs.version }}-dev-${{ steps.version.outputs.short_sha }},enable=${{ github.ref == 'refs/heads/development' }}
-            # release branch: production tags
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/release' }}
-            type=raw,value=release,enable=${{ github.ref == 'refs/heads/release' }}
-            type=raw,value=${{ steps.version.outputs.version }},enable=${{ github.ref == 'refs/heads/release' }}
-            # semver from v* tags
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
-      - name: Build and push embedder image
+      - name: Build and push tagged image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/Dockerfile.embedder
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=embedder
-          cache-to: type=gha,mode=max,scope=embedder
+          cache-from: type=gha,scope=${{ matrix.scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.scope }}
+
+  github-release-on-tag:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [tag-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: vars
+        run: |
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: bookstack-mcp ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          body: |
+            ## Container images
+
+            ```
+            docker pull ghcr.io/bees-roadhouse/bsmcp-server:${{ steps.vars.outputs.version }}
+            docker pull ghcr.io/bees-roadhouse/bsmcp-embedder:${{ steps.vars.outputs.version }}
+            ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Rust MCP server that bridges Claude to a BookStack instance via SSE and Streamable HTTP transports. Organized as a Cargo workspace with pluggable database backends and a separate embedder service.
 
+> Build, branching, CI/CD, versioning, and contributor workflow live in [DEVELOPMENT.md](DEVELOPMENT.md). This file is the architectural map and project-shape context for AI agents working in the codebase.
+
 ## Architecture
 
 ```
@@ -194,7 +196,6 @@ Used by `remember_identity action=list`, `remember_directory`, and the settings 
 - **User/Role CRUD** - Creating/deleting users/roles is admin-level; read-only is sufficient.
 - **PDF/ZIP export** - Binary formats can't be returned as MCP text content.
 
-
 ## Adding a New Tool
 
 1. **bookstack.rs** - Add the API method(s) to `BookStackClient`
@@ -220,55 +221,6 @@ The server implements OAuth 2.1 (authorization code + PKCE) with a browser-based
 1. **Form-based (primary):** Claude opens /authorize → user enters BookStack API token → server validates → stores credentials with auth code → redirects → code exchange issues access token.
 2. **Legacy Bearer:** `Authorization: Bearer token_id:token_secret` on SSE/messages endpoints (Claude Code direct connection).
 
-## Building
-
-```bash
-# Local build (both binaries)
-cargo build --release
-
-# Individual
-cargo build --release -p bsmcp-server
-cargo build --release -p bsmcp-embedder
-
-# Multi-arch Docker
-docker buildx build --builder multiarch --platform linux/amd64,linux/arm64 \
-  -f docker/Dockerfile.server \
-  -t ghcr.io/bees-roadhouse/bsmcp-server:VERSION --push .
-
-docker buildx build --builder multiarch --platform linux/amd64,linux/arm64 \
-  -f docker/Dockerfile.embedder \
-  -t ghcr.io/bees-roadhouse/bsmcp-embedder:VERSION --push .
-```
-
-Images:
-- `ghcr.io/bees-roadhouse/bsmcp-server` — MCP server (~35MB)
-- `ghcr.io/bees-roadhouse/bsmcp-embedder` — Embedder with ONNX (~45MB)
-
-## Docker Compose
-
-Two deployment options:
-
-- `docker/docker-compose.yml` — PostgreSQL (bsmcp-postgres + bsmcp-server + bsmcp-embedder)
-- `docker/docker-compose.sqlite.yml` — SQLite (bsmcp-server + bsmcp-embedder sharing a file)
-
-## Migration
-
-**SQLite → PostgreSQL auto-migration:** When `BSMCP_DB_BACKEND=postgres` and a SQLite DB exists at `BSMCP_DB_PATH`, the server auto-migrates on startup and renames the file to `.db.migrated`.
-
-**Manual migration:**
-```bash
-bsmcp-server migrate --from-sqlite /path/to/db --to-postgres postgres://user:pass@host/db
-```
-
-Migrates: access_tokens, pages, chunks (BLOB→pgvector), relationships, embed_jobs. Validates row counts.
-
-## Branch Info
-
-- `development` - default branch, active work lands here
-- `release` - stable/production branch, merged from development when ready
-- `enhancement/{name}` - branched from development for new functionality
-- `problem/{name}` - branched from development for bug fixes
-
 ## Breaking Changes Log
 
 ### v0.3.0 (from v0.2.x)
@@ -282,16 +234,3 @@ Migrates: access_tokens, pages, chunks (BLOB→pgvector), relationships, embed_j
 - `BSMCP_PUBLIC_URL` removed, replaced by `BSMCP_PUBLIC_DOMAIN` (domain only, not full URL)
 - Docker volume renamed `mcp-data` → `bsmcp-data` — data migration needed
 - OAuth now enforces PKCE (S256)
-
-## Git Workflow
-
-**Branching Model:**
-* `development` — default branch (HEAD), active work lands here
-* `release` — stable/production branch, merged from development when ready
-* `enhancement/{name}` — branched from development for new functionality
-* `problem/{name}` — branched from development for bug fixes and issue resolution
-* No `main` or `master` branches
-
-**GitHub Issues & Labels:**
-* New functionality uses the **enhancement** label, not "feature"
-* Configure repository labels accordingly

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,25 +52,39 @@ docker compose -f docker/docker-compose.sqlite.yml up -d
 
 ## Branching
 
-- `development` — default branch; all PRs land here
-- `release` — stable/production; merged from development when ready to ship
-- `enhancement/{name}` — branched from development for new functionality
-- `problem/{name}` — branched from development for bug fixes
+The canonical reference for the org-wide branching standard is the [Branching Strategy](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) page in the Bee's Roadhouse DevOps book. This file mirrors the policy that applies to this repo specifically.
+
+- `development` — default branch; all active work lands here. Direct pushes are **authorized** (small touchups, scaffolding, emergency hotfixes). Pushes trigger CI build/package.
+- `release` — stable/production; merged from development when ready to ship. The **only** protected branch (org-level ruleset blocks force-push and deletion; PR required).
+- Work branches use the four-prefix taxonomy below.
 
 No `main` or `master` branches exist.
+
+### Work branch prefixes
+
+| Prefix | Use for | GitHub labels | Default semver bump | Example |
+|--------|---------|---------------|---------------------|---------|
+| `feature/{name}` | New capability that didn't exist | `type:enhancement` + `category:feature` | minor | `feature/export-api` |
+| `improvement/{name}` | Existing capability, done better | `type:enhancement` + `category:improvement` | minor | `improvement/search-relevance` |
+| `refactor/{name}` | Design or structure redo | `type:problem` + `category:refactor` | patch (or minor if external behavior changes) | `refactor/auth-flow` |
+| `bug/{name}` | Implementation mistake, something broken | `type:problem` + `category:bug` | patch | `bug/oauth-token-refresh` |
+
+Breaking changes are orthogonal to type — prefix the **PR title** with `BREAKING:` regardless of the branch prefix to force a major-version bump.
 
 ### Workflow
 
 ```
 1. git checkout development && git pull
-2. git checkout -b enhancement/my-feature   (or problem/my-fix)
-3. ... commit work ...
-4. git push -u origin enhancement/my-feature
-5. Open PR against development
-6. CI builds artifact (see CI/CD below) — PR cannot merge until it succeeds
+2. git checkout -b improvement/my-change      # or feature/, refactor/, bug/
+3. ... commit work (signed via SSH; see Commit Signing below) ...
+4. git push -u origin improvement/my-change
+5. Open PR against development; apply the matching type: + category: labels
+6. CI builds artifact + regenerates SBOM/STRUCTURE on the PR source branch (see CI/CD below)
 7. Squash-merge PR into development; delete the work branch
 8. When ready to ship: open PR from development -> release
 ```
+
+Direct pushes to `development` stay available — use them for small atomic changes, scaffolding, or emergency hotfixes. The PR flow is the team norm for anything else.
 
 ## CI/CD
 
@@ -116,20 +130,32 @@ Images are published to `ghcr.io/bees-roadhouse/bsmcp-server` and `ghcr.io/bees-
 
 ### Branch protection
 
-`development` and `release` require:
-- PR (no direct push)
-- Status checks `build-server` and `build-embedder` must pass before merge
-- Squash merges only
+Protection lives at the **organization level** via a GitHub Ruleset (`Release Branch Protection`) targeting `refs/heads/release` on every repo in `bees-roadhouse`:
 
-The required checks are what enforce "artifact must exist before merge". Configure these in **Settings → Branches → Branch protection rules**.
+- `pull_request` (0 required approvals — the gate is CI status, not approver count)
+- `non_fast_forward` (blocks force-push)
+- `deletion` (blocks branch delete)
+
+`development` is **intentionally unprotected** — direct pushes stay authorized so scaffolding, hotfixes, and small atomic changes don't get stuck in PR ceremony. CI runs on every push regardless, so regressions are still caught.
+
+Required status checks (`build-server`, `build-embedder`) gate the merge into `release` once the PR is open. The artifact-before-merge invariant comes from those checks plus the PR-source-branch trigger, not from blocking direct pushes.
+
+### Commit signing
+
+Every commit must be signed via SSH using 1Password's SSH agent. See the [Commit Signing](https://kb.beesroadhouse.com/books/developer-operations-devops/page/commit-signing) page in the DevOps book for full configuration.
 
 ## Versioning
 
 Semantic versioning (`MAJOR.MINOR.PATCH`). Version lives in workspace `Cargo.toml`.
 
-- `enhancement/*` merge to development -> bump minor in the PR
-- `problem/*` merge to development -> bump patch in the PR
-- Release: open PR from development -> release. The release-merge promote job retags with the current `{version}` and creates the GitHub Release.
+Default semver bump per branch prefix (override with `BREAKING:` in the PR title for a major bump):
+
+- `feature/*` — minor
+- `improvement/*` — minor
+- `refactor/*` — patch (minor if external behavior changes)
+- `bug/*` — patch
+
+Release: open PR from development -> release. The release-merge promote job retags with the current `{version}` and creates the GitHub Release.
 
 ## Testing
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,7 @@
 # Development
 
+How to build, test, and ship changes to `bookstack-mcp`. This document is the contributor entry point — README is the user-facing project overview, this file is for engineers.
+
 ## Prerequisites
 
 - Rust toolchain (stable)
@@ -50,40 +52,84 @@ docker compose -f docker/docker-compose.sqlite.yml up -d
 
 ## Branching
 
-- `development` ... default branch, active work lands here
-- `release` ... stable/production, merged from development when ready
-- `enhancement/{name}` ... new functionality, branched from development
-- `problem/{name}` ... bug fixes, branched from development
+- `development` — default branch; all PRs land here
+- `release` — stable/production; merged from development when ready to ship
+- `enhancement/{name}` — branched from development for new functionality
+- `problem/{name}` — branched from development for bug fixes
+
+No `main` or `master` branches exist.
 
 ### Workflow
 
 ```
-1. git checkout development
+1. git checkout development && git pull
 2. git checkout -b enhancement/my-feature   (or problem/my-fix)
 3. ... commit work ...
 4. git push -u origin enhancement/my-feature
-5. Merge to development (PR optional for solo work)
-6. Delete work branch
-7. When ready for production: merge development into release
+5. Open PR against development
+6. CI builds artifact (see CI/CD below) — PR cannot merge until it succeeds
+7. Squash-merge PR into development; delete the work branch
+8. When ready to ship: open PR from development -> release
 ```
 
 ## CI/CD
 
-GitHub Actions builds Docker images when code is merged to `development` or `release`. Since `development` requires PRs (branch protection), the `push` trigger only fires on PR merges.
+**Artifact-before-merge.** Both the Docker images and the SBOM/STRUCTURE doc artifacts are generated on every push to the PR source branch — *before* the merge happens. The PR cannot merge until those builds succeed (enforced via branch protection on `development` and `release`).
 
-- Push to `development` (PR merge) ... tags image as `dev`, `{version}-dev`, and `{version}-dev-{sha}`
-- Push to `release` (merge from development) ... tags image as `latest`, `release`, and `{version}`
-- Push `v*` tag ... adds immutable semver tags (`x.y.z`, `x.y`, `x`)
+This is the inversion of the legacy "build on push to development" model: artifacts are part of the gate, not a side effect of merging.
+
+### What runs on what
+
+| Event | Workflow | What happens |
+|-------|----------|-------------|
+| Push to a work branch with **no open PR** | nothing | test locally |
+| `pull_request: opened/synchronize/reopened` against `development` or `release` | `release.yml` (build jobs) | builds & pushes images tagged `{version}-{branch-slug}-{sha}` (immutable per-commit) and `{version}-{branch-slug}` (rolling per-PR) |
+| Same trigger | `generate-artifacts.yml` | regenerates `SBOM.md` + `STRUCTURE.md`, commits to PR source branch with `[skip ci]` |
+| `pull_request: closed && merged: true`, base = `development` | `release.yml` (promote job) | retags `{version}-{branch-slug}` -> `dev` + `{version}-dev`. No rebuild. |
+| `pull_request: closed && merged: true`, base = `release` | `release.yml` (promote + github-release-on-merge) | retags `{version}-{branch-slug}` -> `{version}` + `release` + `latest`; creates GitHub Release |
+| `v*` tag push (emergency hotfix only) | `release.yml` (tag-release + github-release-on-tag) | builds & pushes semver-tagged images; creates GitHub Release. Prefer the PR-into-release flow above. |
+
+### Why this shape
+
+- **PR-source-branch push, not push-to-development.** A push to a work branch with an open PR is the explicit signal "this is ready for review". A push to development is a merge — it's too late to gate. We want the artifact built on the source so the merge is the no-op it should be.
+- **Retag instead of rebuild on merge.** A squash-merge to development produces a new commit SHA, but its source tree is identical to the PR head. Building it again produces a bit-identical image, so we save the CI minutes and just move the rolling tag.
+- **Per-PR rolling tag (`{version}-{branch-slug}`) survives auto-commits.** If `generate-artifacts.yml` appends a `[skip ci]` commit to the PR, the rolling tag still points at the engineer's last manual SHA. Promote uses the rolling tag, not the PR head SHA.
+- **External fork PRs.** The build jobs run for fork PRs too (forks can open PRs even though they can't push to our repo). The artifact-generate job is skipped for forks because `GITHUB_TOKEN` can't push back to a fork's branch.
+
+### Tag conventions on GHCR
+
+Per-PR (transient, for PR review/testing):
+- `{version}-{branch-slug}-{sha}` — pinnable to one specific commit
+- `{version}-{branch-slug}` — rolling, moves with each PR push
+
+Development stream (after merge to development):
+- `dev` — rolling, latest dev build
+- `{version}-dev` — version-level dev tag
+
+Release stream (after merge to release or `v*` tag):
+- `latest` — rolling, latest release
+- `release` — alias for `latest`
+- `{version}` — pinned semver (e.g., `0.7.4`)
+- `{major}.{minor}`, `{major}` — broader semver pointers (only emitted on `v*` tag push)
 
 Images are published to `ghcr.io/bees-roadhouse/bsmcp-server` and `ghcr.io/bees-roadhouse/bsmcp-embedder` for `linux/amd64` and `linux/arm64`.
+
+### Branch protection
+
+`development` and `release` require:
+- PR (no direct push)
+- Status checks `build-server` and `build-embedder` must pass before merge
+- Squash merges only
+
+The required checks are what enforce "artifact must exist before merge". Configure these in **Settings → Branches → Branch protection rules**.
 
 ## Versioning
 
 Semantic versioning (`MAJOR.MINOR.PATCH`). Version lives in workspace `Cargo.toml`.
 
-- `enhancement/*` merge ... minor bump
-- `problem/*` merge ... patch bump
-- Tag on `release` branch after merging: `git tag v0.7.0 && git push origin --tags`
+- `enhancement/*` merge to development -> bump minor in the PR
+- `problem/*` merge to development -> bump patch in the PR
+- Release: open PR from development -> release. The release-merge promote job retags with the current `{version}` and creates the GitHub Release.
 
 ## Testing
 
@@ -94,7 +140,33 @@ cargo clippy
 
 ## Adding a New Tool
 
-1. Add API method to `BookStackClient` in `crates/bsmcp-common/src/bookstack.rs`
+1. Add API method to `BookStackClient` in `crates/bsmcp-server/src/bookstack.rs`
 2. Add match arm in `execute_tool()` in `crates/bsmcp-server/src/mcp.rs`
 3. Add tool definition in `tool_definitions()` in the same file
 4. Use existing helpers: `arg_str`, `arg_i64`, `arg_i64_required`, `arg_str_default`, `format_json`
+
+## Migration
+
+**SQLite -> PostgreSQL auto-migration:** When `BSMCP_DB_BACKEND=postgres` and a SQLite DB exists at `BSMCP_DB_PATH`, the server auto-migrates on startup and renames the file to `.db.migrated`.
+
+**Manual migration:**
+
+```bash
+bsmcp-server migrate --from-sqlite /path/to/db --to-postgres postgres://user:pass@host/db
+```
+
+Migrates `access_tokens`, `pages`, `chunks` (BLOB -> pgvector), `relationships`, `embed_jobs`. Validates row counts.
+
+## Multi-arch Docker builds (manual)
+
+Normally CI handles this. For local multi-arch testing:
+
+```bash
+docker buildx build --builder multiarch --platform linux/amd64,linux/arm64 \
+  -f docker/Dockerfile.server \
+  -t ghcr.io/bees-roadhouse/bsmcp-server:VERSION --push .
+
+docker buildx build --builder multiarch --platform linux/amd64,linux/arm64 \
+  -f docker/Dockerfile.embedder \
+  -t ghcr.io/bees-roadhouse/bsmcp-embedder:VERSION --push .
+```

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ An MCP (Model Context Protocol) server that gives Claude full access to a [BookS
 
 - Full CRUD on all core BookStack resources (shelves, books, chapters, pages, attachments)
 - Full-text search with BookStack query operators
-- **Semantic vector search** — natural language search across all content via embeddings (optional)
+- **Semantic vector search** — natural language search across all content via embeddings (optional). Hybrid (vector + keyword) with Markov-blanket re-ranking; ACL-filtered when the caller's BookStack user ID is configured.
+- **Hive memory flow (`/remember`)** — server-side reconstitution + memory CRUD that replaces the multi-call AI bootstrap with one structured `briefing` pull. 12 `remember_*` MCP tools cover identity, journals, topics, search, audit, directory, and per-user/global config. Auto-provisions per-user identity + journal structure on first call.
+- **Settings UI (`/settings`)** — browser-based admin/user configuration page (token-gated via the same `/authorize` flow). Pick book/chapter IDs from dropdowns populated by BookStack; toggle semantic-search scopes; one-shot admin-only globals (Hive shelf, User Journals shelf, org identity page, org domains).
 - **Pluggable database** — SQLite for simple deployments, PostgreSQL + pgvector for production
 - **Separate embedder** — background embedding service with pluggable backends (local ONNX, Ollama, OpenAI)
 - **Server-side markdown to HTML conversion** — send markdown, server converts before sending to BookStack
 - **Staging upload flow** — upload local images and attachments through a two-step staging endpoint without exposing local paths to the container ([see below](#uploading-local-files-images--attachments))
+- **Time-aware responses** — every `/remember` response carries a `meta.time` block (now_unix/now_utc/now_local/now_human/timezone) sourced from a per-user cached IANA timezone. Lets agents reason about "yesterday" / "this morning" without re-deriving it.
 - **OAuth 2.1 support** — use as a Claude.ai or Claude Desktop custom connector without config files
 - **Encrypted token storage** — OAuth tokens encrypted at rest with AES-256-GCM
 - **Dual transport** — SSE (MCP 2024-11-05) and Streamable HTTP (MCP 2025-03-26)
@@ -39,7 +42,7 @@ docker/
 
 The MCP server handles all client-facing protocol, OAuth, and search. The embedder runs separately, polling a database-backed job queue to embed pages and serving a `/embed` HTTP endpoint for query-time embedding. The embedder supports three backends: local ONNX models (fastembed), Ollama, or OpenAI-compatible APIs.
 
-## Available Tools (61)
+## Available Tools (61 BookStack + 12 Hive memory = 73)
 
 | Category | Tools |
 |----------|-------|
@@ -51,6 +54,7 @@ The MCP server handles all client-facing protocol, OAuth, and search. The embedd
 | **Pages** | `list_pages`, `get_page`, `create_page`, `update_page`, `delete_page`, `edit_page`, `append_to_page`, `replace_section`, `insert_after` |
 | **Move** | `move_page`, `move_chapter`, `move_book_to_shelf` |
 | **Attachments** | `list_attachments`, `get_attachment`, `create_attachment`, `update_attachment`, `delete_attachment`, `upload_attachment` |
+| **Staging** | `prepare_upload` (used with `upload_image` / `upload_attachment` for local file uploads) |
 | **Exports** | `export_page`, `export_chapter`, `export_book` (markdown, plaintext, html) |
 | **Comments** | `list_comments`, `get_comment`, `create_comment`, `update_comment`, `delete_comment` |
 | **Recycle Bin** | `list_recycle_bin`, `restore_recycle_bin_item`, `destroy_recycle_bin_item` |
@@ -60,8 +64,11 @@ The MCP server handles all client-facing protocol, OAuth, and search. The embedd
 | **Images** | `list_images`, `get_image`, `upload_image`, `update_image`, `delete_image` |
 | **Permissions** | `get_content_permissions`, `update_content_permissions` |
 | **Roles** | `list_roles`, `get_role` |
+| **Hive memory (`/remember`)** | `remember_briefing`, `remember_whoami`, `remember_user`, `remember_config`, `remember_identity`, `remember_directory`, `remember_journal`, `remember_collage`, `remember_shared_collage`, `remember_user_journal`, `remember_audit`, `remember_search` |
 
-Semantic tools (`semantic_search`, `reembed`, `embedding_status`) only appear when `BSMCP_SEMANTIC_SEARCH=true` and an embedder is running. Without semantic search: 58 tools.
+Semantic tools (`semantic_search`, `reembed`, `embedding_status`) only appear when `BSMCP_SEMANTIC_SEARCH=true` and an embedder is running. Without semantic search: 58 BookStack + 12 Hive = 70 tools.
+
+Hive memory tools require user/global settings. The `remember_briefing` tool returns a `setup_nudge` listing every pending field with the exact MCP call to fix it; configure via the `/settings` UI or `remember_config action=write`.
 
 ## Setup
 
@@ -258,6 +265,57 @@ The token ID and secret come from your BookStack API token (created under **My A
 ## Upgrading
 
 All schema migrations are automatic on startup (CREATE TABLE IF NOT EXISTS, ALTER TABLE for new columns). No manual SQL is needed.
+
+### From v0.7.3 to v0.7.4 (this release)
+
+#### What's new
+
+- **Briefing payload trimmed** — `*_semantic_matches` entries now cap at 3 chunks of ~100 chars each (kb_semantic_matches: 4 × 150). Truncated chunks carry `truncated: true` and a `…` suffix. A new top-level `semantic_matches_hint` field tells consumers to call `get_page(page_id)` for full content. Briefing responses shrink ~50% in typical use, well under Claude Code's response-size threshold.
+- **`semantic_search` tool trimmed** — same shape, slightly more headroom (5 chunks × ~200 chars). New top-level `hint` field on the tool response.
+- **Shared trim helper** — chunk-truncation logic lives in one place (`semantic::trim_match`), each caller passes its own budget.
+
+#### What's automatic
+
+- No env vars, no schema changes, drop-in.
+
+### From v0.7.2 to v0.7.3
+
+#### What's new
+
+- **`meta.time` block** on every `/remember` response — `now_unix`, `now_utc`, `now_local`, `now_human`, `timezone`, `timezone_source`, `timezone_refresh_due`. Per-user timezone cached server-side; refresh by passing `client_timezone` (IANA name) on any `remember_*` call.
+- **Actionable setup errors** — `settings_not_configured` errors now carry an `error.fix` block with the exact MCP call to make.
+- **Per-call elapsed timing** exposed in `meta.elapsed_ms`.
+
+### From v0.7.0 to v0.7.2
+
+#### What's new
+
+- **Briefing latency cut** — book-scoped semantic-search candidate filtering, parallel KB fetches, batched DB lookups. `remember_briefing` is significantly faster on instances with large embedded corpora.
+- **`kb_semantic_matches` reshape** — now an envelope `{enabled, reason, detail, results}` so consumers can branch on `enabled` rather than guessing whether an empty list means opt-out vs. zero hits.
+- **Permission ACL filtering** for semantic search — set `bookstack_user_id` in user settings to enable role-based filtering at the candidate-pool layer (much faster than the per-page HTTP fallback).
+- **Per-user identity auto-provisioning** — first call to `remember_user action=read` creates the per-user Identity book + Identity page + journal-agent page if missing, returning what was created in `auto_provisioned`.
+- **Global org settings** — admin-only `org_identity_page_id`, `org_domains`, `org_required_instructions_page_ids`, `org_ai_usage_policy_page_ids` shared across every user on the instance. First-write-wins for the structural IDs.
+- **Owner-only journal pages** — auto-applied content permission lock so journal entries are visible only to the owning agent/user.
+
+### From v0.6.x to v0.7.0
+
+#### What's new
+
+- **`/remember` protocol** — server-side reconstitution + memory CRUD. 12 MCP tools: `remember_briefing`, `remember_whoami`, `remember_user`, `remember_config`, `remember_identity`, `remember_directory`, `remember_journal`, `remember_collage`, `remember_shared_collage`, `remember_user_journal`, `remember_audit`, `remember_search`. HTTP form: `POST /remember/v1/{resource}/{action}`.
+- **`/settings` UI** — browser-based configuration page, token-gated via `/authorize`. Settings session cookie stored server-side (in-memory, 8h TTL).
+- **YAML-frontmatter provenance** — every collection write stamps `written_by`, `ai_identity_ouid`, `user_id`, `written_at`, `trace_id`, `resource`, `key`, `supersedes_page` at the top of the page body. Invisible in BookStack's renderer; readable by tools.
+- **Soft delete** — `remember_*_collection action=delete` prepends `[archived]` to the page name and stamps `deleted: true` in frontmatter rather than hard-deleting.
+- **`remember_audit` log** — server-side audit table, scoped to the calling user, captures every write with trace_id and target_page_id.
+
+### From v0.5.3 to v0.6.x
+
+#### What's new
+
+- **Image upload & file attachment tools** — `upload_image` and `upload_attachment` accept either a `staging_id` (from `prepare_upload`), a public `url`, or BookStack's standard direct-upload form data.
+- **Staging upload flow** — two-step `prepare_upload` → POST file to returned URL → call `upload_image`/`upload_attachment` with the staging ID. Lets containerized servers receive local files without exposing client paths. 5-minute TTL, single-use, 50MB cap.
+- **Move operations** — dedicated `move_page`, `move_chapter`, `move_book_to_shelf` tools (cleaner than the implicit move via update operations).
+- **`embed` parameter** on `upload_image` — auto-appends the uploaded image into the target page's content.
+- **DNS rebinding protection** — reqwest client pins validated DNS addresses to prevent SSRF via DNS rebinding attacks.
 
 ### From v0.5.2 to v0.5.3
 

--- a/README.md
+++ b/README.md
@@ -596,6 +596,10 @@ The reason: Step 2 requires the MCP client to make an outbound HTTP POST to the 
 
 If you're using Claude.ai or Claude Desktop, you can still use `upload_image` with the `url` parameter for files that are already web-accessible, or upload through the BookStack web UI directly.
 
+## Development
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for build instructions, branching model, CI/CD (artifact-before-merge), versioning, and the workflow for adding new tools.
+
 ## License
 
 MIT

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,0 +1,476 @@
+# Software Bill of Materials
+
+_Auto-generated on 2026-04-27 15:50 UTC from commit `0c01607` via `cargo metadata --locked`._
+
+| Package | Version | License | Repository |
+|---------|---------|---------|------------|
+| adler2 | 2.0.1 | 0BSD OR MIT OR Apache-2.0 | https://github.com/oyvindln/adler2 |
+| aead | 0.5.2 | MIT OR Apache-2.0 | https://github.com/RustCrypto/traits |
+| aes | 0.8.4 | MIT OR Apache-2.0 | https://github.com/RustCrypto/block-ciphers |
+| aes-gcm | 0.10.3 | Apache-2.0 OR MIT | https://github.com/RustCrypto/AEADs |
+| ahash | 0.8.12 | MIT OR Apache-2.0 | https://github.com/tkaitchuck/ahash |
+| aho-corasick | 1.1.4 | Unlicense OR MIT | https://github.com/BurntSushi/aho-corasick |
+| aligned | 0.4.3 | MIT OR Apache-2.0 | https://github.com/rust-embedded-community/aligned |
+| aligned-vec | 0.6.4 | MIT | https://github.com/sarah-ek/aligned-vec/ |
+| allocator-api2 | 0.2.21 | MIT OR Apache-2.0 | https://github.com/zakarumych/allocator-api2 |
+| android_system_properties | 0.1.5 | MIT/Apache-2.0 | https://github.com/nical/android_system_properties |
+| anyhow | 1.0.102 | MIT OR Apache-2.0 | https://github.com/dtolnay/anyhow |
+| arbitrary | 1.4.2 | MIT OR Apache-2.0 | https://github.com/rust-fuzz/arbitrary/ |
+| arg_enum_proc_macro | 0.3.4 | MIT | https://github.com/lu-zero/arg_enum_proc_macro |
+| arrayvec | 0.7.6 | MIT OR Apache-2.0 | https://github.com/bluss/arrayvec |
+| as-slice | 0.2.1 | MIT OR Apache-2.0 | https://github.com/japaric/as-slice |
+| async-trait | 0.1.89 | MIT OR Apache-2.0 | https://github.com/dtolnay/async-trait |
+| atoi | 2.0.0 | MIT | https://github.com/pacman82/atoi-rs |
+| atomic-waker | 1.1.2 | Apache-2.0 OR MIT | https://github.com/smol-rs/atomic-waker |
+| autocfg | 1.5.0 | Apache-2.0 OR MIT | https://github.com/cuviper/autocfg |
+| av-scenechange | 0.14.1 | MIT | https://github.com/rust-av/av-scenechange |
+| av1-grain | 0.2.5 | BSD-2-Clause | https://github.com/rust-av/av1-grain |
+| avif-serialize | 0.8.8 | BSD-3-Clause | https://github.com/kornelski/avif-serialize |
+| axum | 0.8.8 | MIT | https://github.com/tokio-rs/axum |
+| axum-core | 0.5.6 | MIT | https://github.com/tokio-rs/axum |
+| base64 | 0.13.1 | MIT/Apache-2.0 | https://github.com/marshallpierce/rust-base64 |
+| base64 | 0.22.1 | MIT OR Apache-2.0 | https://github.com/marshallpierce/rust-base64 |
+| base64ct | 1.8.3 | Apache-2.0 OR MIT | https://github.com/RustCrypto/formats |
+| bit_field | 0.10.3 | Apache-2.0/MIT | https://github.com/phil-opp/rust-bit-field |
+| bitflags | 2.11.0 | MIT OR Apache-2.0 | https://github.com/bitflags/bitflags |
+| bitstream-io | 4.9.0 | MIT/Apache-2.0 | https://github.com/tuffy/bitstream-io |
+| block-buffer | 0.10.4 | MIT OR Apache-2.0 | https://github.com/RustCrypto/utils |
+| built | 0.8.0 | MIT | https://github.com/lukaslueg/built |
+| bumpalo | 3.20.2 | MIT OR Apache-2.0 | https://github.com/fitzgen/bumpalo |
+| bytemuck | 1.25.0 | Zlib OR Apache-2.0 OR MIT | https://github.com/Lokathor/bytemuck |
+| byteorder | 1.5.0 | Unlicense OR MIT | https://github.com/BurntSushi/byteorder |
+| byteorder-lite | 0.1.0 | Unlicense OR MIT | https://github.com/image-rs/byteorder-lite |
+| bytes | 1.11.1 | MIT | https://github.com/tokio-rs/bytes |
+| castaway | 0.2.4 | MIT | https://github.com/sagebind/castaway |
+| cc | 1.2.58 | MIT OR Apache-2.0 | https://github.com/rust-lang/cc-rs |
+| cfg-if | 1.0.4 | MIT OR Apache-2.0 | https://github.com/rust-lang/cfg-if |
+| chrono | 0.4.44 | MIT OR Apache-2.0 | https://github.com/chronotope/chrono |
+| chrono-tz | 0.10.4 | MIT OR Apache-2.0 | https://github.com/chronotope/chrono-tz |
+| cipher | 0.4.4 | MIT OR Apache-2.0 | https://github.com/RustCrypto/traits |
+| color_quant | 1.1.0 | MIT | https://github.com/image-rs/color_quant.git |
+| compact_str | 0.9.0 | MIT | https://github.com/ParkMyCar/compact_str |
+| concurrent-queue | 2.5.0 | Apache-2.0 OR MIT | https://github.com/smol-rs/concurrent-queue |
+| console | 0.15.11 | MIT | https://github.com/console-rs/console |
+| const-oid | 0.9.6 | Apache-2.0 OR MIT | https://github.com/RustCrypto/formats/tree/master/const-oid |
+| core-foundation | 0.9.4 | MIT OR Apache-2.0 | https://github.com/servo/core-foundation-rs |
+| core-foundation | 0.10.1 | MIT OR Apache-2.0 | https://github.com/servo/core-foundation-rs |
+| core-foundation-sys | 0.8.7 | MIT OR Apache-2.0 | https://github.com/servo/core-foundation-rs |
+| core2 | 0.4.0 | Apache-2.0 OR MIT | https://github.com/bbqsrc/core2 |
+| cpufeatures | 0.2.17 | MIT OR Apache-2.0 | https://github.com/RustCrypto/utils |
+| crc | 3.4.0 | MIT OR Apache-2.0 | https://github.com/mrhooray/crc-rs.git |
+| crc-catalog | 2.4.0 | MIT OR Apache-2.0 | https://github.com/akhilles/crc-catalog.git |
+| crc32fast | 1.5.0 | MIT OR Apache-2.0 | https://github.com/srijs/rust-crc32fast |
+| crossbeam-deque | 0.8.6 | MIT OR Apache-2.0 | https://github.com/crossbeam-rs/crossbeam |
+| crossbeam-epoch | 0.9.18 | MIT OR Apache-2.0 | https://github.com/crossbeam-rs/crossbeam |
+| crossbeam-queue | 0.3.12 | MIT OR Apache-2.0 | https://github.com/crossbeam-rs/crossbeam |
+| crossbeam-utils | 0.8.21 | MIT OR Apache-2.0 | https://github.com/crossbeam-rs/crossbeam |
+| crunchy | 0.2.4 | MIT | https://github.com/eira-fransham/crunchy |
+| crypto-common | 0.1.7 | MIT OR Apache-2.0 | https://github.com/RustCrypto/traits |
+| ctr | 0.9.2 | MIT OR Apache-2.0 | https://github.com/RustCrypto/block-modes |
+| darling | 0.20.11 | MIT | https://github.com/TedDriggs/darling |
+| darling_core | 0.20.11 | MIT | https://github.com/TedDriggs/darling |
+| darling_macro | 0.20.11 | MIT | https://github.com/TedDriggs/darling |
+| dary_heap | 0.3.8 | MIT OR Apache-2.0 | https://github.com/hanmertens/dary_heap |
+| der | 0.7.10 | Apache-2.0 OR MIT | https://github.com/RustCrypto/formats/tree/master/der |
+| der | 0.8.0 | Apache-2.0 OR MIT | https://github.com/RustCrypto/formats |
+| derive_builder | 0.20.2 | MIT OR Apache-2.0 | https://github.com/colin-kiegel/rust-derive-builder |
+| derive_builder_core | 0.20.2 | MIT OR Apache-2.0 | https://github.com/colin-kiegel/rust-derive-builder |
+| derive_builder_macro | 0.20.2 | MIT OR Apache-2.0 | https://github.com/colin-kiegel/rust-derive-builder |
+| digest | 0.10.7 | MIT OR Apache-2.0 | https://github.com/RustCrypto/traits |
+| dirs | 6.0.0 | MIT OR Apache-2.0 | https://github.com/soc/dirs-rs |
+| dirs-sys | 0.5.0 | MIT OR Apache-2.0 | https://github.com/dirs-dev/dirs-sys-rs |
+| displaydoc | 0.2.5 | MIT OR Apache-2.0 | https://github.com/yaahc/displaydoc |
+| dotenvy | 0.15.7 | MIT | https://github.com/allan2/dotenvy |
+| either | 1.15.0 | MIT OR Apache-2.0 | https://github.com/rayon-rs/either |
+| encode_unicode | 1.0.0 | Apache-2.0 OR MIT | https://github.com/tormol/encode_unicode |
+| encoding_rs | 0.8.35 | (Apache-2.0 OR MIT) AND BSD-3-Clause | https://github.com/hsivonen/encoding_rs |
+| equator | 0.4.2 | MIT | https://github.com/sarah-ek/equator/ |
+| equator-macro | 0.4.2 | MIT | https://github.com/sarah-ek/equator/ |
+| equivalent | 1.0.2 | Apache-2.0 OR MIT | https://github.com/indexmap-rs/equivalent |
+| errno | 0.3.14 | MIT OR Apache-2.0 | https://github.com/lambda-fairy/rust-errno |
+| esaxx-rs | 0.1.10 | Apache-2.0 | https://github.com/Narsil/esaxx-rs |
+| etcetera | 0.8.0 | MIT OR Apache-2.0 | https://github.com/lunacookies/etcetera |
+| event-listener | 5.4.1 | Apache-2.0 OR MIT | https://github.com/smol-rs/event-listener |
+| exr | 1.74.0 | BSD-3-Clause | https://github.com/johannesvollmer/exrs |
+| fallible-iterator | 0.3.0 | MIT/Apache-2.0 | https://github.com/sfackler/rust-fallible-iterator |
+| fallible-streaming-iterator | 0.1.9 | MIT/Apache-2.0 | https://github.com/sfackler/fallible-streaming-iterator |
+| fastembed | 5.13.0 | Apache-2.0 | https://github.com/Anush008/fastembed-rs |
+| fastrand | 2.3.0 | Apache-2.0 OR MIT | https://github.com/smol-rs/fastrand |
+| fax | 0.2.6 | MIT | https://github.com/pdf-rs/fax |
+| fax_derive | 0.2.0 | MIT | https://github.com/pdf-rs/fax |
+| fdeflate | 0.3.7 | MIT OR Apache-2.0 | https://github.com/image-rs/fdeflate |
+| find-msvc-tools | 0.1.9 | MIT OR Apache-2.0 | https://github.com/rust-lang/cc-rs |
+| flate2 | 1.1.9 | MIT OR Apache-2.0 | https://github.com/rust-lang/flate2-rs |
+| flume | 0.11.1 | Apache-2.0/MIT | https://github.com/zesterer/flume |
+| fnv | 1.0.7 | Apache-2.0 / MIT | https://github.com/servo/rust-fnv |
+| foldhash | 0.1.5 | Zlib | https://github.com/orlp/foldhash |
+| foldhash | 0.2.0 | Zlib | https://github.com/orlp/foldhash |
+| foreign-types | 0.3.2 | MIT/Apache-2.0 | https://github.com/sfackler/foreign-types |
+| foreign-types-shared | 0.1.1 | MIT/Apache-2.0 | https://github.com/sfackler/foreign-types |
+| form_urlencoded | 1.2.2 | MIT OR Apache-2.0 | https://github.com/servo/rust-url |
+| futures | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/futures-rs |
+| futures-channel | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/futures-rs |
+| futures-core | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/futures-rs |
+| futures-executor | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/futures-rs |
+| futures-intrusive | 0.5.0 | MIT OR Apache-2.0 | https://github.com/Matthias247/futures-intrusive |
+| futures-io | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/futures-rs |
+| futures-macro | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/futures-rs |
+| futures-sink | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/futures-rs |
+| futures-task | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/futures-rs |
+| futures-util | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/futures-rs |
+| generic-array | 0.14.7 | MIT | https://github.com/fizyk20/generic-array.git |
+| getrandom | 0.2.17 | MIT OR Apache-2.0 | https://github.com/rust-random/getrandom |
+| getrandom | 0.3.4 | MIT OR Apache-2.0 | https://github.com/rust-random/getrandom |
+| getrandom | 0.4.2 | MIT OR Apache-2.0 | https://github.com/rust-random/getrandom |
+| ghash | 0.5.1 | Apache-2.0 OR MIT | https://github.com/RustCrypto/universal-hashes |
+| gif | 0.14.1 | MIT OR Apache-2.0 | https://github.com/image-rs/image-gif |
+| h2 | 0.4.13 | MIT | https://github.com/hyperium/h2 |
+| half | 2.7.1 | MIT OR Apache-2.0 | https://github.com/VoidStarKat/half-rs |
+| hashbrown | 0.14.5 | MIT OR Apache-2.0 | https://github.com/rust-lang/hashbrown |
+| hashbrown | 0.15.5 | MIT OR Apache-2.0 | https://github.com/rust-lang/hashbrown |
+| hashbrown | 0.16.1 | MIT OR Apache-2.0 | https://github.com/rust-lang/hashbrown |
+| hashlink | 0.9.1 | MIT OR Apache-2.0 | https://github.com/kyren/hashlink |
+| hashlink | 0.10.0 | MIT OR Apache-2.0 | https://github.com/kyren/hashlink |
+| heck | 0.5.0 | MIT OR Apache-2.0 | https://github.com/withoutboats/heck |
+| hermit-abi | 0.5.2 | MIT OR Apache-2.0 | https://github.com/hermit-os/hermit-rs |
+| hex | 0.4.3 | MIT OR Apache-2.0 | https://github.com/KokaKiwi/rust-hex |
+| hf-hub | 0.4.3 | Apache-2.0 | https://github.com/huggingface/hf-hub |
+| hkdf | 0.12.4 | MIT OR Apache-2.0 | https://github.com/RustCrypto/KDFs/ |
+| hmac | 0.12.1 | MIT OR Apache-2.0 | https://github.com/RustCrypto/MACs |
+| hmac-sha256 | 1.1.14 | ISC | https://github.com/jedisct1/rust-hmac-sha256 |
+| home | 0.5.12 | MIT OR Apache-2.0 | https://github.com/rust-lang/cargo |
+| http | 1.4.0 | MIT OR Apache-2.0 | https://github.com/hyperium/http |
+| http-body | 1.0.1 | MIT | https://github.com/hyperium/http-body |
+| http-body-util | 0.1.3 | MIT | https://github.com/hyperium/http-body |
+| httparse | 1.10.1 | MIT OR Apache-2.0 | https://github.com/seanmonstar/httparse |
+| httpdate | 1.0.3 | MIT OR Apache-2.0 | https://github.com/pyfisch/httpdate |
+| hyper | 1.9.0 | MIT | https://github.com/hyperium/hyper |
+| hyper-rustls | 0.27.7 | Apache-2.0 OR ISC OR MIT | https://github.com/rustls/hyper-rustls |
+| hyper-tls | 0.6.0 | MIT/Apache-2.0 | https://github.com/hyperium/hyper-tls |
+| hyper-util | 0.1.20 | MIT | https://github.com/hyperium/hyper-util |
+| iana-time-zone | 0.1.65 | MIT OR Apache-2.0 | https://github.com/strawlab/iana-time-zone |
+| iana-time-zone-haiku | 0.1.2 | MIT OR Apache-2.0 | https://github.com/strawlab/iana-time-zone |
+| icu_collections | 2.1.1 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| icu_locale_core | 2.1.1 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| icu_normalizer | 2.1.1 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| icu_normalizer_data | 2.1.1 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| icu_properties | 2.1.2 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| icu_properties_data | 2.1.2 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| icu_provider | 2.1.1 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| id-arena | 2.3.0 | MIT/Apache-2.0 | https://github.com/fitzgen/id-arena |
+| ident_case | 1.0.1 | MIT/Apache-2.0 | https://github.com/TedDriggs/ident_case |
+| idna | 1.1.0 | MIT OR Apache-2.0 | https://github.com/servo/rust-url/ |
+| idna_adapter | 1.2.1 | Apache-2.0 OR MIT | https://github.com/hsivonen/idna_adapter |
+| image | 0.25.10 | MIT OR Apache-2.0 | https://github.com/image-rs/image |
+| image-webp | 0.2.4 | MIT OR Apache-2.0 | https://github.com/image-rs/image-webp |
+| imgref | 1.12.0 | CC0-1.0 OR Apache-2.0 | https://github.com/kornelski/imgref |
+| indexmap | 2.13.0 | Apache-2.0 OR MIT | https://github.com/indexmap-rs/indexmap |
+| indicatif | 0.17.11 | MIT | https://github.com/console-rs/indicatif |
+| inout | 0.1.4 | MIT OR Apache-2.0 | https://github.com/RustCrypto/utils |
+| interpolate_name | 0.2.4 | MIT | https://github.com/lu-zero/interpolate_name |
+| ipnet | 2.12.0 | MIT OR Apache-2.0 | https://github.com/krisprice/ipnet |
+| iri-string | 0.7.12 | MIT OR Apache-2.0 | https://github.com/lo48576/iri-string |
+| itertools | 0.14.0 | MIT OR Apache-2.0 | https://github.com/rust-itertools/itertools |
+| itoa | 1.0.18 | MIT OR Apache-2.0 | https://github.com/dtolnay/itoa |
+| jobserver | 0.1.34 | MIT OR Apache-2.0 | https://github.com/rust-lang/jobserver-rs |
+| js-sys | 0.3.93 | MIT OR Apache-2.0 | https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys |
+| lazy_static | 1.5.0 | MIT OR Apache-2.0 | https://github.com/rust-lang-nursery/lazy-static.rs |
+| leb128fmt | 0.1.0 | MIT OR Apache-2.0 | https://github.com/bluk/leb128fmt |
+| lebe | 0.5.3 | BSD-3-Clause | https://github.com/johannesvollmer/lebe |
+| libc | 0.2.183 | MIT OR Apache-2.0 | https://github.com/rust-lang/libc |
+| libfuzzer-sys | 0.4.12 | (MIT OR Apache-2.0) AND NCSA | https://github.com/rust-fuzz/libfuzzer |
+| libm | 0.2.16 | MIT | https://github.com/rust-lang/compiler-builtins |
+| libredox | 0.1.15 | MIT | https://gitlab.redox-os.org/redox-os/libredox.git |
+| libsqlite3-sys | 0.30.1 | MIT | https://github.com/rusqlite/rusqlite |
+| linux-raw-sys | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/sunfishcode/linux-raw-sys |
+| litemap | 0.8.1 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| lock_api | 0.4.14 | MIT OR Apache-2.0 | https://github.com/Amanieu/parking_lot |
+| log | 0.4.29 | MIT OR Apache-2.0 | https://github.com/rust-lang/log |
+| loop9 | 0.1.5 | MIT | https://gitlab.com/kornelski/loop9.git |
+| lzma-rust2 | 0.15.7 | Apache-2.0 | https://github.com/hasenbanck/lzma-rust2/ |
+| macro_rules_attribute | 0.2.2 | Apache-2.0 OR MIT OR Zlib | https://github.com/danielhenrymantilla/macro_rules_attribute-rs |
+| macro_rules_attribute-proc_macro | 0.2.2 | Apache-2.0 OR MIT OR Zlib | https://github.com/danielhenrymantilla/macro_rules_attribute-rs |
+| matchit | 0.8.4 | MIT AND BSD-3-Clause | https://github.com/ibraheemdev/matchit |
+| matrixmultiply | 0.3.10 | MIT/Apache-2.0 | https://github.com/bluss/matrixmultiply/ |
+| maybe-rayon | 0.1.1 | MIT | https://github.com/shssoichiro/maybe-rayon |
+| md-5 | 0.10.6 | MIT OR Apache-2.0 | https://github.com/RustCrypto/hashes |
+| memchr | 2.8.0 | Unlicense OR MIT | https://github.com/BurntSushi/memchr |
+| mime | 0.3.17 | MIT OR Apache-2.0 | https://github.com/hyperium/mime |
+| mime_guess | 2.0.5 | MIT | https://github.com/abonander/mime_guess |
+| minimal-lexical | 0.2.1 | MIT/Apache-2.0 | https://github.com/Alexhuszagh/minimal-lexical |
+| miniz_oxide | 0.8.9 | MIT OR Zlib OR Apache-2.0 | https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide |
+| mio | 1.2.0 | MIT | https://github.com/tokio-rs/mio |
+| monostate | 0.1.18 | MIT OR Apache-2.0 | https://github.com/dtolnay/monostate |
+| monostate-impl | 0.1.18 | MIT OR Apache-2.0 | https://github.com/dtolnay/monostate |
+| moxcms | 0.8.1 | BSD-3-Clause OR Apache-2.0 | https://github.com/awxkee/moxcms.git |
+| multer | 3.1.0 | MIT | https://github.com/rwf2/multer |
+| native-tls | 0.2.18 | MIT OR Apache-2.0 | https://github.com/rust-native-tls/rust-native-tls |
+| ndarray | 0.17.2 | MIT OR Apache-2.0 | https://github.com/rust-ndarray/ndarray |
+| new_debug_unreachable | 1.0.6 | MIT | https://github.com/mbrubeck/rust-debug-unreachable |
+| nom | 7.1.3 | MIT | https://github.com/Geal/nom |
+| nom | 8.0.0 | MIT | https://github.com/rust-bakery/nom |
+| noop_proc_macro | 0.3.0 | MIT | https://github.com/lu-zero/noop_proc_macro |
+| num-bigint | 0.4.6 | MIT OR Apache-2.0 | https://github.com/rust-num/num-bigint |
+| num-bigint-dig | 0.8.6 | MIT/Apache-2.0 | https://github.com/dignifiedquire/num-bigint |
+| num-complex | 0.4.6 | MIT OR Apache-2.0 | https://github.com/rust-num/num-complex |
+| num-derive | 0.4.2 | MIT OR Apache-2.0 | https://github.com/rust-num/num-derive |
+| num-integer | 0.1.46 | MIT OR Apache-2.0 | https://github.com/rust-num/num-integer |
+| num-iter | 0.1.45 | MIT OR Apache-2.0 | https://github.com/rust-num/num-iter |
+| num-rational | 0.4.2 | MIT OR Apache-2.0 | https://github.com/rust-num/num-rational |
+| num-traits | 0.2.19 | MIT OR Apache-2.0 | https://github.com/rust-num/num-traits |
+| num_cpus | 1.17.0 | MIT OR Apache-2.0 | https://github.com/seanmonstar/num_cpus |
+| number_prefix | 0.4.0 | MIT | https://github.com/ogham/rust-number-prefix |
+| once_cell | 1.21.4 | MIT OR Apache-2.0 | https://github.com/matklad/once_cell |
+| onig | 6.5.1 | MIT | https://github.com/iwillspeak/rust-onig |
+| onig_sys | 69.9.1 | MIT | https://github.com/iwillspeak/rust-onig |
+| opaque-debug | 0.3.1 | MIT OR Apache-2.0 | https://github.com/RustCrypto/utils |
+| openssl | 0.10.76 | Apache-2.0 | https://github.com/rust-openssl/rust-openssl |
+| openssl-macros | 0.1.1 | MIT/Apache-2.0 | - |
+| openssl-probe | 0.2.1 | MIT OR Apache-2.0 | https://github.com/rustls/openssl-probe |
+| openssl-sys | 0.9.112 | MIT | https://github.com/rust-openssl/rust-openssl |
+| option-ext | 0.2.0 | MPL-2.0 | https://github.com/soc/option-ext.git |
+| ort | 2.0.0-rc.11 | MIT OR Apache-2.0 | https://github.com/pykeio/ort |
+| ort-sys | 2.0.0-rc.11 | MIT OR Apache-2.0 | https://github.com/pykeio/ort |
+| parking | 2.2.1 | Apache-2.0 OR MIT | https://github.com/smol-rs/parking |
+| parking_lot | 0.12.5 | MIT OR Apache-2.0 | https://github.com/Amanieu/parking_lot |
+| parking_lot_core | 0.9.12 | MIT OR Apache-2.0 | https://github.com/Amanieu/parking_lot |
+| paste | 1.0.15 | MIT OR Apache-2.0 | https://github.com/dtolnay/paste |
+| pastey | 0.1.1 | MIT OR Apache-2.0 | https://github.com/as1100k/pastey |
+| pem-rfc7468 | 0.7.0 | Apache-2.0 OR MIT | https://github.com/RustCrypto/formats/tree/master/pem-rfc7468 |
+| pem-rfc7468 | 1.0.0 | Apache-2.0 OR MIT | https://github.com/RustCrypto/formats |
+| percent-encoding | 2.3.2 | MIT OR Apache-2.0 | https://github.com/servo/rust-url/ |
+| pgvector | 0.4.1 | MIT OR Apache-2.0 | https://github.com/pgvector/pgvector-rust |
+| phf | 0.12.1 | MIT | https://github.com/rust-phf/rust-phf |
+| phf_shared | 0.12.1 | MIT | https://github.com/rust-phf/rust-phf |
+| pin-project-lite | 0.2.17 | Apache-2.0 OR MIT | https://github.com/taiki-e/pin-project-lite |
+| pkcs1 | 0.7.5 | Apache-2.0 OR MIT | https://github.com/RustCrypto/formats/tree/master/pkcs1 |
+| pkcs8 | 0.10.2 | Apache-2.0 OR MIT | https://github.com/RustCrypto/formats/tree/master/pkcs8 |
+| pkg-config | 0.3.32 | MIT OR Apache-2.0 | https://github.com/rust-lang/pkg-config-rs |
+| plain | 0.2.3 | MIT/Apache-2.0 | https://github.com/randomites/plain |
+| png | 0.18.1 | MIT OR Apache-2.0 | https://github.com/image-rs/image-png |
+| polyval | 0.6.2 | Apache-2.0 OR MIT | https://github.com/RustCrypto/universal-hashes |
+| portable-atomic | 1.13.1 | Apache-2.0 OR MIT | https://github.com/taiki-e/portable-atomic |
+| portable-atomic-util | 0.2.6 | Apache-2.0 OR MIT | https://github.com/taiki-e/portable-atomic-util |
+| potential_utf | 0.1.4 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| ppv-lite86 | 0.2.21 | MIT OR Apache-2.0 | https://github.com/cryptocorrosion/cryptocorrosion |
+| prettyplease | 0.2.37 | MIT OR Apache-2.0 | https://github.com/dtolnay/prettyplease |
+| proc-macro2 | 1.0.106 | MIT OR Apache-2.0 | https://github.com/dtolnay/proc-macro2 |
+| profiling | 1.0.17 | MIT OR Apache-2.0 | https://github.com/aclysma/profiling |
+| profiling-procmacros | 1.0.17 | MIT OR Apache-2.0 | https://github.com/aclysma/profiling |
+| pulldown-cmark | 0.12.2 | MIT | https://github.com/raphlinus/pulldown-cmark |
+| pulldown-cmark-escape | 0.11.0 | MIT | https://github.com/raphlinus/pulldown-cmark |
+| pxfm | 0.1.28 | BSD-3-Clause OR Apache-2.0 | https://github.com/awxkee/pxfm |
+| qoi | 0.4.1 | MIT/Apache-2.0 | https://github.com/aldanor/qoi-rust |
+| quick-error | 2.0.1 | MIT/Apache-2.0 | http://github.com/tailhook/quick-error |
+| quote | 1.0.45 | MIT OR Apache-2.0 | https://github.com/dtolnay/quote |
+| r-efi | 5.3.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later | https://github.com/r-efi/r-efi |
+| r-efi | 6.0.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later | https://github.com/r-efi/r-efi |
+| rand | 0.8.5 | MIT OR Apache-2.0 | https://github.com/rust-random/rand |
+| rand | 0.9.2 | MIT OR Apache-2.0 | https://github.com/rust-random/rand |
+| rand_chacha | 0.3.1 | MIT OR Apache-2.0 | https://github.com/rust-random/rand |
+| rand_chacha | 0.9.0 | MIT OR Apache-2.0 | https://github.com/rust-random/rand |
+| rand_core | 0.6.4 | MIT OR Apache-2.0 | https://github.com/rust-random/rand |
+| rand_core | 0.9.5 | MIT OR Apache-2.0 | https://github.com/rust-random/rand |
+| rav1e | 0.8.1 | BSD-2-Clause | https://github.com/xiph/rav1e/ |
+| ravif | 0.13.0 | BSD-3-Clause | https://github.com/kornelski/cavif-rs |
+| rawpointer | 0.2.1 | MIT/Apache-2.0 | https://github.com/bluss/rawpointer/ |
+| rayon | 1.11.0 | MIT OR Apache-2.0 | https://github.com/rayon-rs/rayon |
+| rayon-cond | 0.4.0 | Apache-2.0/MIT | https://github.com/cuviper/rayon-cond |
+| rayon-core | 1.13.0 | MIT OR Apache-2.0 | https://github.com/rayon-rs/rayon |
+| redox_syscall | 0.5.18 | MIT | https://gitlab.redox-os.org/redox-os/syscall |
+| redox_syscall | 0.7.3 | MIT | https://gitlab.redox-os.org/redox-os/syscall |
+| redox_users | 0.5.2 | MIT | https://gitlab.redox-os.org/redox-os/users |
+| regex | 1.12.3 | MIT OR Apache-2.0 | https://github.com/rust-lang/regex |
+| regex-automata | 0.4.14 | MIT OR Apache-2.0 | https://github.com/rust-lang/regex |
+| regex-syntax | 0.8.10 | MIT OR Apache-2.0 | https://github.com/rust-lang/regex |
+| reqwest | 0.12.28 | MIT OR Apache-2.0 | https://github.com/seanmonstar/reqwest |
+| rgb | 0.8.53 | MIT | https://github.com/kornelski/rust-rgb |
+| ring | 0.17.14 | Apache-2.0 AND ISC | https://github.com/briansmith/ring |
+| rsa | 0.9.10 | MIT OR Apache-2.0 | https://github.com/RustCrypto/RSA |
+| rusqlite | 0.32.1 | MIT | https://github.com/rusqlite/rusqlite |
+| rustix | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/rustix |
+| rustls | 0.23.37 | Apache-2.0 OR ISC OR MIT | https://github.com/rustls/rustls |
+| rustls-pki-types | 1.14.0 | MIT OR Apache-2.0 | https://github.com/rustls/pki-types |
+| rustls-webpki | 0.103.10 | ISC | https://github.com/rustls/webpki |
+| rustversion | 1.0.22 | MIT OR Apache-2.0 | https://github.com/dtolnay/rustversion |
+| ryu | 1.0.23 | Apache-2.0 OR BSL-1.0 | https://github.com/dtolnay/ryu |
+| safetensors | 0.7.0 | Apache-2.0 | https://github.com/huggingface/safetensors |
+| schannel | 0.1.29 | MIT | https://github.com/steffengy/schannel-rs |
+| scopeguard | 1.2.0 | MIT OR Apache-2.0 | https://github.com/bluss/scopeguard |
+| security-framework | 3.7.0 | MIT OR Apache-2.0 | https://github.com/kornelski/rust-security-framework |
+| security-framework-sys | 2.17.0 | MIT OR Apache-2.0 | https://github.com/kornelski/rust-security-framework |
+| semver | 1.0.27 | MIT OR Apache-2.0 | https://github.com/dtolnay/semver |
+| serde | 1.0.228 | MIT OR Apache-2.0 | https://github.com/serde-rs/serde |
+| serde_core | 1.0.228 | MIT OR Apache-2.0 | https://github.com/serde-rs/serde |
+| serde_derive | 1.0.228 | MIT OR Apache-2.0 | https://github.com/serde-rs/serde |
+| serde_json | 1.0.149 | MIT OR Apache-2.0 | https://github.com/serde-rs/json |
+| serde_path_to_error | 0.1.20 | MIT OR Apache-2.0 | https://github.com/dtolnay/path-to-error |
+| serde_urlencoded | 0.7.1 | MIT/Apache-2.0 | https://github.com/nox/serde_urlencoded |
+| sha1 | 0.10.6 | MIT OR Apache-2.0 | https://github.com/RustCrypto/hashes |
+| sha2 | 0.10.9 | MIT OR Apache-2.0 | https://github.com/RustCrypto/hashes |
+| shlex | 1.3.0 | MIT OR Apache-2.0 | https://github.com/comex/rust-shlex |
+| signal-hook-registry | 1.4.8 | MIT OR Apache-2.0 | https://github.com/vorner/signal-hook |
+| signature | 2.2.0 | Apache-2.0 OR MIT | https://github.com/RustCrypto/traits/tree/master/signature |
+| simd-adler32 | 0.3.9 | MIT | https://github.com/mcountryman/simd-adler32 |
+| simd_helpers | 0.1.0 | MIT | https://github.com/lu-zero/simd_helpers |
+| siphasher | 1.0.2 | MIT/Apache-2.0 | https://github.com/jedisct1/rust-siphash |
+| slab | 0.4.12 | MIT | https://github.com/tokio-rs/slab |
+| smallvec | 1.15.1 | MIT OR Apache-2.0 | https://github.com/servo/rust-smallvec |
+| socket2 | 0.6.3 | MIT OR Apache-2.0 | https://github.com/rust-lang/socket2 |
+| socks | 0.3.4 | MIT/Apache-2.0 | https://github.com/sfackler/rust-socks |
+| spin | 0.9.8 | MIT | https://github.com/mvdnes/spin-rs.git |
+| spki | 0.7.3 | Apache-2.0 OR MIT | https://github.com/RustCrypto/formats/tree/master/spki |
+| spm_precompiled | 0.1.4 | Apache-2.0 | https://github.com/huggingface/spm_precompiled |
+| sqlx | 0.8.6 | MIT OR Apache-2.0 | https://github.com/launchbadge/sqlx |
+| sqlx-core | 0.8.6 | MIT OR Apache-2.0 | https://github.com/launchbadge/sqlx |
+| sqlx-macros | 0.8.6 | MIT OR Apache-2.0 | https://github.com/launchbadge/sqlx |
+| sqlx-macros-core | 0.8.6 | MIT OR Apache-2.0 | https://github.com/launchbadge/sqlx |
+| sqlx-mysql | 0.8.6 | MIT OR Apache-2.0 | https://github.com/launchbadge/sqlx |
+| sqlx-postgres | 0.8.6 | MIT OR Apache-2.0 | https://github.com/launchbadge/sqlx |
+| sqlx-sqlite | 0.8.6 | MIT OR Apache-2.0 | https://github.com/launchbadge/sqlx |
+| stable_deref_trait | 1.2.1 | MIT OR Apache-2.0 | https://github.com/storyyeller/stable_deref_trait |
+| static_assertions | 1.1.0 | MIT OR Apache-2.0 | https://github.com/nvzqz/static-assertions-rs |
+| stringprep | 0.1.5 | MIT/Apache-2.0 | https://github.com/sfackler/rust-stringprep |
+| strsim | 0.11.1 | MIT | https://github.com/rapidfuzz/strsim-rs |
+| subtle | 2.6.1 | BSD-3-Clause | https://github.com/dalek-cryptography/subtle |
+| syn | 2.0.117 | MIT OR Apache-2.0 | https://github.com/dtolnay/syn |
+| sync_wrapper | 1.0.2 | Apache-2.0 | https://github.com/Actyx/sync_wrapper |
+| synstructure | 0.13.2 | MIT | https://github.com/mystor/synstructure |
+| system-configuration | 0.7.0 | MIT OR Apache-2.0 | https://github.com/mullvad/system-configuration-rs |
+| system-configuration-sys | 0.6.0 | MIT OR Apache-2.0 | https://github.com/mullvad/system-configuration-rs |
+| tempfile | 3.27.0 | MIT OR Apache-2.0 | https://github.com/Stebalien/tempfile |
+| thiserror | 2.0.18 | MIT OR Apache-2.0 | https://github.com/dtolnay/thiserror |
+| thiserror-impl | 2.0.18 | MIT OR Apache-2.0 | https://github.com/dtolnay/thiserror |
+| tiff | 0.11.3 | MIT | https://github.com/image-rs/image-tiff |
+| tinystr | 0.8.2 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| tinyvec | 1.11.0 | Zlib OR Apache-2.0 OR MIT | https://github.com/Lokathor/tinyvec |
+| tinyvec_macros | 0.1.1 | MIT OR Apache-2.0 OR Zlib | https://github.com/Soveu/tinyvec_macros |
+| tokenizers | 0.22.2 | Apache-2.0 | https://github.com/huggingface/tokenizers |
+| tokio | 1.50.0 | MIT | https://github.com/tokio-rs/tokio |
+| tokio-macros | 2.6.1 | MIT | https://github.com/tokio-rs/tokio |
+| tokio-native-tls | 0.3.1 | MIT | https://github.com/tokio-rs/tls |
+| tokio-rustls | 0.26.4 | MIT OR Apache-2.0 | https://github.com/rustls/tokio-rustls |
+| tokio-stream | 0.1.18 | MIT | https://github.com/tokio-rs/tokio |
+| tokio-util | 0.7.18 | MIT | https://github.com/tokio-rs/tokio |
+| tower | 0.5.3 | MIT | https://github.com/tower-rs/tower |
+| tower-http | 0.6.8 | MIT | https://github.com/tower-rs/tower-http |
+| tower-layer | 0.3.3 | MIT | https://github.com/tower-rs/tower |
+| tower-service | 0.3.3 | MIT | https://github.com/tower-rs/tower |
+| tracing | 0.1.44 | MIT | https://github.com/tokio-rs/tracing |
+| tracing-attributes | 0.1.31 | MIT | https://github.com/tokio-rs/tracing |
+| tracing-core | 0.1.36 | MIT | https://github.com/tokio-rs/tracing |
+| try-lock | 0.2.5 | MIT | https://github.com/seanmonstar/try-lock |
+| typenum | 1.19.0 | MIT OR Apache-2.0 | https://github.com/paholg/typenum |
+| unicase | 2.9.0 | MIT OR Apache-2.0 | https://github.com/seanmonstar/unicase |
+| unicode-bidi | 0.3.18 | MIT OR Apache-2.0 | https://github.com/servo/unicode-bidi |
+| unicode-ident | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 | https://github.com/dtolnay/unicode-ident |
+| unicode-normalization | 0.1.25 | MIT OR Apache-2.0 | https://github.com/unicode-rs/unicode-normalization |
+| unicode-normalization-alignments | 0.1.12 | MIT/Apache-2.0 | https://github.com/n1t0/unicode-normalization |
+| unicode-properties | 0.1.4 | MIT/Apache-2.0 | https://github.com/unicode-rs/unicode-properties |
+| unicode-segmentation | 1.13.2 | MIT OR Apache-2.0 | https://github.com/unicode-rs/unicode-segmentation |
+| unicode-width | 0.2.2 | MIT OR Apache-2.0 | https://github.com/unicode-rs/unicode-width |
+| unicode-xid | 0.2.6 | MIT OR Apache-2.0 | https://github.com/unicode-rs/unicode-xid |
+| unicode_categories | 0.1.1 | MIT OR Apache-2.0 | https://github.com/swgillespie/unicode-categories |
+| universal-hash | 0.5.1 | MIT OR Apache-2.0 | https://github.com/RustCrypto/traits |
+| untrusted | 0.9.0 | ISC | https://github.com/briansmith/untrusted |
+| ureq | 2.12.1 | MIT OR Apache-2.0 | https://github.com/algesten/ureq |
+| ureq | 3.3.0 | MIT OR Apache-2.0 | https://github.com/algesten/ureq |
+| ureq-proto | 0.6.0 | MIT OR Apache-2.0 | https://github.com/algesten/ureq-proto |
+| url | 2.5.8 | MIT OR Apache-2.0 | https://github.com/servo/rust-url |
+| urlencoding | 2.1.3 | MIT | https://github.com/kornelski/rust_urlencoding |
+| utf8-zero | 0.8.1 | MIT OR Apache-2.0 | https://github.com/algesten/utf8-zero |
+| utf8_iter | 1.0.4 | Apache-2.0 OR MIT | https://github.com/hsivonen/utf8_iter |
+| uuid | 1.23.0 | Apache-2.0 OR MIT | https://github.com/uuid-rs/uuid |
+| v_frame | 0.3.9 | BSD-2-Clause | https://github.com/rust-av/v_frame |
+| vcpkg | 0.2.15 | MIT/Apache-2.0 | https://github.com/mcgoo/vcpkg-rs |
+| version_check | 0.9.5 | MIT/Apache-2.0 | https://github.com/SergioBenitez/version_check |
+| want | 0.3.1 | MIT | https://github.com/seanmonstar/want |
+| wasi | 0.11.1+wasi-snapshot-preview1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wasi |
+| wasip2 | 1.0.2+wasi-0.2.9 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wasi-rs |
+| wasip3 | 0.4.0+wasi-0.3.0-rc-2026-01-06 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wasi-rs |
+| wasite | 0.1.0 | Apache-2.0 OR BSL-1.0 OR MIT | https://github.com/ardaku/wasite |
+| wasm-bindgen | 0.2.116 | MIT OR Apache-2.0 | https://github.com/wasm-bindgen/wasm-bindgen |
+| wasm-bindgen-futures | 0.4.66 | MIT OR Apache-2.0 | https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures |
+| wasm-bindgen-macro | 0.2.116 | MIT OR Apache-2.0 | https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro |
+| wasm-bindgen-macro-support | 0.2.116 | MIT OR Apache-2.0 | https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support |
+| wasm-bindgen-shared | 0.2.116 | MIT OR Apache-2.0 | https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared |
+| wasm-encoder | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder |
+| wasm-metadata | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata |
+| wasm-streams | 0.4.2 | MIT OR Apache-2.0 | https://github.com/MattiasBuelens/wasm-streams/ |
+| wasmparser | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser |
+| web-sys | 0.3.93 | MIT OR Apache-2.0 | https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys |
+| web-time | 1.1.0 | MIT OR Apache-2.0 | https://github.com/daxpedda/web-time |
+| webpki-root-certs | 1.0.6 | CDLA-Permissive-2.0 | https://github.com/rustls/webpki-roots |
+| webpki-roots | 0.26.11 | CDLA-Permissive-2.0 | https://github.com/rustls/webpki-roots |
+| webpki-roots | 1.0.6 | CDLA-Permissive-2.0 | https://github.com/rustls/webpki-roots |
+| weezl | 0.1.12 | MIT OR Apache-2.0 | https://github.com/image-rs/weezl |
+| whoami | 1.6.1 | Apache-2.0 OR BSL-1.0 OR MIT | https://github.com/ardaku/whoami |
+| winapi | 0.3.9 | MIT/Apache-2.0 | https://github.com/retep998/winapi-rs |
+| winapi-i686-pc-windows-gnu | 0.4.0 | MIT/Apache-2.0 | https://github.com/retep998/winapi-rs |
+| winapi-x86_64-pc-windows-gnu | 0.4.0 | MIT/Apache-2.0 | https://github.com/retep998/winapi-rs |
+| windows-core | 0.62.2 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-implement | 0.60.2 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-interface | 0.59.3 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-link | 0.2.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-registry | 0.6.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-result | 0.4.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-strings | 0.5.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-sys | 0.48.0 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-sys | 0.52.0 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-sys | 0.59.0 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-sys | 0.60.2 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-sys | 0.61.2 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-targets | 0.48.5 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-targets | 0.52.6 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows-targets | 0.53.5 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_aarch64_gnullvm | 0.48.5 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_aarch64_gnullvm | 0.52.6 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_aarch64_gnullvm | 0.53.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_aarch64_msvc | 0.48.5 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_aarch64_msvc | 0.52.6 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_aarch64_msvc | 0.53.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_i686_gnu | 0.48.5 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_i686_gnu | 0.52.6 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_i686_gnu | 0.53.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_i686_gnullvm | 0.52.6 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_i686_gnullvm | 0.53.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_i686_msvc | 0.48.5 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_i686_msvc | 0.52.6 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_i686_msvc | 0.53.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_x86_64_gnu | 0.48.5 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_x86_64_gnu | 0.52.6 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_x86_64_gnu | 0.53.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_x86_64_gnullvm | 0.48.5 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_x86_64_gnullvm | 0.52.6 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_x86_64_gnullvm | 0.53.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_x86_64_msvc | 0.48.5 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_x86_64_msvc | 0.52.6 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| windows_x86_64_msvc | 0.53.1 | MIT OR Apache-2.0 | https://github.com/microsoft/windows-rs |
+| wit-bindgen | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wit-bindgen |
+| wit-bindgen-core | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wit-bindgen |
+| wit-bindgen-rust | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wit-bindgen |
+| wit-bindgen-rust-macro | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wit-bindgen |
+| wit-component | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component |
+| wit-parser | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser |
+| writeable | 0.6.2 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| y4m | 0.8.0 | MIT | https://github.com/image-rs/y4m.git |
+| yoke | 0.8.1 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| yoke-derive | 0.8.1 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| zerocopy | 0.8.48 | BSD-2-Clause OR Apache-2.0 OR MIT | https://github.com/google/zerocopy |
+| zerocopy-derive | 0.8.48 | BSD-2-Clause OR Apache-2.0 OR MIT | https://github.com/google/zerocopy |
+| zerofrom | 0.1.6 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| zerofrom-derive | 0.1.6 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| zeroize | 1.8.2 | Apache-2.0 OR MIT | https://github.com/RustCrypto/utils |
+| zerotrie | 0.2.3 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| zerovec | 0.11.5 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| zerovec-derive | 0.11.2 | Unicode-3.0 | https://github.com/unicode-org/icu4x |
+| zmij | 1.0.21 | MIT | https://github.com/dtolnay/zmij |
+| zune-core | 0.5.1 | MIT OR Apache-2.0 OR Zlib | https://github.com/etemesi254/zune-image |
+| zune-inflate | 0.2.54 | MIT OR Apache-2.0 OR Zlib | - |
+| zune-jpeg | 0.5.15 | MIT OR Apache-2.0 OR Zlib | https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpeg |
+
+## Summary
+
+- Total third-party packages: 464
+- Workspace members: 5
+- Generated by: cargo metadata

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,0 +1,62 @@
+# Repository Structure
+
+_Auto-generated on 2026-04-27 15:50 UTC from commit `0c01607`._
+
+```
+.
+├── crates
+│   ├── bsmcp-common
+│   │   ├── src
+│   │   │   ├── acl.rs
+│   │   │   ├── bookstack.rs
+│   │   │   ├── chunking.rs
+│   │   │   ├── config.rs
+│   │   │   ├── db.rs
+│   │   │   ├── lib.rs
+│   │   │   ├── settings.rs
+│   │   │   ├── types.rs
+│   │   │   └── vector.rs
+│   │   └── Cargo.toml
+│   ├── bsmcp-db-postgres
+│   │   ├── src
+│   │   │   └── lib.rs
+│   │   └── Cargo.toml
+│   ├── bsmcp-db-sqlite
+│   │   ├── src
+│   │   │   └── lib.rs
+│   │   └── Cargo.toml
+│   ├── bsmcp-embedder
+│   │   ├── src
+│   │   │   ├── embed.rs
+│   │   │   ├── main.rs
+│   │   │   └── pipeline.rs
+│   │   └── Cargo.toml
+│   └── bsmcp-server
+│       ├── src
+│       │   ├── remember
+│       │   ├── llm.rs
+│       │   ├── main.rs
+│       │   ├── mcp.rs
+│       │   ├── migrate.rs
+│       │   ├── oauth.rs
+│       │   ├── semantic.rs
+│       │   ├── settings_ui.rs
+│       │   ├── sse.rs
+│       │   ├── staging.rs
+│       │   └── summary.rs
+│       └── Cargo.toml
+├── docker
+│   ├── Dockerfile.embedder
+│   ├── Dockerfile.server
+│   ├── docker-compose.sqlite.yml
+│   └── docker-compose.yml
+├── CLAUDE.md
+├── Cargo.lock
+├── Cargo.toml
+├── DEVELOPMENT.md
+├── README.md
+├── STRUCTURE.md
+└── entrypoint.sh
+
+14 directories, 40 files
+```

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -9,7 +9,7 @@ use pulldown_cmark::{html, Options, Parser};
 use bsmcp_common::bookstack::{self, BookStackClient, ContentType, ExportFormat};
 use bsmcp_common::db::DbBackend;
 use crate::remember;
-use crate::semantic::SemanticState;
+use crate::semantic::{trim_match, SemanticState};
 
 const PROTOCOL_VERSION: &str = "2025-03-26";
 
@@ -135,7 +135,8 @@ async fn execute_tool(
             // entry point — it has no UserSettings context to look up the
             // caller's `bookstack_user_id`. The HTTP `filter_by_permission`
             // fallback inside `sem.search` still enforces access control.
-            let result = sem.search(&query, limit, threshold, hybrid, verbose, client, None, None).await?;
+            let mut result = sem.search(&query, limit, threshold, hybrid, verbose, client, None, None).await?;
+            trim_semantic_search_payload(&mut result);
             format_json(&result)
         }
         "reembed" => {
@@ -915,6 +916,35 @@ fn filter_string_update_fields(args: &Value, fields: &[&str]) -> Value {
 
 fn format_json(v: &Value) -> Result<String, String> {
     serde_json::to_string_pretty(v).map_err(|e| e.to_string())
+}
+
+/// `semantic_search` MCP-tool payload trim. Caps each result's chunks and
+/// truncates each chunk's content so a wide query doesn't blow past Claude
+/// Code's response-size budget (which would force the response to spill to a
+/// local file). Slightly more generous than the briefing's per-section trim
+/// because the caller asked for these results explicitly and gets one shot at
+/// them; the briefing pulls every session and amortizes across many tools.
+///
+/// Truncation logic itself lives in `crate::semantic::trim_match` — this
+/// function only owns the budget and the response-envelope hint.
+const SEMANTIC_SEARCH_CHUNK_LIMIT: usize = 5;
+const SEMANTIC_SEARCH_CHUNK_CHARS: usize = 200;
+const SEMANTIC_SEARCH_HINT: &str =
+    "Each result returns up to 5 chunks of ~200 chars (truncated chunks have `truncated: true` and end with …). \
+     These are search-result previews, not full page content — call `get_page(page_id)` to read the full markdown when a match looks relevant.";
+
+fn trim_semantic_search_payload(payload: &mut Value) {
+    let Some(obj) = payload.as_object_mut() else { return; };
+    if let Some(results) = obj.get_mut("results").and_then(|v| v.as_array_mut()) {
+        for result in results.iter_mut() {
+            // Drop into the shared helper. take() leaves Value::Null in the slot;
+            // we immediately overwrite it with the trimmed result so no consumer
+            // ever sees the placeholder.
+            let owned = std::mem::take(result);
+            *result = trim_match(owned, SEMANTIC_SEARCH_CHUNK_LIMIT, SEMANTIC_SEARCH_CHUNK_CHARS);
+        }
+    }
+    obj.insert("hint".to_string(), Value::String(SEMANTIC_SEARCH_HINT.to_string()));
 }
 
 fn format_search_results(data: &Value, base_url: &str) -> String {

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -11,6 +11,33 @@ use bsmcp_common::bookstack::BookStackClient;
 
 use super::envelope::ErrorCode;
 use super::{frontmatter, Context, Outcome};
+use crate::semantic::trim_match;
+
+/// Per-book semantic-match trim: max chunks per page, max chars per chunk.
+/// Tighter than the `semantic_search` MCP tool because the briefing is
+/// pulled at the start of every session and has to amortize across many
+/// downstream tools. The AI is expected to call `get_page(page_id)` when
+/// it needs more context.
+const PER_BOOK_CHUNK_LIMIT: usize = 3;
+const PER_BOOK_CHUNK_CHARS: usize = 100;
+
+/// `kb_semantic_matches` runs across the entire embedded corpus, so each
+/// hit lands with less surrounding context than the per-book scopes.
+/// Slightly more generous chunk allowance compensates for that.
+const KB_CHUNK_LIMIT: usize = 4;
+const KB_CHUNK_CHARS: usize = 150;
+
+/// Cap on `kb_semantic_matches` results returned. Was 10; lowered to keep
+/// the briefing payload from blowing past response-size budgets when full-KB
+/// search is enabled.
+const KB_MATCH_LIMIT: usize = 6;
+
+/// Surfaced once at the top of the briefing so the AI knows the contract:
+/// matches are deliberately small; `get_page` is the escape hatch.
+const SEMANTIC_MATCHES_HINT: &str =
+    "Each *_semantic_matches entry returns up to 3 chunks of ~100 chars (kb_semantic_matches: up to 4 chunks of ~150 chars). \
+     Truncated chunks have `truncated: true` and end with …. \
+     These are search-result previews, not full page content — call `get_page(page_id)` to read the full markdown when a match looks relevant.";
 
 pub async fn read(ctx: &Context) -> Outcome {
     let user_prompt = ctx.body_str("user_prompt").unwrap_or_default();
@@ -170,8 +197,9 @@ pub async fn read(ctx: &Context) -> Outcome {
                     let bid = h.get("book_id").and_then(|v| v.as_i64()).unwrap_or(0);
                     !exclude.contains(&bid)
                 })
-                .take(10)
+                .take(KB_MATCH_LIMIT)
                 .cloned()
+                .map(|h| trim_match(h, KB_CHUNK_LIMIT, KB_CHUNK_CHARS))
                 .collect();
         }
         slice
@@ -350,6 +378,7 @@ pub async fn read(ctx: &Context) -> Outcome {
         "shared_collage_active": shared_collage,
         "shared_collage_semantic_matches": semantic.shared_collage_matches,
         "kb_semantic_matches": kb_matches_envelope(ctx, &semantic.kb_matches),
+        "semantic_matches_hint": SEMANTIC_MATCHES_HINT,
         "system_prompt_additions": system_prompt,
         // `time` is now in `meta.time` on every remember response (not just
         // briefing). Kept here too — readers were already targeting
@@ -483,6 +512,7 @@ fn filter_by_book(hits: &[Value], book_id: Option<i64>, limit: usize) -> Vec<Val
         .filter(|h| h.get("book_id").and_then(|v| v.as_i64()) == Some(book_id))
         .take(limit)
         .cloned()
+        .map(|h| trim_match(h, PER_BOOK_CHUNK_LIMIT, PER_BOOK_CHUNK_CHARS))
         .collect()
 }
 

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -16,6 +16,32 @@ use bsmcp_common::types::MarkovBlanket;
 
 const PERMISSION_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
 
+/// Cap a single semantic-match's chunks and truncate each chunk's content.
+/// Shared by every caller that surfaces chunk previews to a model — the
+/// briefing (per-book + kb) and the `semantic_search` MCP tool — so the
+/// truncation rules stay in one place even when the budgets differ per
+/// caller. `sem.search()` itself returns full chunks; trimming is the
+/// caller's responsibility.
+///
+/// Truncated chunks get a `truncated: true` flag and a `…` suffix so
+/// consumers can tell a clipped chunk from a naturally short one. Char-count
+/// is used (not byte-count) so multibyte UTF-8 isn't sliced mid-codepoint.
+pub fn trim_match(mut hit: Value, max_chunks: usize, max_chars: usize) -> Value {
+    let Some(obj) = hit.as_object_mut() else { return hit; };
+    let Some(chunks) = obj.get_mut("chunks").and_then(|v| v.as_array_mut()) else { return hit; };
+    chunks.truncate(max_chunks);
+    for chunk in chunks.iter_mut() {
+        let Some(chunk_obj) = chunk.as_object_mut() else { continue; };
+        let Some(content) = chunk_obj.get("content").and_then(|v| v.as_str()) else { continue; };
+        if content.chars().count() > max_chars {
+            let truncated: String = content.chars().take(max_chars).collect();
+            chunk_obj.insert("content".to_string(), Value::String(format!("{truncated}…")));
+            chunk_obj.insert("truncated".to_string(), Value::Bool(true));
+        }
+    }
+    hit
+}
+
 struct CachedAccess {
     accessible: bool,
     cached_at: Instant,


### PR DESCRIPTION
## Summary

Bundles three improvements landing on `development` together:

1. **CI: PR-source-branch artifact gating** (commit `648a9ff`).
   - `release.yml` now builds on `pull_request: opened/synchronize/reopened` against `development` or `release`. Pushes immutable `{version}-{branch-slug}-{sha}` + rolling `{version}-{branch-slug}` tags. New promote job retags on PR merge — no rebuild.
   - `generate-artifacts.yml` regenerates `SBOM.md` + `STRUCTURE.md` on PR source branch with `[skip ci]`.
2. **Briefing + `semantic_search` chunk trim** (commit `39ecee1`, this PR's main code change).
   - `/remember/briefing` `*_semantic_matches` capped at 3 chunks × ~100 chars (kb_semantic_matches: 4 × 150; match cap dropped 10 → 6).
   - `semantic_search` MCP tool capped at 5 chunks × ~200 chars.
   - Truncated chunks carry `truncated: true` and end with `…`.
   - New top-level hint fields (`semantic_matches_hint` in briefing, `hint` in tool response) point AI consumers at `get_page(page_id)` for full content.
   - Truncation logic unified in `semantic::trim_match` (single source of truth, per-caller budget). UTF-8 char-count safe.
3. **Doc sync: DEVELOPMENT.md + README.md.**
   - `DEVELOPMENT.md`: replace legacy 2-prefix branching scheme with the canonical 4-prefix taxonomy (`feature/`, `improvement/`, `refactor/`, `bug/`); fix the branch-protection section (development is intentionally unprotected; release is the only protected branch via the org-level `Release Branch Protection` ruleset); add commit-signing pointer.
   - `README.md`: features list adds `/remember` Hive memory flow, `/settings` UI, ACL filtering, per-user auto-provisioning, org globals, and the `meta.time` block. Tools table adds Staging row + 12 Hive memory tools (count: 61 BookStack + 12 Hive = 73). New upgrade entries cover v0.6.x through v0.7.4.

## Test plan

- [x] `cargo build -p bsmcp-server` succeeds locally
- [ ] CI artifact-gating workflow fires on this PR (build-server + build-embedder both green)
- [ ] `remember_briefing` response includes `semantic_matches_hint` and per-book chunks ≤ 3 × 100 chars
- [ ] `kb_semantic_matches` chunks ≤ 4 × 150 chars (when `semantic_against_full_kb=true`)
- [ ] `semantic_search` MCP tool response includes top-level `hint` field and chunks ≤ 5 × 200 chars
- [ ] Briefing payload size on Pia's instance drops from ~85K to <40K chars (Claude Code stops spilling response to local file)
- [ ] DEVELOPMENT.md branching/protection sections match BookStack KB Branching Strategy page (1860)
- [ ] README features + tool table reflect current v0.7.x surface area

🤖 Generated with [Claude Code](https://claude.com/claude-code)