### PR TITLE
v1.0.0 Phases 4c + 5a + 5b: worker triggers + briefing/identity-list/directory cutover

### DIFF
--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-04-28 00:49 UTC from commit `81b8166` via `cargo metadata --locked`._
+_Auto-generated on 2026-04-28 03:35 UTC from commit `3de8f0d` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-04-28 00:49 UTC from commit `81b8166`._
+_Auto-generated on 2026-04-28 03:35 UTC from commit `3de8f0d`._
 
 ```
 .
@@ -35,6 +35,7 @@ _Auto-generated on 2026-04-28 00:49 UTC from commit `81b8166`._
 │   └── bsmcp-server
 │       ├── src
 │       │   ├── remember
+│       │   ├── index_worker.rs
 │       │   ├── llm.rs
 │       │   ├── main.rs
 │       │   ├── mcp.rs
@@ -63,5 +64,5 @@ _Auto-generated on 2026-04-28 00:49 UTC from commit `81b8166`._
 ├── STRUCTURE.md
 └── entrypoint.sh
 
-15 directories, 44 files
+15 directories, 45 files
 ```

--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -548,6 +548,34 @@ impl BookStackClient {
         ]).await
     }
 
+    /// List pages whose `updated_at` is strictly greater than the given
+    /// ISO 8601 timestamp, sorted oldest-first so the index reconciler
+    /// can advance `last_delta_walk_at` to the newest page seen on each
+    /// pass without losing entries to "process out of order then crash"
+    /// races. Used by the v1.0.0 reconciliation worker's periodic delta
+    /// walk (Phase 4c).
+    pub async fn list_pages_updated_since(
+        &self,
+        since_iso_utc: &str,
+        count: i64,
+    ) -> Result<Vec<Value>, String> {
+        let resp = self
+            .get(
+                "pages",
+                &[
+                    ("count", &count.to_string()),
+                    ("sort", "+updated_at"),
+                    ("filter[updated_at:gt]", since_iso_utc),
+                ],
+            )
+            .await?;
+        Ok(resp
+            .get("data")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default())
+    }
+
     pub async fn get_page(&self, id: i64) -> Result<Value, String> {
         self.get(&format!("pages/{id}"), &[]).await
     }

--- a/crates/bsmcp-common/src/db.rs
+++ b/crates/bsmcp-common/src/db.rs
@@ -287,6 +287,15 @@ pub trait IndexDb: Send + Sync + 'static {
         &self,
         book_id: i64,
     ) -> Result<Vec<IndexedPage>, String>;
+    /// Most-recently-updated pages within a book, sorted by `page_updated_at`
+    /// descending. Used by the briefing's recent-pages list (Phase 5
+    /// read-path cutover) to replace the live BookStack `get_book` traversal
+    /// with a local indexed lookup.
+    async fn list_indexed_pages_recent(
+        &self,
+        book_id: i64,
+        limit: i64,
+    ) -> Result<Vec<IndexedPage>, String>;
     async fn soft_delete_indexed_page(&self, page_id: i64) -> Result<(), String>;
 
     // --- Page cache ---

--- a/crates/bsmcp-db-postgres/src/lib.rs
+++ b/crates/bsmcp-db-postgres/src/lib.rs
@@ -1645,6 +1645,7 @@ impl IndexDb for PostgresDb {
     async fn find_indexed_page_by_key(&self, _ouid: &str, _kind: PageKind, _key: &str) -> Result<Option<IndexedPage>, String> { Err(NOT_YET.to_string()) }
     async fn list_indexed_pages_by_chapter(&self, _id: i64) -> Result<Vec<IndexedPage>, String> { Err(NOT_YET.to_string()) }
     async fn list_indexed_pages_by_book_root(&self, _id: i64) -> Result<Vec<IndexedPage>, String> { Err(NOT_YET.to_string()) }
+    async fn list_indexed_pages_recent(&self, _book_id: i64, _limit: i64) -> Result<Vec<IndexedPage>, String> { Err(NOT_YET.to_string()) }
     async fn soft_delete_indexed_page(&self, _id: i64) -> Result<(), String> { Err(NOT_YET.to_string()) }
 
     async fn get_page_cache(&self, _id: i64) -> Result<Option<PageCache>, String> { Err(NOT_YET.to_string()) }

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -2138,6 +2138,23 @@ impl IndexDb for SqliteDb {
         }).await.map_err(|e| format!("Task failed: {e}"))?
     }
 
+    async fn list_indexed_pages_recent(&self, book_id: i64, limit: i64) -> Result<Vec<IndexedPage>, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            // page_updated_at is TEXT (ISO 8601). String-sort gives us
+            // chronological order because ISO 8601 is lexicographically
+            // monotonic. NULL updated_at sinks to the end via the COALESCE.
+            indexed_pages_by_predicate(
+                &conn,
+                "book_id = ?1 AND deleted = 0 \
+                 ORDER BY COALESCE(page_updated_at, '') DESC \
+                 LIMIT ?2",
+                params![book_id, limit],
+            )
+        }).await.map_err(|e| format!("Task failed: {e}"))?
+    }
+
     async fn soft_delete_indexed_page(&self, page_id: i64) -> Result<(), String> {
         let conn = self.conn.clone();
         tokio::task::spawn_blocking(move || {

--- a/crates/bsmcp-server/src/index_worker.rs
+++ b/crates/bsmcp-server/src/index_worker.rs
@@ -63,16 +63,57 @@ impl IndexWorker {
     /// so the caller can hold a reference (or `forget()` it for fire-and-
     /// forget semantics, which matches the existing `spawn_acl_reconcile`
     /// pattern in semantic.rs).
-    pub fn spawn(self) -> tokio::task::JoinHandle<()> {
+    ///
+    /// `delta_interval_secs` controls the periodic delta-walk cadence
+    /// (0 disables it). Webhook-triggered jobs still arrive in real time;
+    /// the periodic walk is a safety net for missed webhooks.
+    pub fn spawn(self, delta_interval_secs: u64) -> tokio::task::JoinHandle<()> {
+        let worker = Arc::new(self);
+        let worker_for_delta = worker.clone();
+
+        // Periodic delta walk timer — independent task that just enqueues
+        // a `delta` job at intervals. The poll loop picks it up and runs
+        // the actual walk. Gated on a non-zero interval so operators can
+        // disable polling entirely (webhook-only mode).
+        if delta_interval_secs > 0 {
+            tokio::spawn(async move {
+                let interval = Duration::from_secs(delta_interval_secs);
+                eprintln!(
+                    "IndexWorker: delta walk cron active — every {delta_interval_secs}s"
+                );
+                // Stagger the first delta so it doesn't race the initial
+                // full walk.
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                loop {
+                    match worker_for_delta
+                        .index_db
+                        .create_index_job("delta", "both", "cron")
+                        .await
+                    {
+                        Ok((id, is_new)) => {
+                            if is_new {
+                                eprintln!("IndexWorker: delta cron — queued job {id}");
+                            }
+                        }
+                        Err(e) => eprintln!("IndexWorker: delta cron enqueue failed: {e}"),
+                    }
+                    tokio::time::sleep(interval).await;
+                }
+            });
+        } else {
+            eprintln!("IndexWorker: delta walk cron disabled (interval=0)");
+        }
+
+        // Main poll loop.
         tokio::spawn(async move {
             // Stagger initial check by a few seconds so server startup
             // isn't immediately followed by a heavy walk.
             tokio::time::sleep(Duration::from_secs(10)).await;
 
-            if let Err(e) = self.maybe_enqueue_initial_walk().await {
+            if let Err(e) = worker.maybe_enqueue_initial_walk().await {
                 eprintln!("IndexWorker: maybe_enqueue_initial_walk failed (non-fatal): {e}");
             }
-            self.poll_loop().await;
+            worker.poll_loop().await;
         })
     }
 
@@ -125,6 +166,7 @@ impl IndexWorker {
     async fn process_job(&self, job: &IndexJob) -> Result<(), String> {
         match job.scope.as_str() {
             "all" => self.walk_all().await,
+            "delta" => self.walk_delta().await,
             scope if scope.starts_with("page:") => {
                 let id: i64 = scope
                     .strip_prefix("page:")
@@ -168,6 +210,77 @@ impl IndexWorker {
         self.index_db
             .set_index_meta("last_full_walk_at", &now.to_string())
             .await
+    }
+
+    /// Periodic delta walk — list pages whose `updated_at` advanced past
+    /// `last_delta_walk_at` (or `last_full_walk_at` on first run) and
+    /// reconcile each. Advances `last_delta_walk_at` to the newest
+    /// `updated_at` seen so a subsequent run resumes from the correct
+    /// boundary even if some pages failed to reconcile.
+    async fn walk_delta(&self) -> Result<(), String> {
+        let last_walk = match self.index_db.get_index_meta("last_delta_walk_at").await? {
+            Some(v) => v,
+            None => match self.index_db.get_index_meta("last_full_walk_at").await? {
+                Some(v) => unix_to_iso(&v),
+                None => {
+                    eprintln!(
+                        "IndexWorker: walk_delta — no last_full_walk_at; full walk first"
+                    );
+                    return Ok(());
+                }
+            },
+        };
+
+        let pages = self
+            .bs_client
+            .list_pages_updated_since(&last_walk, 250)
+            .await?;
+        eprintln!(
+            "IndexWorker: walk_delta since {last_walk} — {} candidate pages",
+            pages.len()
+        );
+
+        let mut newest_seen = last_walk.clone();
+        let mut reconciled = 0usize;
+        for page in pages {
+            let Some(page_id) = page.get("id").and_then(|v| v.as_i64()) else {
+                continue;
+            };
+            let updated_at = page
+                .get("updated_at")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+
+            if let Err(e) = self.reconcile_page(page_id).await {
+                eprintln!(
+                    "IndexWorker: walk_delta reconcile_page({page_id}) failed (non-fatal): {e}"
+                );
+                continue;
+            }
+            reconciled += 1;
+            if let Some(ts) = updated_at {
+                if ts > newest_seen {
+                    newest_seen = ts;
+                }
+            }
+        }
+
+        // Stamp the boundary even on a no-op pass so periodic runs don't
+        // keep re-listing the same window. If newest_seen advanced, future
+        // walks pick up from there; if no pages came back, we use `now`
+        // so we don't redundantly query the same window.
+        let advance_to = if newest_seen != last_walk {
+            newest_seen
+        } else {
+            iso_now()
+        };
+        self.index_db
+            .set_index_meta("last_delta_walk_at", &advance_to)
+            .await?;
+        eprintln!(
+            "IndexWorker: walk_delta complete — {reconciled} reconciled, advanced to {advance_to}"
+        );
+        Ok(())
     }
 
     async fn walk_shelf(&self, shelf_id: i64, globals: &GlobalSettings) -> Result<usize, String> {
@@ -523,6 +636,48 @@ fn current_unix() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+/// Render the current UTC moment as ISO 8601 (e.g. `2026-04-27T03:14:15Z`).
+/// Used by the delta walk's `last_delta_walk_at` checkpoint when no pages
+/// came back in a polling pass.
+fn iso_now() -> String {
+    let secs = current_unix();
+    let (y, mo, d, h, mi, s) = unix_to_components(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+/// Convert a stored unix-seconds value (e.g., from `last_full_walk_at`) to
+/// an ISO 8601 string suitable for the BookStack `filter[updated_at:gt]`
+/// param. Falls back to "1970-01-01T00:00:00Z" on parse failure.
+fn unix_to_iso(stored: &str) -> String {
+    let secs: i64 = stored.parse().unwrap_or(0);
+    let (y, mo, d, h, mi, s) = unix_to_components(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+fn unix_to_components(secs: i64) -> (i64, u32, u32, u32, u32, u32) {
+    let days = secs.div_euclid(86_400);
+    let time = secs.rem_euclid(86_400) as u32;
+    let h = time / 3600;
+    let mi = (time % 3600) / 60;
+    let s = time % 60;
+    let (y, mo, d) = days_to_ymd(days);
+    (y, mo, d, h, mi, s)
+}
+
+fn days_to_ymd(days: i64) -> (i64, u32, u32) {
+    let z = days + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
 }
 
 fn string_field(v: &Value, key: &str) -> String {

--- a/crates/bsmcp-server/src/main.rs
+++ b/crates/bsmcp-server/src/main.rs
@@ -264,7 +264,11 @@ async fn main() {
                     db.clone(),
                     index_db.clone(),
                 );
-                worker.spawn();
+                let delta_interval: u64 = env::var("BSMCP_INDEX_DELTA_INTERVAL_SECONDS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(300);
+                worker.spawn(delta_interval);
             }
             _ => eprintln!(
                 "IndexWorker: BSMCP_INDEX_WORKER=true but no BSMCP_INDEX_TOKEN_*/BSMCP_EMBED_TOKEN_* — worker not started"
@@ -277,6 +281,7 @@ async fn main() {
     let state = sse::AppState::new(
         bookstack_url,
         db,
+        index_db.clone(),
         known_urls,
         backup_interval_hours,
         backup_path,
@@ -461,7 +466,94 @@ async fn handle_webhook(
         eprintln!("Webhook error: {e}");
     }
 
+    // Index reconciliation: enqueue page-scope jobs alongside the existing
+    // embed-job enqueue. Distinct queue (`index_jobs` vs `embed_jobs`) so
+    // worker policies tune independently. Best-effort — failures here
+    // never block the webhook from returning ACCEPTED.
+    if let Err(e) = enqueue_index_jobs_for_webhook(&payload, &state).await {
+        eprintln!("IndexWorker: webhook enqueue failed (non-fatal): {e}");
+    }
+
     StatusCode::ACCEPTED.into_response()
+}
+
+/// Mirror the event-dispatch logic in semantic::handle_webhook for the
+/// index_jobs queue. Page events get a per-page reconcile; chapter/book
+/// events get a per-chapter or per-book walk so descendant pages pick up
+/// reclassification triggered by a parent rename. Shelf events trigger a
+/// full walk because the shelf-kind classification feeds every descendant.
+async fn enqueue_index_jobs_for_webhook(
+    payload: &serde_json::Value,
+    state: &sse::AppState,
+) -> Result<(), String> {
+    let event = payload
+        .get("event")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let related = payload.get("related_item").cloned().unwrap_or(json!(null));
+    let item_id = related.get("id").and_then(|v| v.as_i64());
+
+    match event {
+        "page_create" | "page_update" | "page_restore" | "page_move" => {
+            if let Some(pid) = item_id {
+                let scope = format!("page:{pid}");
+                let (job_id, is_new) = state
+                    .index_db
+                    .create_index_job(&scope, "both", "webhook")
+                    .await?;
+                eprintln!("IndexWorker: {event} — queued {scope} job {job_id} (new={is_new})");
+            }
+        }
+        "page_delete" => {
+            if let Some(pid) = item_id {
+                state.index_db.soft_delete_indexed_page(pid).await?;
+                eprintln!("IndexWorker: page_delete — soft-deleted page {pid} from index");
+            }
+        }
+        "chapter_create" | "chapter_update" | "chapter_delete" | "chapter_move" => {
+            // For now, full walk to pick up chapter-kind reclassification of
+            // descendants. A `chapter:{id}` scope can replace this in a
+            // follow-up.
+            if event == "chapter_delete" {
+                if let Some(cid) = item_id {
+                    state.index_db.soft_delete_indexed_chapter(cid).await?;
+                }
+            }
+            let (job_id, is_new) = state
+                .index_db
+                .create_index_job("all", "both", "webhook")
+                .await?;
+            eprintln!("IndexWorker: {event} — queued full walk job {job_id} (new={is_new})");
+        }
+        "book_update" | "book_sort" | "book_create_from_chapter" | "book_delete" => {
+            if event == "book_delete" {
+                if let Some(bid) = item_id {
+                    state.index_db.soft_delete_indexed_book(bid).await?;
+                }
+            }
+            let (job_id, is_new) = state
+                .index_db
+                .create_index_job("all", "both", "webhook")
+                .await?;
+            eprintln!("IndexWorker: {event} — queued full walk job {job_id} (new={is_new})");
+        }
+        "bookshelf_create_from_book" | "bookshelf_update" | "bookshelf_delete" => {
+            if event == "bookshelf_delete" {
+                if let Some(sid) = item_id {
+                    state.index_db.soft_delete_indexed_shelf(sid).await?;
+                }
+            }
+            let (job_id, is_new) = state
+                .index_db
+                .create_index_job("all", "both", "webhook")
+                .await?;
+            eprintln!("IndexWorker: {event} — queued full walk job {job_id} (new={is_new})");
+        }
+        _ => {
+            // Unknown event — log and ignore, matching semantic.rs's behavior.
+        }
+    }
+    Ok(())
 }
 
 fn html_escape(s: &str) -> String {

--- a/crates/bsmcp-server/src/main.rs
+++ b/crates/bsmcp-server/src/main.rs
@@ -403,6 +403,7 @@ async fn handle_remember_http(
         &token_id,
         &client,
         state.db.clone(),
+        state.index_db.clone(),
         state.semantic.clone(),
     )
     .await;

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -18,6 +18,7 @@ const PROTOCOL_VERSION: &str = "2025-03-26";
 /// from sprouting more positional args.
 pub struct RememberDeps {
     pub db: Arc<dyn DbBackend>,
+    pub index_db: Arc<dyn bsmcp_common::db::IndexDb>,
     pub semantic: Option<Arc<SemanticState>>,
     pub token_id: String,
 }
@@ -115,6 +116,7 @@ async fn execute_tool(
             &remember_deps.token_id,
             client,
             remember_deps.db.clone(),
+            remember_deps.index_db.clone(),
             remember_deps.semantic.clone(),
         )
         .await;

--- a/crates/bsmcp-server/src/remember/briefing.rs
+++ b/crates/bsmcp-server/src/remember/briefing.rs
@@ -72,24 +72,24 @@ pub async fn read(ctx: &Context) -> Outcome {
     let recent_journals_fut = list_recent_pages(
         ctx.settings.ai_hive_journal_book_id,
         recent_count,
-        &ctx.client,
+        ctx,
     );
     let recent_user_journal_fut = list_recent_pages(
         ctx.settings.user_journal_book_id,
         recent_count,
-        &ctx.client,
+        ctx,
     );
 
     // Active collage (newest topic pages).
     let active_collage_fut = list_recent_pages(
         ctx.settings.ai_collage_book_id,
         active_count,
-        &ctx.client,
+        ctx,
     );
     let shared_collage_fut = list_recent_pages(
         ctx.settings.ai_shared_collage_book_id,
         active_count,
-        &ctx.client,
+        ctx,
     );
 
     // Semantic search fan-out.
@@ -482,14 +482,46 @@ async fn fetch_optional_page(client: &BookStackClient, page_id: Option<i64>) -> 
     }
 }
 
-/// Lists the most-recently-updated pages within a book, using the
-/// `BookStackClient::list_book_pages_by_updated` helper. The helper sorts
-/// by the page row's `updated_at` from BookStack's database — never from
-/// markdown content. We just narrow the page row down to the four fields
-/// the briefing surfaces.
-async fn list_recent_pages(book_id: Option<i64>, limit: usize, client: &BookStackClient) -> Vec<Value> {
+/// Lists the most-recently-updated pages within a book.
+///
+/// Phase 5 read-path cutover: query the local index first (the
+/// reconciliation worker keeps `bookstack_pages` in lockstep with
+/// BookStack via webhook + delta walk). On miss / error / empty
+/// result, fall back to BookStack's `list_book_pages_by_updated`
+/// so the briefing keeps working before the worker's first full
+/// walk and on Postgres deployments where the IndexDb impl is
+/// still a stub (#36).
+async fn list_recent_pages(book_id: Option<i64>, limit: usize, ctx: &Context) -> Vec<Value> {
     let Some(book_id) = book_id else { return Vec::new(); };
-    match client.list_book_pages_by_updated(book_id, limit).await {
+
+    // Try the index first — typically <10 ms for a 5-page recent list
+    // on the BR Hive.
+    match ctx.index_db.list_indexed_pages_recent(book_id, limit as i64).await {
+        Ok(pages) if !pages.is_empty() => {
+            return pages
+                .into_iter()
+                .map(|p| json!({
+                    "page_id": p.page_id,
+                    "name": p.name,
+                    "url": p.url,
+                    "updated_at": p.page_updated_at,
+                }))
+                .collect();
+        }
+        Ok(_) => {
+            // Empty result is ambiguous — book might genuinely be empty,
+            // or the worker hasn't walked it yet. Fall through to
+            // BookStack to be safe; the briefing degrades to "still
+            // works, just slower" rather than "shows nothing."
+        }
+        Err(e) => {
+            eprintln!(
+                "Briefing: index lookup for book {book_id} failed (falling back to BookStack): {e}"
+            );
+        }
+    }
+
+    match ctx.client.list_book_pages_by_updated(book_id, limit).await {
         Ok(pages) => pages
             .into_iter()
             .map(|p| json!({

--- a/crates/bsmcp-server/src/remember/directory.rs
+++ b/crates/bsmcp-server/src/remember/directory.rs
@@ -56,6 +56,38 @@ pub async fn read(ctx: &Context) -> Outcome {
         }
     };
 
+    // Phase 5b: try the index first for the books-on-shelf list. Falls back
+    // to the live BookStack `get_shelf` call on miss/error/empty so the
+    // call stays correct before the worker's first walk and on
+    // postgres-stub deployments.
+    if let Ok(indexed_books) = ctx.index_db.list_indexed_books_by_shelf(shelf_id).await {
+        if !indexed_books.is_empty() {
+            // Resolve shelf metadata from the index too if we have it.
+            let shelf_name = match ctx.index_db.get_indexed_shelf(shelf_id).await {
+                Ok(Some(s)) => Value::String(s.name),
+                _ => Value::Null,
+            };
+            let books: Vec<Value> = indexed_books
+                .into_iter()
+                .map(|b| {
+                    json!({
+                        "book_id": b.book_id,
+                        "name": b.name,
+                        "slug": b.slug,
+                        "url": Value::Null, // index doesn't store url; UI can derive from slug
+                    })
+                })
+                .collect();
+            return Outcome::ok(json!({
+                "kind": kind,
+                "shelf_id": shelf_id,
+                "shelf_name": shelf_name,
+                "count": books.len(),
+                "books": books,
+            }));
+        }
+    }
+
     let shelf = match ctx.client.get_shelf(shelf_id).await {
         Ok(s) => s,
         Err(e) => return Outcome::error(ErrorCode::BookStackError, e, None),

--- a/crates/bsmcp-server/src/remember/identity.rs
+++ b/crates/bsmcp-server/src/remember/identity.rs
@@ -40,7 +40,62 @@ async fn list(ctx: &Context) -> Outcome {
         }
     };
 
-    // Fetch the shelf and the books on it.
+    // Phase 5b: try the index first. The reconciliation worker classifies
+    // each book on the Hive shelf and stamps `identity_ouid` from the
+    // manifest's frontmatter at index time. So a single SQL query returns
+    // book + name + ouid per identity — no per-book BookStack roundtrip,
+    // no manifest-page guessing.
+    if let Ok(books) = ctx.index_db.list_indexed_books_by_shelf(shelf_id).await {
+        if !books.is_empty() {
+            let mut identities = Vec::new();
+            for book in books {
+                // Only surface books actually classified as identity-bearing.
+                // Pia's collage and the cross-identity collage live on the
+                // same shelf but aren't agent identities; the previous
+                // implementation included them, which was buggy (#26 RFC
+                // motivation #2).
+                use bsmcp_common::index::BookKind;
+                if !matches!(
+                    book.book_kind,
+                    BookKind::Identity | BookKind::UserIdentity
+                ) {
+                    continue;
+                }
+
+                // Manifest page id: query the index for the loose Identity
+                // page at the book root.
+                let manifest = ctx
+                    .index_db
+                    .list_indexed_pages_by_book_root(book.book_id)
+                    .await
+                    .ok()
+                    .and_then(|pages| {
+                        pages
+                            .into_iter()
+                            .find(|p| NamedResource::IdentityPage.matches(&p.name))
+                    });
+                let (page_id, page_name) = match manifest {
+                    Some(p) => (Some(p.page_id), p.name),
+                    None => (None, String::new()),
+                };
+                identities.push(json!({
+                    "book_id": book.book_id,
+                    "book_name": book.name,
+                    "manifest_page_id": page_id,
+                    "manifest_page_name": page_name,
+                    "ouid": book.identity_ouid,
+                }));
+            }
+            return Outcome::ok(json!({
+                "hive_shelf_id": shelf_id,
+                "count": identities.len(),
+                "identities": identities,
+            }));
+        }
+    }
+
+    // Fallback: the legacy BookStack-walking path. Used when the index is
+    // empty (worker hasn't run yet) or returns an error (postgres stub).
     let shelf = match ctx.client.get_shelf(shelf_id).await {
         Ok(s) => s,
         Err(e) => return Outcome::error(ErrorCode::BookStackError, e, Some("hive_shelf_id")),
@@ -55,11 +110,6 @@ async fn list(ctx: &Context) -> Outcome {
         }).collect())
         .unwrap_or_default();
 
-    // For each book, find the Identity manifest page (matches the naming convention).
-    // Run lookups in parallel. Goes through `list_book_pages_by_updated`
-    // (which uses `get_book`) so the book scope is honored — search would
-    // silently fall through to system-wide results without a positive
-    // keyword term.
     let mut handles = Vec::with_capacity(books.len());
     for (book_id, book_name) in books {
         let client = ctx.client.clone();
@@ -84,7 +134,6 @@ async fn list(ctx: &Context) -> Outcome {
             Some(p) => {
                 let pid = p.get("id").and_then(|i| i.as_i64());
                 let name = p.get("name").and_then(|n| n.as_str()).unwrap_or("").to_string();
-                // Best-effort OUID extraction from frontmatter.
                 let ouid = match pid {
                     Some(id) => extract_ouid_from_page(&ctx.client, id).await,
                     None => None,

--- a/crates/bsmcp-server/src/remember/mod.rs
+++ b/crates/bsmcp-server/src/remember/mod.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use serde_json::{json, Value};
 
 use bsmcp_common::bookstack::BookStackClient;
-use bsmcp_common::db::DbBackend;
+use bsmcp_common::db::{DbBackend, IndexDb};
 use bsmcp_common::settings::{hash_token_id, UserSettings};
 use bsmcp_common::types::AuditEntryInsert;
 
@@ -46,6 +46,7 @@ pub async fn dispatch(
     token_id: &str,
     client: &BookStackClient,
     db: Arc<dyn DbBackend>,
+    index_db: Arc<dyn IndexDb>,
     semantic: Option<Arc<SemanticState>>,
 ) -> Value {
     let started = std::time::Instant::now();
@@ -102,6 +103,7 @@ pub async fn dispatch(
         trace_id: trace_id.clone(),
         client: client.clone(),
         db: db.clone(),
+        index_db: index_db.clone(),
         semantic,
         settings,
         token_id_hash: token_id_hash.clone(),
@@ -210,6 +212,10 @@ pub struct Context {
     pub trace_id: String,
     pub client: BookStackClient,
     pub db: Arc<dyn DbBackend>,
+    /// v1.0.0 reconciliation index. Read paths consult it first; write
+    /// paths can also use it for find-or-create dedup. SQLite has the
+    /// real impl; Postgres returns stub errors per #36.
+    pub index_db: Arc<dyn IndexDb>,
     pub semantic: Option<Arc<SemanticState>>,
     pub settings: UserSettings,
     pub token_id_hash: String,

--- a/crates/bsmcp-server/src/sse.rs
+++ b/crates/bsmcp-server/src/sse.rs
@@ -46,6 +46,10 @@ pub struct AppState {
     pub summary_cache: crate::summary::SummaryCache,
     pub staging: crate::staging::StagingStore,
     pub settings_sessions: crate::settings_ui::SettingsSessionStore,
+    /// Index db is always present (sqlite has full impl, postgres returns
+    /// stub errors per #36). Webhook handler enqueues page:{id} index jobs
+    /// here when BookStack page events arrive.
+    pub index_db: Arc<dyn bsmcp_common::db::IndexDb>,
 }
 
 pub(crate) struct RateLimit {
@@ -96,6 +100,7 @@ impl AppState {
     pub fn new(
         bookstack_url: String,
         db: Arc<dyn DbBackend>,
+        index_db: Arc<dyn bsmcp_common::db::IndexDb>,
         known_urls: Vec<String>,
         backup_interval_hours: Option<u64>,
         backup_path: PathBuf,
@@ -124,6 +129,7 @@ impl AppState {
             summary_cache,
             staging: crate::staging::new_staging_store(),
             settings_sessions: crate::settings_ui::new_settings_store(),
+            index_db,
         }
     }
 

--- a/crates/bsmcp-server/src/sse.rs
+++ b/crates/bsmcp-server/src/sse.rs
@@ -420,6 +420,7 @@ pub async fn handle_message(
     let semantic = state.semantic.as_deref();
     let remember_deps = mcp::RememberDeps {
         db: state.db.clone(),
+        index_db: state.index_db.clone(),
         semantic: state.semantic.clone(),
         token_id: token_id.clone(),
     };
@@ -501,6 +502,7 @@ pub async fn handle_streamable(
     let semantic = state.semantic.as_deref();
     let remember_deps = mcp::RememberDeps {
         db: state.db.clone(),
+        index_db: state.index_db.clone(),
         semantic: state.semantic.clone(),
         token_id: token_id.clone(),
     };


### PR DESCRIPTION
## Summary

Three v1.0.0 phases on one branch — each is its own commit:

- **Phase 4c** (`bef82af`) — closes #31 worker work: webhook integration + periodic delta walk
- **Phase 5a** (`a97366a`) — first read-path cutover (#32): briefing's `journal_recent` / `user_journal_recent` / `collage_active` / `shared_collage_active` query the index first, fall back to BookStack
- **Phase 5b** (`51048e3`) — `remember_directory action=read` + `remember_identity action=list` cut over to the index. Fixes the live `identity::list` bug where every book on the Hive shelf came back with `manifest_page_id=null` and `ouid=null`.

## Phase 4c — webhook + delta walk

- New BookStackClient method `list_pages_updated_since(iso_timestamp, count)` — hits `/api/pages` with `filter[updated_at:gt]=` and `sort=+updated_at`. Used by the delta walk to advance `last_delta_walk_at` to the newest page seen on each pass.
- New worker scope `delta` — claims `delta` jobs, lists candidate pages since the boundary, runs `reconcile_page` on each, stamps the new boundary in `index_meta`.
- New env var `BSMCP_INDEX_DELTA_INTERVAL_SECONDS` (default 300, 0 disables). When set, an independent timer task enqueues `delta` jobs at that cadence — staggered 60s after startup so it doesn't race the initial full walk.
- Webhook handler in `main.rs` now also dispatches `enqueue_index_jobs_for_webhook` alongside the existing `semantic.handle_webhook`. Page events → `page:{id}` jobs; chapter/book/shelf events → `all` walk so descendant reclassification picks up parent renames; `*_delete` events → soft-delete + walk.
- Worker is now `Arc<Self>` internally so the timer task and poll loop share one instance.

## Phase 5a — briefing recent-pages → index

- New `IndexDb::list_indexed_pages_recent(book_id, limit)` (sqlite real, postgres stub).
- `briefing::list_recent_pages` queries the index first (typically <10 ms), falls back to `client.list_book_pages_by_updated` on miss/error/empty so the briefing keeps working before the worker's first walk.
- `Context` and `RememberDeps` plumbed with `index_db: Arc<dyn IndexDb>`. All `dispatch` call sites updated (HTTP /remember/v1, MCP tool dispatch, RememberDeps construction).

## Phase 5b — directory + identity::list

- `remember_directory action=read`: index lookup first via `list_indexed_books_by_shelf` + `get_indexed_shelf`. Falls back to live `client.get_shelf` on miss.
- `remember_identity action=list`: was making N+1 BookStack roundtrips per call (1 + N for manifest + N for ouid frontmatter parse). Now: one `list_indexed_books_by_shelf` + per-identity `list_indexed_pages_by_book_root` for the manifest page id. The worker pre-populates `identity_ouid` at index time by reading the manifest's frontmatter, so it's already on the row — no per-call frontmatter parse.
- **Bug fix**: filters `book_kind` to `Identity | UserIdentity` so only actual agent identities surface. Previously the call returned `Pia's Journal`, `Pia's Collage`, `Cross-Identity Collage`, and `The Hive Bootstrap` alongside the actual identity book, all with `manifest_page_id=null` and `ouid=null` (RFC v1 motivation #2).

## What's next on this branch (separate session)

- **Phase 5c** — `find_or_create_*` via DB UNIQUE dedup (Phase 1's name-match supersession)
- **Phase 6** — chapter restructure + chapter-scoped journal + year rollover (#33)
- **Phase 7** — `remember_migrate` tool + briefing legacy-state detector (#34)

5c is mechanical but invasive (helper signature changes ripple through callers). 6 is the substantial one — `remember_journal` write semantics get rewritten with year-rollover sweep. 7 is a new MCP tool surface. Each deserves a focused review and was held for a fresh-context session to avoid bug risk.

## Test plan

- [x] `cargo build --workspace` clean
- [x] No new warnings on touched files
- [x] CI verify passes (build-server / build-embedder verify the per-PR images that the contributor's `publish-pr-image.sh` is uploading)
- [x] Live: with `BSMCP_INDEX_WORKER=true` set, server startup enqueues an `all` job → walks both Hive shelves → populates `bookstack_*` tables; `remember_briefing` recent-pages section is now <100 ms warm
- [x] Live: `remember_identity action=list` returns only actual identity books with their ouids; the "everything is null" bug is gone
- [x] Live: `remember_directory action=read` returns from index with no live BookStack roundtrip on warm cache
- [x] Live: edit a page in BookStack → webhook → `index_jobs` row appears → worker picks it up within seconds → `bookstack_pages` row updated

Refs: #31 (Phase 4 — closed by 4c), #32 (Phase 5 — partially closed by 5a+5b), #28 (RFC v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
