### PR TITLE
Phase 2: append / update_section / append_section + whoami auto-discovery

### DIFF
--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-04-27 21:37 UTC from commit `d9fc605` via `cargo metadata --locked`._
+_Auto-generated on 2026-04-27 22:56 UTC from commit `1be830a` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-04-27 21:37 UTC from commit `d9fc605`._
+_Auto-generated on 2026-04-27 22:56 UTC from commit `1be830a`._
 
 ```
 .

--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -183,6 +183,16 @@ const MAX_ERROR_BODY_SIZE: usize = 4096; // 4KB for error messages
 /// (e.g. from Clone, format!, auth_header()) and reqwest HeaderValue copies may remain
 /// in freed memory until overwritten by the allocator.
 /// This is a best-effort defense-in-depth measure, not a guarantee against memory forensics.
+/// What `BookStackClient::whoami()` returns when it can identify the
+/// authenticated user. `email` is `None` only when BookStack returns a user
+/// row without one (rare — typically only seeded service accounts).
+#[derive(Clone, Debug)]
+pub struct UserIdentity {
+    pub bookstack_user_id: i64,
+    pub email: Option<String>,
+    pub name: String,
+}
+
 #[derive(Clone)]
 pub struct BookStackClient {
     client: Client,
@@ -721,6 +731,64 @@ impl BookStackClient {
 
     pub async fn get_user(&self, id: i64) -> Result<Value, String> {
         self.get(&format!("users/{id}"), &[]).await
+    }
+
+    /// Discover the authenticated user's BookStack identity (id + email + name)
+    /// without requiring user configuration.
+    ///
+    /// BookStack has no `/api/users/me` endpoint, but its search API resolves
+    /// `{created_by:me}` server-side. We probe by searching for any single
+    /// page the user has created, extract `created_by.id` from the result,
+    /// then fetch `/api/users/{id}` to get email + name (the search response
+    /// only carries id/name/slug — email lives on the user record).
+    ///
+    /// Returns `Ok(None)` when the user has no content yet (brand-new accounts)
+    /// — the caller should retry on first write or fall back to manual config.
+    /// Returns `Err` only when BookStack is unreachable or rejects the call
+    /// for non-empty-result reasons.
+    pub async fn whoami(&self) -> Result<Option<UserIdentity>, String> {
+        // Probe via search. Single-page results, page-type only, created-by-self.
+        let resp = self
+            .search("{type:page} {created_by:me}", 1, 1)
+            .await?;
+        let candidates = resp.get("data").and_then(|v| v.as_array());
+        let Some(items) = candidates else {
+            return Ok(None);
+        };
+        for item in items {
+            // Each result has a `preview_html` block plus the underlying entity
+            // shape. The created_by ref is at the top level on page rows.
+            let created_by = match item.get("created_by") {
+                Some(v) => v,
+                None => continue,
+            };
+            let user_id = match created_by.get("id").and_then(|v| v.as_i64()) {
+                Some(id) => id,
+                None => continue,
+            };
+            // Fetch the user record for email — search responses don't carry it.
+            // Reading your own user row works for any authenticated user; admin
+            // is only required to read OTHER users.
+            let user = match self.get_user(user_id).await {
+                Ok(u) => u,
+                Err(e) => return Err(format!("whoami: get_user({user_id}) failed: {e}")),
+            };
+            let email = user
+                .get("email")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let name = user
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            return Ok(Some(UserIdentity {
+                bookstack_user_id: user_id,
+                email,
+                name,
+            }));
+        }
+        Ok(None)
     }
 
     // --- Audit Log ---

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -1942,7 +1942,9 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
     let common_collection_props = json!({
         "id": { "type": ["integer", "string"], "description": "BookStack page ID (for read/write/delete by id)" },
         "key": { "type": "string", "description": "Natural key (date YYYY-MM-DD for journals, slug for topics, lowercase name for subagents)" },
-        "body": { "type": "string", "description": "Markdown body for write" },
+        "body": { "type": "string", "description": "Markdown body for write/append/update_section/append_section" },
+        "section": { "type": "string", "description": "H2 heading text for update_section / append_section. Match is exact (whitespace-trimmed). If the section doesn't exist it gets appended." },
+        "timestamp": { "type": "boolean", "description": "When true on action=append, prefix the appended chunk with a `## HH:MM TZ` heading using the user's local timezone — useful for multi-append-per-day journal entries.", "default": false },
         "query": { "type": "string", "description": "Search query for action=search" },
         "limit": { "type": "integer", "default": 25 },
         "offset": { "type": "integer", "default": 0 },
@@ -1964,20 +1966,29 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
 
     tools.push(remember_tool(
         "whoami",
-        "AI agent identity. read returns the manifest page + subagent list + book/chapter pointers. write replaces the manifest page body (frontmatter auto-stamped).",
-        &["read", "write"],
+        "AI agent identity. read returns the manifest page + subagent list + book/chapter pointers. \
+         write replaces the manifest page body (frontmatter auto-stamped) — destructive. \
+         update_section replaces just the named H2 section's body, preserving every other section. \
+         append_section appends to the named section's body (creates the section if missing). \
+         Prefer update_section / append_section over write for incremental edits — write is full-replace and rarely what you want.",
+        &["read", "write", "update_section", "append_section"],
         json!({
-            "body": { "type": "string", "description": "New manifest markdown for write" },
+            "body": { "type": "string", "description": "New manifest markdown for write, OR section content for update_section/append_section" },
+            "section": { "type": "string", "description": "H2 heading text for update_section / append_section. Match is exact (whitespace-trimmed). If the section doesn't exist it gets appended." },
         }),
     ));
 
     tools.push(remember_tool(
         "user",
-        "Human user identity. read auto-provisions missing structure (per-user Identity book on the user-journals shelf, Identity page, Agent: {user_id}-journal-agent page, journal book) when `user_id` is set, returning what was created in `auto_provisioned`. write replaces the user identity page body. \
-         IMPORTANT: as you work with the user, learn what they care about, how they prefer to collaborate, and update the identity page to reflect that — the briefing surfaces a refresh reminder after 30 days of inactivity.",
-        &["read", "write"],
+        "Human user identity. read auto-provisions missing structure (per-user Identity book on the user-journals shelf, Identity page, Agent: {user_id}-journal-agent page, journal book) when `user_id` is set, returning what was created in `auto_provisioned`. \
+         write replaces the user identity page body — destructive. \
+         update_section replaces just the named H2 section, preserving every other section. \
+         append_section appends to the named section's body (creates the section if missing). \
+         IMPORTANT: as you work with the user, learn what they care about, how they prefer to collaborate, and update the identity page to reflect that — the briefing surfaces a refresh reminder after 30 days of inactivity. Prefer update_section / append_section over write for incremental edits.",
+        &["read", "write", "update_section", "append_section"],
         json!({
-            "body": { "type": "string", "description": "New user identity markdown for write" },
+            "body": { "type": "string", "description": "New user identity markdown for write, OR section content for update_section/append_section" },
+            "section": { "type": "string", "description": "H2 heading text for update_section / append_section. Match is exact (whitespace-trimmed). If the section doesn't exist it gets appended." },
         }),
     ));
 
@@ -1999,28 +2010,28 @@ fn add_remember_tools(tools: &mut Vec<Value>) {
     tools.push(remember_tool(
         "journal",
         "AI agent's daily journal entries (book of pages, monthly chapters auto-managed). Key = date YYYY-MM-DD; defaults to today on write if omitted.",
-        &["read", "write", "search", "delete"],
+        &["read", "write", "append", "update_section", "append_section", "search", "delete"],
         common_collection_props.clone(),
     ));
 
     tools.push(remember_tool(
         "collage",
         "AI agent's active topics. Key = topic slug. Pages live directly in the configured Topics book.",
-        &["read", "write", "search", "delete"],
+        &["read", "write", "append", "update_section", "append_section", "search", "delete"],
         common_collection_props.clone(),
     ));
 
     tools.push(remember_tool(
         "shared_collage",
         "Cross-agent shared topics. Same shape as collage but a different parent book.",
-        &["read", "write", "search", "delete"],
+        &["read", "write", "append", "update_section", "append_section", "search", "delete"],
         common_collection_props.clone(),
     ));
 
     tools.push(remember_tool(
         "user_journal",
         "Human user's journal (when configured by the user). Key = date YYYY-MM-DD with monthly chapters auto-managed.",
-        &["read", "write", "search", "delete"],
+        &["read", "write", "append", "update_section", "append_section", "search", "delete"],
         common_collection_props.clone(),
     ));
 

--- a/crates/bsmcp-server/src/remember/collection.rs
+++ b/crates/bsmcp-server/src/remember/collection.rs
@@ -9,6 +9,7 @@ use bsmcp_common::settings::{GlobalSettings, UserSettings};
 use super::envelope::{ErrorCode, RememberWarning};
 use super::frontmatter;
 use super::provision;
+use super::section;
 use super::{Context, Outcome};
 
 /// Book ID where a resource's pages live. Pages may be distributed across
@@ -94,6 +95,26 @@ pub async fn handle(
                 );
             }
             handle_write(resource, parent, ctx).await
+        }
+        "append" => {
+            if !resource.writable() {
+                return Outcome::error(
+                    ErrorCode::InvalidArgument,
+                    format!("{} is read-only", resource.name()),
+                    None,
+                );
+            }
+            handle_append(resource, parent, ctx).await
+        }
+        "update_section" | "append_section" => {
+            if !resource.writable() {
+                return Outcome::error(
+                    ErrorCode::InvalidArgument,
+                    format!("{} is read-only", resource.name()),
+                    None,
+                );
+            }
+            handle_section_op(resource, parent, ctx, action == "append_section").await
         }
         "search" => handle_search(resource, parent, ctx).await,
         "delete" => {
@@ -386,6 +407,447 @@ async fn find_or_create_chapter(
         .get("id")
         .and_then(|v| v.as_i64())
         .ok_or_else(|| "create_chapter returned no id".to_string())
+}
+
+// --- APPEND (non-destructive write) ---
+//
+// Add `body` to the existing page at `key` (or create the page if missing).
+// Optional `timestamp=true` prefixes the appended chunk with a local time
+// marker (`## HH:MM TZ`) so multi-append-per-day journals produce a readable
+// timeline. The original `written_at` frontmatter field is preserved if the
+// page already exists; provenance for the append shows up as `last_appended_at`
+// + `append_count` (parsed-and-incremented from the existing frontmatter).
+
+async fn handle_append(
+    resource: &dyn CollectionResource,
+    parent: CollectionParent,
+    ctx: &Context,
+) -> Outcome {
+    let globals = ctx.db.get_global_settings().await.unwrap_or_default();
+    if let Some(shelf_id) = resource.shelf_pin(&globals) {
+        provision::ensure_book_on_shelf(&ctx.client, parent, shelf_id).await;
+    }
+
+    let body_text = match ctx.body_str("body") {
+        Some(b) => b,
+        None => {
+            return Outcome::error(
+                ErrorCode::InvalidArgument,
+                "body field is required for append",
+                Some("body"),
+            );
+        }
+    };
+    let timestamp = ctx
+        .body
+        .get("timestamp")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let id_arg = ctx.body_i64("id");
+    let key_arg = ctx.body_str("key").or_else(|| match resource.key_kind() {
+        KeyKind::Date => Some(frontmatter::today_iso_date()),
+        _ => None,
+    });
+
+    if id_arg.is_none() && key_arg.is_none() {
+        return Outcome::error(
+            ErrorCode::InvalidArgument,
+            "either id or key is required for append",
+            Some("key"),
+        );
+    }
+
+    let normalized_key = key_arg.as_deref().map(|k| match resource.key_kind() {
+        KeyKind::Slug => frontmatter::slugify(k),
+        KeyKind::Date => k.to_string(),
+    });
+    let page_name = normalized_key
+        .as_deref()
+        .map(|k| resource.key_to_page_name(k))
+        .unwrap_or_default();
+
+    let existing_id = if let Some(id) = id_arg {
+        Some(id)
+    } else if !page_name.is_empty() {
+        match find_page_by_name(parent, &page_name, ctx).await {
+            Ok(maybe) => maybe,
+            Err(e) => return Outcome::error(ErrorCode::BookStackError, e, None),
+        }
+    } else {
+        None
+    };
+
+    // Build the append chunk body (with optional timestamp prefix). Trimming
+    // the user's body lets the prefix line stand on its own and keeps the
+    // separator newlines clean.
+    let chunk = if timestamp {
+        let stamp = local_time_marker(&ctx.settings);
+        format!("## {stamp}\n\n{body}\n", body = body_text.trim())
+    } else {
+        format!("{}\n", body_text.trim())
+    };
+
+    if let Some(id) = existing_id {
+        // Read existing page body, parse the prior frontmatter to preserve
+        // `written_at` and increment `append_count`, then write back the
+        // concatenated body with refreshed frontmatter.
+        let page = match ctx.client.get_page(id).await {
+            Ok(p) => p,
+            Err(e) => return Outcome::error(ErrorCode::BookStackError, e, None),
+        };
+        let existing_md = page
+            .get("markdown")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let prior_existing_body = frontmatter::strip(existing_md);
+        let prior = parse_provenance(existing_md);
+
+        let new_body = if prior_existing_body.trim().is_empty() {
+            chunk
+        } else {
+            format!("{}\n\n{}", prior_existing_body.trim_end(), chunk)
+        };
+        let new_append_count = prior.append_count.unwrap_or(0) + 1;
+
+        let frontmatter_block = build_append_frontmatter(
+            &ctx.settings,
+            &ctx.trace_id,
+            resource.name(),
+            normalized_key.as_deref(),
+            Some(id),
+            prior.written_at.as_deref(),
+            new_append_count,
+        );
+        let full_body = format!("{frontmatter_block}{new_body}");
+        let payload = if page_name.is_empty() {
+            json!({ "markdown": full_body })
+        } else {
+            json!({ "name": page_name, "markdown": full_body })
+        };
+        match ctx.client.update_page(id, &payload).await {
+            Ok(updated) => Outcome::ok_with_target(
+                build_write_response(&updated, "appended"),
+                Some(id),
+                normalized_key.clone(),
+            ),
+            Err(e) => Outcome::error(ErrorCode::BookStackError, e, None),
+        }
+    } else {
+        // No existing page — fall through to create-with-new-body. Reuses the
+        // standard `write` create path (find/create sub-chapter etc.) since
+        // append-into-nothing is identical to write-with-this-body.
+        let target = match resolve_create_target(resource, parent, normalized_key.as_deref(), ctx).await {
+            Ok(t) => t,
+            Err(e) => return Outcome::error(ErrorCode::BookStackError, e, None),
+        };
+        let frontmatter_block = build_append_frontmatter(
+            &ctx.settings,
+            &ctx.trace_id,
+            resource.name(),
+            normalized_key.as_deref(),
+            None,
+            None,
+            1,
+        );
+        let full_body = format!("{frontmatter_block}{chunk}");
+        let mut payload = json!({ "name": page_name, "markdown": full_body });
+        match target {
+            CreateTarget::Book(id) => { payload["book_id"] = json!(id); }
+            CreateTarget::Chapter(id) => { payload["chapter_id"] = json!(id); }
+        }
+        match ctx.client.create_page(&payload).await {
+            Ok(created) => {
+                let new_id = created.get("id").and_then(|v| v.as_i64());
+                Outcome::ok_with_target(
+                    build_write_response(&created, "created"),
+                    new_id,
+                    normalized_key.clone(),
+                )
+            }
+            Err(e) => Outcome::error(ErrorCode::BookStackError, e, None),
+        }
+    }
+}
+
+// --- UPDATE_SECTION / APPEND_SECTION (section-aware writes) ---
+
+async fn handle_section_op(
+    resource: &dyn CollectionResource,
+    parent: CollectionParent,
+    ctx: &Context,
+    is_append: bool,
+) -> Outcome {
+    let action_label = if is_append { "append_section" } else { "update_section" };
+    let section_name = match ctx.body_str("section") {
+        Some(s) => s,
+        None => {
+            return Outcome::error(
+                ErrorCode::InvalidArgument,
+                format!("section field is required for {action_label}"),
+                Some("section"),
+            );
+        }
+    };
+    let body_text = match ctx.body_str("body") {
+        Some(b) => b,
+        None => {
+            return Outcome::error(
+                ErrorCode::InvalidArgument,
+                format!("body field is required for {action_label}"),
+                Some("body"),
+            );
+        }
+    };
+
+    let id_arg = ctx.body_i64("id");
+    let key_arg = ctx.body_str("key").or_else(|| match resource.key_kind() {
+        KeyKind::Date => Some(frontmatter::today_iso_date()),
+        _ => None,
+    });
+    if id_arg.is_none() && key_arg.is_none() {
+        return Outcome::error(
+            ErrorCode::InvalidArgument,
+            format!("either id or key is required for {action_label}"),
+            Some("key"),
+        );
+    }
+    let normalized_key = key_arg.as_deref().map(|k| match resource.key_kind() {
+        KeyKind::Slug => frontmatter::slugify(k),
+        KeyKind::Date => k.to_string(),
+    });
+    let page_name = normalized_key
+        .as_deref()
+        .map(|k| resource.key_to_page_name(k))
+        .unwrap_or_default();
+
+    let existing_id = if let Some(id) = id_arg {
+        Some(id)
+    } else if !page_name.is_empty() {
+        match find_page_by_name(parent, &page_name, ctx).await {
+            Ok(maybe) => maybe,
+            Err(e) => return Outcome::error(ErrorCode::BookStackError, e, None),
+        }
+    } else {
+        None
+    };
+
+    let (existing_body, prior) = if let Some(id) = existing_id {
+        match ctx.client.get_page(id).await {
+            Ok(page) => {
+                let raw = page.get("markdown").and_then(|v| v.as_str()).unwrap_or("");
+                (frontmatter::strip(raw).to_string(), parse_provenance(raw))
+            }
+            Err(e) => return Outcome::error(ErrorCode::BookStackError, e, None),
+        }
+    } else {
+        // No existing page — section op effectively creates the page with
+        // a single section.
+        (String::new(), Provenance::default())
+    };
+
+    let new_body = if is_append {
+        section::append_to_section(&existing_body, &section_name, &body_text)
+    } else {
+        section::replace_section(&existing_body, &section_name, &body_text)
+    };
+
+    let frontmatter_block = build_section_frontmatter(
+        &ctx.settings,
+        &ctx.trace_id,
+        resource.name(),
+        normalized_key.as_deref(),
+        existing_id,
+        prior.written_at.as_deref(),
+        prior.append_count,
+        &section_name,
+    );
+    let full_body = format!("{frontmatter_block}{new_body}");
+
+    if let Some(id) = existing_id {
+        let payload = if page_name.is_empty() {
+            json!({ "markdown": full_body })
+        } else {
+            json!({ "name": page_name, "markdown": full_body })
+        };
+        match ctx.client.update_page(id, &payload).await {
+            Ok(updated) => Outcome::ok_with_target(
+                build_write_response(&updated, action_label),
+                Some(id),
+                normalized_key.clone(),
+            ),
+            Err(e) => Outcome::error(ErrorCode::BookStackError, e, None),
+        }
+    } else {
+        let target = match resolve_create_target(resource, parent, normalized_key.as_deref(), ctx).await {
+            Ok(t) => t,
+            Err(e) => return Outcome::error(ErrorCode::BookStackError, e, None),
+        };
+        let mut payload = json!({ "name": page_name, "markdown": full_body });
+        match target {
+            CreateTarget::Book(id) => { payload["book_id"] = json!(id); }
+            CreateTarget::Chapter(id) => { payload["chapter_id"] = json!(id); }
+        }
+        match ctx.client.create_page(&payload).await {
+            Ok(created) => {
+                let new_id = created.get("id").and_then(|v| v.as_i64());
+                Outcome::ok_with_target(
+                    build_write_response(&created, "created"),
+                    new_id,
+                    normalized_key.clone(),
+                )
+            }
+            Err(e) => Outcome::error(ErrorCode::BookStackError, e, None),
+        }
+    }
+}
+
+// --- Frontmatter parsing + extended builders ---
+//
+// Phase 2's new actions need to carry a few extra provenance fields beyond
+// what `frontmatter::build` emits — and to do that without rewriting the
+// existing `write` flow, we parse selected fields out of the prior body
+// here and re-stamp.
+
+#[derive(Default, Debug)]
+struct Provenance {
+    written_at: Option<String>,
+    append_count: Option<i64>,
+}
+
+fn parse_provenance(markdown: &str) -> Provenance {
+    let trimmed = markdown.trim_start();
+    if !trimmed.starts_with("---") {
+        return Provenance::default();
+    }
+    let mut out = Provenance::default();
+    let mut iter = trimmed.lines();
+    iter.next(); // opening ---
+    for line in iter {
+        let line = line.trim();
+        if line == "---" {
+            break;
+        }
+        if let Some((key, value)) = line.split_once(':') {
+            let key = key.trim();
+            let value = value.trim().trim_matches('"');
+            match key {
+                "written_at" => out.written_at = Some(value.to_string()),
+                "append_count" => out.append_count = value.parse().ok(),
+                _ => {}
+            }
+        }
+    }
+    out
+}
+
+fn build_append_frontmatter(
+    settings: &bsmcp_common::settings::UserSettings,
+    trace_id: &str,
+    resource: &str,
+    key: Option<&str>,
+    supersedes_page: Option<i64>,
+    preserved_written_at: Option<&str>,
+    new_append_count: i64,
+) -> String {
+    let mut out = String::from("---\n");
+    if let Some(name) = &settings.ai_identity_name {
+        out.push_str(&format!("written_by: {}\n", yaml_quote(name)));
+    }
+    if let Some(ouid) = &settings.ai_identity_ouid {
+        out.push_str(&format!("ai_identity_ouid: {}\n", yaml_quote(ouid)));
+    }
+    if let Some(user_id) = &settings.user_id {
+        out.push_str(&format!("user_id: {}\n", yaml_quote(user_id)));
+    }
+    let written_at = preserved_written_at
+        .map(|s| s.to_string())
+        .unwrap_or_else(frontmatter::now_iso_utc);
+    out.push_str(&format!("written_at: {}\n", yaml_quote(&written_at)));
+    out.push_str(&format!("last_appended_at: {}\n", yaml_quote(&frontmatter::now_iso_utc())));
+    out.push_str(&format!("append_count: {new_append_count}\n"));
+    out.push_str(&format!("trace_id: {}\n", yaml_quote(trace_id)));
+    out.push_str(&format!("resource: {}\n", yaml_quote(resource)));
+    if let Some(k) = key {
+        out.push_str(&format!("key: {}\n", yaml_quote(k)));
+    }
+    if let Some(p) = supersedes_page {
+        out.push_str(&format!("supersedes_page: {p}\n"));
+    }
+    out.push_str("---\n\n");
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_section_frontmatter(
+    settings: &bsmcp_common::settings::UserSettings,
+    trace_id: &str,
+    resource: &str,
+    key: Option<&str>,
+    supersedes_page: Option<i64>,
+    preserved_written_at: Option<&str>,
+    preserved_append_count: Option<i64>,
+    last_section: &str,
+) -> String {
+    let mut out = String::from("---\n");
+    if let Some(name) = &settings.ai_identity_name {
+        out.push_str(&format!("written_by: {}\n", yaml_quote(name)));
+    }
+    if let Some(ouid) = &settings.ai_identity_ouid {
+        out.push_str(&format!("ai_identity_ouid: {}\n", yaml_quote(ouid)));
+    }
+    if let Some(user_id) = &settings.user_id {
+        out.push_str(&format!("user_id: {}\n", yaml_quote(user_id)));
+    }
+    let written_at = preserved_written_at
+        .map(|s| s.to_string())
+        .unwrap_or_else(frontmatter::now_iso_utc);
+    out.push_str(&format!("written_at: {}\n", yaml_quote(&written_at)));
+    out.push_str(&format!(
+        "last_section_update_at: {}\n",
+        yaml_quote(&frontmatter::now_iso_utc())
+    ));
+    out.push_str(&format!("last_updated_section: {}\n", yaml_quote(last_section)));
+    if let Some(c) = preserved_append_count {
+        out.push_str(&format!("append_count: {c}\n"));
+    }
+    out.push_str(&format!("trace_id: {}\n", yaml_quote(trace_id)));
+    out.push_str(&format!("resource: {}\n", yaml_quote(resource)));
+    if let Some(k) = key {
+        out.push_str(&format!("key: {}\n", yaml_quote(k)));
+    }
+    if let Some(p) = supersedes_page {
+        out.push_str(&format!("supersedes_page: {p}\n"));
+    }
+    out.push_str("---\n\n");
+    out
+}
+
+/// Conservative YAML scalar quoting — same logic as `frontmatter::build`.
+fn yaml_quote(s: &str) -> String {
+    let needs_quote = s.is_empty()
+        || s.chars().any(|c| matches!(c, ':' | '#' | '\'' | '"' | '\n' | '{' | '}' | '[' | ']' | ','))
+        || matches!(s, "true" | "false" | "null" | "yes" | "no" | "~");
+    if needs_quote {
+        let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("\"{escaped}\"")
+    } else {
+        s.to_string()
+    }
+}
+
+/// Format the user's local time as `HH:MM TZ` for the optional timestamp
+/// prefix on `append`. Falls back to the configured timezone, then UTC.
+fn local_time_marker(settings: &bsmcp_common::settings::UserSettings) -> String {
+    use chrono::Utc;
+    let now_utc = Utc::now();
+    if let Some(tz_name) = settings.timezone.as_deref() {
+        if let Ok(tz) = tz_name.parse::<chrono_tz::Tz>() {
+            let local = now_utc.with_timezone(&tz);
+            return format!("{}", local.format("%H:%M %Z"));
+        }
+    }
+    format!("{} UTC", now_utc.format("%H:%M"))
 }
 
 fn build_write_response(page: &Value, action: &str) -> Value {

--- a/crates/bsmcp-server/src/remember/mod.rs
+++ b/crates/bsmcp-server/src/remember/mod.rs
@@ -19,6 +19,7 @@ pub mod identity;
 pub mod naming;
 pub mod provision;
 pub mod search;
+pub mod section;
 pub mod singletons;
 pub mod user_provision;
 
@@ -109,8 +110,12 @@ pub async fn dispatch(
 
     let outcome = route(resource, action, &ctx).await;
 
-    // Best-effort audit logging (only on writes/deletes, not on every read).
-    let log_audit = matches!(action, "write" | "delete");
+    // Best-effort audit logging — every state-changing action is audited.
+    // Reads and dry-run actions are not.
+    let log_audit = matches!(
+        action,
+        "write" | "delete" | "append" | "update_section" | "append_section"
+    );
     if log_audit {
         let ouid = ctx.settings.ai_identity_ouid.clone();
         let user_id = ctx.settings.user_id.clone();
@@ -172,8 +177,12 @@ async fn route(resource: &str, action: &str, ctx: &Context) -> Outcome {
         ("briefing", "read") => briefing::read(ctx).await,
         ("whoami", "read") => singletons::read_whoami(ctx).await,
         ("whoami", "write") => singletons::write_whoami(ctx).await,
+        ("whoami", "update_section") => singletons::update_section_whoami(ctx).await,
+        ("whoami", "append_section") => singletons::append_section_whoami(ctx).await,
         ("user", "read") => singletons::read_user(ctx).await,
         ("user", "write") => singletons::write_user(ctx).await,
+        ("user", "update_section") => singletons::update_section_user(ctx).await,
+        ("user", "append_section") => singletons::append_section_user(ctx).await,
         ("config", "read") => singletons::read_config(ctx).await,
         ("config", "write") => singletons::write_config(ctx).await,
         ("config", "dismiss_setup_nudge") => singletons::dismiss_setup_nudge(ctx).await,

--- a/crates/bsmcp-server/src/remember/section.rs
+++ b/crates/bsmcp-server/src/remember/section.rs
@@ -1,0 +1,240 @@
+//! Markdown section helpers for the `update_section` and `append_section`
+//! actions. Pure functions over a markdown body — no DB, no async.
+//!
+//! A "section" is everything from a `## {name}` H2 line up to (but not
+//! including) the next `## ` H2, or end-of-body. H1 (`# `) and deeper
+//! headings (`### ` etc.) don't terminate a section. Frontmatter (leading
+//! `---` block) is left untouched — callers strip it before calling here
+//! and re-prepend after.
+
+/// The byte ranges of a found H2 section.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct H2Range {
+    /// Byte index where the `## {name}` line starts.
+    pub heading_start: usize,
+    /// Byte index where the section body starts (line after the heading).
+    pub content_start: usize,
+    /// Byte index where the next `## ` heading or end-of-body begins.
+    pub content_end: usize,
+}
+
+/// Find an H2 section by exact name match. Whitespace inside the heading
+/// text is trimmed for comparison; the H2 marker itself must be `## `
+/// (two hashes + space). Returns the first match; H2 names are expected
+/// to be unique within a page.
+pub fn find_h2_section(body: &str, target_name: &str) -> Option<H2Range> {
+    let target = target_name.trim();
+    let mut pos = 0usize;
+    for line in body.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if let Some(rest) = trimmed.strip_prefix("## ") {
+            if rest.trim() == target {
+                let heading_start = pos;
+                let content_start = pos + line.len();
+                let content_end = find_next_h2(body, content_start);
+                return Some(H2Range {
+                    heading_start,
+                    content_start,
+                    content_end,
+                });
+            }
+        }
+        pos += line.len();
+    }
+    None
+}
+
+/// Find the byte index of the next `## ` heading at or after `from`,
+/// returning end-of-body if none.
+fn find_next_h2(body: &str, from: usize) -> usize {
+    let rest = &body[from..];
+    let mut p = from;
+    for line in rest.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.starts_with("## ") {
+            return p;
+        }
+        p += line.len();
+    }
+    body.len()
+}
+
+/// Replace the named section's body, preserving the heading and every other
+/// section. If the section doesn't exist, append it at end-of-body. Result
+/// always ends with exactly one trailing newline.
+pub fn replace_section(body: &str, section_name: &str, new_content: &str) -> String {
+    match find_h2_section(body, section_name) {
+        Some(range) => {
+            let mut out = String::with_capacity(body.len() + new_content.len());
+            // Everything up to and including the heading line.
+            out.push_str(&body[..range.content_start]);
+            // Replacement body (trimmed, then a trailing blank line for
+            // separation from the next H2).
+            let trimmed_new = new_content.trim();
+            if !trimmed_new.is_empty() {
+                out.push('\n');
+                out.push_str(trimmed_new);
+                out.push_str("\n\n");
+            }
+            // Everything from the next H2 onward.
+            out.push_str(&body[range.content_end..]);
+            normalize_trailing_newline(out)
+        }
+        None => append_section_at_end(body, section_name, new_content),
+    }
+}
+
+/// Append `additional_content` to the named section's body, preserving the
+/// heading and every other section. If the section doesn't exist, create
+/// it at end-of-body. Result always ends with exactly one trailing newline.
+pub fn append_to_section(body: &str, section_name: &str, additional_content: &str) -> String {
+    match find_h2_section(body, section_name) {
+        Some(range) => {
+            let mut out = String::with_capacity(body.len() + additional_content.len());
+            // Everything up to (but not including) the next H2.
+            // Trim trailing whitespace from the section body so the appended
+            // content butts up cleanly with one blank line of separation.
+            let kept = body[..range.content_end].trim_end();
+            out.push_str(kept);
+            let trimmed_new = additional_content.trim();
+            if !trimmed_new.is_empty() {
+                out.push_str("\n\n");
+                out.push_str(trimmed_new);
+            }
+            out.push_str("\n\n");
+            // Everything from the next H2 onward.
+            out.push_str(&body[range.content_end..]);
+            normalize_trailing_newline(out)
+        }
+        None => append_section_at_end(body, section_name, additional_content),
+    }
+}
+
+fn append_section_at_end(body: &str, section_name: &str, content: &str) -> String {
+    let mut out = body.trim_end().to_string();
+    if !out.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str("## ");
+    out.push_str(section_name.trim());
+    out.push('\n');
+    let trimmed_content = content.trim();
+    if !trimmed_content.is_empty() {
+        out.push('\n');
+        out.push_str(trimmed_content);
+    }
+    out.push('\n');
+    out
+}
+
+fn normalize_trailing_newline(mut s: String) -> String {
+    while s.ends_with("\n\n") {
+        s.pop();
+    }
+    if !s.ends_with('\n') {
+        s.push('\n');
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_section_by_exact_name() {
+        let body = "## Communication style\n\nTerse.\n\n## Working preferences\n\nDocker.\n";
+        let r = find_h2_section(body, "Communication style").expect("should find");
+        assert_eq!(&body[r.heading_start..r.content_start], "## Communication style\n");
+        assert_eq!(&body[r.content_start..r.content_end], "\nTerse.\n\n");
+    }
+
+    #[test]
+    fn finds_last_section_when_no_following_h2() {
+        let body = "## Notes\n\nLast section.\n";
+        let r = find_h2_section(body, "Notes").expect("should find");
+        assert_eq!(r.content_end, body.len());
+    }
+
+    #[test]
+    fn does_not_match_h1_or_h3() {
+        let body = "# Communication style\n\n## Other\n\n### Communication style\n\nfoo\n";
+        assert!(find_h2_section(body, "Communication style").is_none());
+    }
+
+    #[test]
+    fn replace_section_preserves_other_sections() {
+        let body = "## A\n\nold A\n\n## B\n\nold B\n";
+        let result = replace_section(body, "A", "new A");
+        assert!(result.contains("## A\n\nnew A\n"));
+        assert!(result.contains("## B\n\nold B\n"));
+    }
+
+    #[test]
+    fn replace_section_appends_when_missing() {
+        let body = "## A\n\nbody\n";
+        let result = replace_section(body, "C", "new C");
+        assert!(result.contains("## A\n\nbody"));
+        assert!(result.ends_with("## C\n\nnew C\n"));
+    }
+
+    #[test]
+    fn replace_section_with_empty_body_keeps_heading() {
+        let body = "## A\n\nold\n\n## B\n\nB body\n";
+        let result = replace_section(body, "A", "");
+        assert!(result.contains("## A"));
+        assert!(result.contains("## B\n\nB body"));
+        assert!(!result.contains("old"));
+    }
+
+    #[test]
+    fn append_to_section_extends_existing() {
+        let body = "## A\n\nfirst\n\n## B\n\nB body\n";
+        let result = append_to_section(body, "A", "second");
+        assert!(result.contains("## A\n\nfirst\n\nsecond"));
+        assert!(result.contains("## B\n\nB body"));
+    }
+
+    #[test]
+    fn append_to_section_creates_when_missing() {
+        let body = "## A\n\nbody\n";
+        let result = append_to_section(body, "C", "C body");
+        assert!(result.contains("## A\n\nbody"));
+        assert!(result.contains("## C\n\nC body"));
+    }
+
+    #[test]
+    fn append_at_end_of_empty_body() {
+        let result = append_section_at_end("", "Notes", "first note");
+        assert_eq!(result, "## Notes\n\nfirst note\n");
+    }
+
+    #[test]
+    fn append_at_end_of_nonempty_body() {
+        let result = append_section_at_end("## Existing\n\nbody\n", "New", "new body");
+        assert!(result.contains("## Existing\n\nbody"));
+        assert!(result.ends_with("## New\n\nnew body\n"));
+    }
+
+    #[test]
+    fn trailing_newline_normalized() {
+        let body = "## A\n\nbody\n";
+        let result = replace_section(body, "A", "new");
+        assert!(result.ends_with('\n'));
+        assert!(!result.ends_with("\n\n\n"));
+    }
+
+    #[test]
+    fn handles_crlf_endings() {
+        let body = "## A\r\n\r\nbody\r\n\r\n## B\r\n\r\nB body\r\n";
+        let r = find_h2_section(body, "A").expect("should find with CRLF");
+        // Heading line includes CRLF
+        assert!(body[r.heading_start..r.content_start].starts_with("## A"));
+    }
+
+    #[test]
+    fn whitespace_in_target_name_trimmed_for_match() {
+        let body = "## Notes\n\nbody\n";
+        assert!(find_h2_section(body, "  Notes  ").is_some());
+    }
+}

--- a/crates/bsmcp-server/src/remember/singletons.rs
+++ b/crates/bsmcp-server/src/remember/singletons.rs
@@ -11,6 +11,7 @@ use bsmcp_common::settings::{GlobalSettings, UserSettings};
 use super::envelope::ErrorCode;
 use super::frontmatter;
 use super::provision;
+use super::section;
 use super::user_provision;
 use super::{Context, Outcome};
 
@@ -102,6 +103,14 @@ pub async fn write_whoami(ctx: &Context) -> Outcome {
         ),
         Err(e) => Outcome::error(ErrorCode::BookStackError, e, None),
     }
+}
+
+pub async fn update_section_whoami(ctx: &Context) -> Outcome {
+    section_op_singleton(ctx, "whoami", false).await
+}
+
+pub async fn append_section_whoami(ctx: &Context) -> Outcome {
+    section_op_singleton(ctx, "whoami", true).await
 }
 
 // --- user ---
@@ -261,6 +270,208 @@ pub async fn write_user(ctx: &Context) -> Outcome {
             None,
         ),
         Err(e) => Outcome::error(ErrorCode::BookStackError, e, None),
+    }
+}
+
+pub async fn update_section_user(ctx: &Context) -> Outcome {
+    section_op_singleton(ctx, "user", false).await
+}
+
+pub async fn append_section_user(ctx: &Context) -> Outcome {
+    section_op_singleton(ctx, "user", true).await
+}
+
+// --- shared section-op machinery for whoami / user singletons ---
+//
+// Resolves the target page for the named singleton, reads its body, runs the
+// section transform, and writes back with refreshed frontmatter that
+// preserves `written_at` (set on first creation) while stamping
+// `last_section_update_at` and `last_updated_section`.
+
+async fn section_op_singleton(ctx: &Context, resource: &'static str, is_append: bool) -> Outcome {
+    let action_label = if is_append { "append_section" } else { "update_section" };
+
+    let section_name = match ctx.body_str("section") {
+        Some(s) => s,
+        None => {
+            return Outcome::error(
+                ErrorCode::InvalidArgument,
+                format!("section field is required for {action_label}"),
+                Some("section"),
+            );
+        }
+    };
+    let body_text = match ctx.body_str("body") {
+        Some(b) => b,
+        None => {
+            return Outcome::error(
+                ErrorCode::InvalidArgument,
+                format!("body field is required for {action_label}"),
+                Some("body"),
+            );
+        }
+    };
+
+    // Resolve page id per resource. `user` runs the same auto-provision
+    // chain as `read_user` / `write_user` so a fresh-token user can update
+    // a section without a prior read.
+    let (page_id, working_settings) = match resource {
+        "whoami" => match ctx.settings.ai_identity_page_id {
+            Some(id) => (id, ctx.settings.clone()),
+            None => {
+                return Outcome::settings_not_configured(
+                    "ai_identity_page_id",
+                    "ai_identity_page_id not configured — set the manifest page in /settings first",
+                );
+            }
+        },
+        "user" => {
+            let globals = ctx.db.get_global_settings().await.unwrap_or_default();
+            let mut ws = ctx.settings.clone();
+            let provision_result = user_provision::auto_provision_user_identity(
+                &ctx.client,
+                globals.user_journals_shelf_id,
+                &mut ws,
+            )
+            .await;
+            if provision_result.any_changes() {
+                if let Err(e) = ctx.db.save_user_settings(&ctx.token_id_hash, &ws).await {
+                    eprintln!("{action_label}_user: persist auto-provisioned IDs failed (non-fatal): {e}");
+                }
+                provision::lock_journal_books_to_owner(
+                    &ctx.client,
+                    ws.ai_hive_journal_book_id,
+                    ws.user_journal_book_id,
+                )
+                .await;
+            }
+            match ws.user_identity_page_id {
+                Some(id) => (id, ws),
+                None => {
+                    return Outcome::settings_not_configured(
+                        "user_identity_page_id",
+                        "user_identity_page_id not configured (auto-provision needs `user_id` — \
+                         try `remember_user action=read` first to trigger whoami auto-discovery)",
+                    );
+                }
+            }
+        }
+        _ => {
+            return Outcome::error(
+                ErrorCode::InternalError,
+                format!("section_op_singleton called with unknown resource: {resource}"),
+                None,
+            );
+        }
+    };
+
+    // Read existing body, run the section transform, write back.
+    let page = match ctx.client.get_page(page_id).await {
+        Ok(p) => p,
+        Err(e) => return Outcome::error(ErrorCode::BookStackError, e, None),
+    };
+    let raw = page.get("markdown").and_then(|v| v.as_str()).unwrap_or("");
+    let existing_body = frontmatter::strip(raw);
+    let preserved_written_at = parse_written_at(raw);
+
+    let new_body = if is_append {
+        section::append_to_section(existing_body, &section_name, &body_text)
+    } else {
+        section::replace_section(existing_body, &section_name, &body_text)
+    };
+
+    let frontmatter_block = build_singleton_section_frontmatter(
+        &working_settings,
+        &ctx.trace_id,
+        resource,
+        Some(page_id),
+        preserved_written_at.as_deref(),
+        &section_name,
+    );
+    let payload = json!({ "markdown": format!("{frontmatter_block}{new_body}") });
+    match ctx.client.update_page(page_id, &payload).await {
+        Ok(updated) => Outcome::ok_with_target(
+            json!({
+                "action": action_label,
+                "id": page_id,
+                "section": section_name,
+                "name": updated.get("name").cloned().unwrap_or(Value::Null),
+                "url": updated.get("url").cloned().unwrap_or(Value::Null),
+                "updated_at": updated.get("updated_at").cloned().unwrap_or(Value::Null),
+            }),
+            Some(page_id),
+            None,
+        ),
+        Err(e) => Outcome::error(ErrorCode::BookStackError, e, None),
+    }
+}
+
+/// Pull `written_at` out of a page's leading YAML frontmatter (if any).
+/// Used to preserve the original creation timestamp across section edits.
+fn parse_written_at(markdown: &str) -> Option<String> {
+    let trimmed = markdown.trim_start();
+    if !trimmed.starts_with("---") {
+        return None;
+    }
+    let mut iter = trimmed.lines();
+    iter.next(); // opening ---
+    for line in iter {
+        let line = line.trim();
+        if line == "---" {
+            break;
+        }
+        if let Some(rest) = line.strip_prefix("written_at:") {
+            return Some(rest.trim().trim_matches('"').to_string());
+        }
+    }
+    None
+}
+
+fn build_singleton_section_frontmatter(
+    settings: &bsmcp_common::settings::UserSettings,
+    trace_id: &str,
+    resource: &str,
+    supersedes_page: Option<i64>,
+    preserved_written_at: Option<&str>,
+    last_section: &str,
+) -> String {
+    let mut out = String::from("---\n");
+    if let Some(name) = &settings.ai_identity_name {
+        out.push_str(&format!("written_by: {}\n", yaml_quote(name)));
+    }
+    if let Some(ouid) = &settings.ai_identity_ouid {
+        out.push_str(&format!("ai_identity_ouid: {}\n", yaml_quote(ouid)));
+    }
+    if let Some(user_id) = &settings.user_id {
+        out.push_str(&format!("user_id: {}\n", yaml_quote(user_id)));
+    }
+    let written_at = preserved_written_at
+        .map(|s| s.to_string())
+        .unwrap_or_else(frontmatter::now_iso_utc);
+    out.push_str(&format!("written_at: {}\n", yaml_quote(&written_at)));
+    out.push_str(&format!(
+        "last_section_update_at: {}\n",
+        yaml_quote(&frontmatter::now_iso_utc())
+    ));
+    out.push_str(&format!("last_updated_section: {}\n", yaml_quote(last_section)));
+    out.push_str(&format!("trace_id: {}\n", yaml_quote(trace_id)));
+    out.push_str(&format!("resource: {}\n", yaml_quote(resource)));
+    if let Some(p) = supersedes_page {
+        out.push_str(&format!("supersedes_page: {p}\n"));
+    }
+    out.push_str("---\n\n");
+    out
+}
+
+fn yaml_quote(s: &str) -> String {
+    let needs_quote = s.is_empty()
+        || s.chars().any(|c| matches!(c, ':' | '#' | '\'' | '"' | '\n' | '{' | '}' | '[' | ']' | ','))
+        || matches!(s, "true" | "false" | "null" | "yes" | "no" | "~");
+    if needs_quote {
+        let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("\"{escaped}\"")
+    } else {
+        s.to_string()
     }
 }
 

--- a/crates/bsmcp-server/src/remember/user_provision.rs
+++ b/crates/bsmcp-server/src/remember/user_provision.rs
@@ -24,6 +24,73 @@ use bsmcp_common::settings::UserSettings;
 use super::naming::NamedResource;
 use super::provision;
 
+/// Discover the authenticated user's BookStack identity via
+/// [`BookStackClient::whoami`] and populate `user_id` and `bookstack_user_id`
+/// in the settings if they're missing. Idempotent — if both fields are
+/// already populated, returns immediately. Failures are non-fatal: the
+/// caller still gets a `UserSettings` it can work with, just without
+/// auto-discovered fields, and the next call will retry.
+///
+/// Records what was discovered on `result.warnings` (informational, not
+/// errors) so the caller can surface "auto-discovered user_id from BookStack"
+/// in the response. The classifier treats user_id as the canonical naming
+/// key for per-user resources, so getting it populated makes
+/// auto-provisioning's "find-or-create by name" more deterministic.
+pub async fn auto_discover_user_identity(
+    client: &BookStackClient,
+    settings: &mut UserSettings,
+) -> Option<String> {
+    let needs_user_id = settings.user_id.as_deref().map(|s| s.is_empty()).unwrap_or(true);
+    let needs_bookstack_user_id = settings.bookstack_user_id.is_none();
+    if !needs_user_id && !needs_bookstack_user_id {
+        return None;
+    }
+    let identity = match client.whoami().await {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            // No content yet — nothing to introspect. Caller surfaces the
+            // setup_nudge for `user_id` if still unset.
+            return Some(
+                "whoami: BookStack returned no content for the authenticated user; \
+                 user_id stays unset until the user creates content (or sets it manually)"
+                    .to_string(),
+            );
+        }
+        Err(e) => {
+            eprintln!("auto_discover_user_identity: whoami failed (non-fatal): {e}");
+            return Some(format!("whoami probe failed (non-fatal): {e}"));
+        }
+    };
+
+    let mut summary_parts = Vec::new();
+    if needs_user_id {
+        // Prefer email as user_id (stable, human-readable, unique) — fall back
+        // to BookStack's display name only if email is missing (rare).
+        let chosen = identity
+            .email
+            .clone()
+            .filter(|e| !e.is_empty())
+            .unwrap_or_else(|| identity.name.clone());
+        if !chosen.is_empty() {
+            settings.user_id = Some(chosen.clone());
+            summary_parts.push(format!("user_id={chosen}"));
+        }
+    }
+    if needs_bookstack_user_id {
+        settings.bookstack_user_id = Some(identity.bookstack_user_id);
+        summary_parts.push(format!("bookstack_user_id={}", identity.bookstack_user_id));
+    }
+
+    if summary_parts.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "Auto-discovered from BookStack /api/users via whoami probe: {}",
+            summary_parts.join(", ")
+        ))
+    }
+}
+
 /// What changed during a provisioning pass. Returned so the caller (typically
 /// `singletons::read_user`) can persist the new IDs and surface a human
 /// summary in the response.
@@ -61,10 +128,19 @@ pub async fn auto_provision_user_identity(
 ) -> UserProvisionResult {
     let mut result = UserProvisionResult::default();
 
+    // Step 0: try to auto-discover user_id + bookstack_user_id from BookStack
+    // before bailing on a missing user_id. This is what makes the per-user
+    // resources nameable without the user pre-configuring anything.
+    if let Some(summary) = auto_discover_user_identity(client, settings).await {
+        result.warnings.push(summary);
+    }
+
     let user_id = match settings.user_id.as_ref() {
         Some(uid) if !uid.is_empty() => uid.clone(),
         _ => {
-            // No user_id → can't name per-user resources. Quietly skip.
+            // No user_id even after whoami — typically a brand-new BookStack
+            // account with no content yet. Quietly skip; subsequent calls
+            // will retry the whoami probe.
             return result;
         }
     };


### PR DESCRIPTION
## Summary

**Phase 2 of the v1.0.0 work** (RFC #28). Two commits, each independently reviewable.

### Phase 2a — `whoami` auto-discovery (commit `0d32a8e`)

Auto-populates `user_id` and `bookstack_user_id` in `user_settings` the first time `remember_user action=read` runs against a configured token. Both fields stop showing up in the briefing's `setup_nudge`.

BookStack has no `/api/users/me`, so `BookStackClient::whoami()` probes via `search_content("{type:page} {created_by:me}", page=1, count=1)` — BookStack resolves `me` server-side. The first result's `created_by.id` reveals the user id; `get_user(id)` returns email + name (anyone can read their own user row). Returns `Ok(None)` for brand-new accounts with no content; the next call retries.

`auto_provision_user_identity` calls `auto_discover_user_identity` as step 0 before bailing on missing `user_id` — typical first-call flow becomes `whoami probe → settings populated → existing provisioning steps name per-user resources from the discovered id`.

### Phase 2b — `append` / `update_section` / `append_section` actions (commit `09c6d14`)

Three new non-destructive action verbs on the `/remember` protocol. Pure-additive — every existing `write` caller works unchanged.

- **`append`** (collections only — journal / collage / shared_collage / user_journal): adds body to existing page or creates one. Optional `timestamp=true` prefixes the appended chunk with `## HH:MM TZ` using the user's local timezone. Stamps `last_appended_at` + `append_count` (parsed-and-incremented from the existing frontmatter, so the original `written_at` is preserved).
- **`update_section`** (collections + singletons whoami/user): replaces the named H2 section's body, preserves every other section. Match on exact H2 text (whitespace-trimmed). Falls back to appending the section at end-of-body when missing.
- **`append_section`** (collections + singletons): same matching, appends to section body instead of replacing. Falls back to creating the section when missing.

Both `update_section` and `append_section` stamp `last_section_update_at` + `last_updated_section`, preserving `written_at` from the original creation.

New module `crates/bsmcp-server/src/remember/section.rs`: pure-function H2 finder + replace + append, with 12 unit tests covering H2-vs-H1/H3 disambiguation, last-section boundary, replace-preserves-others, append-creates-when-missing, CRLF tolerance, whitespace-trim matching, etc.

MCP tool surface: action enum on every `remember_*` tool expanded to include the new verbs. Tool descriptions updated to steer agents toward non-destructive edits ("Prefer update_section / append_section over write for incremental edits"). `common_collection_props` gains `section` (string) and `timestamp` (boolean).

Audit log gate widened to log every state-changing action.

## Why this matters

The RFC's motivation: we hit destructive `write` live during v0.7.4 smoke testing — a single `journal write key=2026-04-27` clobbered the day's actual content. The destructive verb stays for callers that genuinely want it; agents now have the right verbs for incremental edits without read-modify-write cycles.

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (37 tests; 12 new in `section.rs`)
- [x] Live: revoke + recreate a BookStack token, run `remember_user action=read` once, confirm `user_id` + `bookstack_user_id` auto-populate.
- [x] Live: `remember_journal action=append key=2026-04-27 body="..." timestamp=true` adds to today's entry without clobbering, frontmatter shows `append_count: 1` then `2` after another append.
- [x] Live: `remember_user action=update_section section="Communication style" body="Terse..."` replaces just that section, preserves "Working preferences" / "Recurring topics" / etc.
- [x] Live: `remember_user action=append_section section="Recurring topics" body="- New project: ATLAS"` appends one bullet to that section, leaves the rest alone.
- [x] Live: section ops on a page with no matching H2 create the section at end-of-body.

## What this PR does NOT do

- Doesn't move auto-provision under the OAuth probe path — whoami runs lazily on first `remember_user`, not at token-validate time. Lazy avoids extra API roundtrips per login.
- Doesn't touch the schema (Phase 3 / PR #27).
- Doesn't change reading paths to use the index/cache (Phase 5).

Refs: #28 (RFC v2 — v1.0.0 architecture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)