### PR TITLE
Phase 5c: index-aware find_or_create + workflow_dispatch recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ on:
     branches: [development, release]
     tags:
       - 'v*'
+  # Manual trigger for push-retag — used when a push event drops (GitHub
+  # Actions occasionally fails to fire workflow runs for squash-merge
+  # commits). Run via `gh workflow run "Build and Release" --ref development`.
+  # Only push-retag respects this trigger; PR build-* jobs and tag-release
+  # gate on their own event types and stay no-ops.
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -169,7 +175,7 @@ jobs:
   #     publish-pr-image.sh on that branch beforehand, producing
   #     `{version}-{branch_slug}-{push_sha}`.
   push-retag:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/release')
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/release')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -149,9 +149,10 @@ echo $GHCR_PAT | docker login ghcr.io -u <gh-user> --password-stdin
 | Push to a work branch with **no open PR** | nothing | test locally |
 | `pull_request: opened/synchronize/reopened` against `development` or `release` | `release.yml` (`build-server`, `build-embedder` verify jobs) | confirms the contributor's per-PR images exist on GHCR with both `linux/amd64` and `linux/arm64`. ~30 seconds. No build. |
 | Same trigger | `generate-artifacts.yml` | regenerates `SBOM.md` + `STRUCTURE.md`, commits to PR source branch with `[skip ci]` |
-| `pull_request: closed && merged: true`, base = `development` | `release.yml` (`promote`) | retags `{version}-{branch-slug}` → `dev` + `{version}-dev`. No rebuild. |
-| `pull_request: closed && merged: true`, base = `release` | `release.yml` (`promote` + `github-release-on-merge` + `release-binaries-on-merge`) | retags → `{version}` + `release` + `latest`; creates GitHub Release; builds `bsmcp-server` native binaries for 5 targets and attaches them to the Release. |
+| `push` to `development` (squash-merge or direct push) | `release.yml` (`push-retag`) | retags the contributor's per-PR image to `:dev`, `:dev-{push_sha}`, `:{version}-dev`, `:{version}-dev-{push_sha}`. No rebuild. |
+| `push` to `release` (squash-merge or direct push) | `release.yml` (`push-retag` + `github-release-on-merge` + `release-binaries-on-merge`) | retags to `:{version}`, `:{version}-{push_sha}`, `:release`, `:latest`; creates GitHub Release; builds `bsmcp-server` native binaries for 5 targets and attaches them to the Release. |
 | `v*` tag push (emergency hotfix only) | `release.yml` (`tag-release` + `github-release-on-tag` + `release-binaries-on-tag`) | builds & pushes semver-tagged images directly in CI (the only build path that still runs in CI), creates the Release, attaches the server binaries. Use only when the contributor cannot push images themselves. |
+| `workflow_dispatch` on `release.yml`, ref = `development` or `release` | `release.yml` (`push-retag`) | manual recovery path when a `push` event drops (GitHub Actions occasionally fails to fire workflow runs for squash-merge commits). Run via `gh workflow run "Build and Release" --ref development`. |
 
 ### Why this shape
 

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-04-28 03:35 UTC from commit `3de8f0d` via `cargo metadata --locked`._
+_Auto-generated on 2026-04-28 03:57 UTC from commit `90050c9` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-04-28 03:35 UTC from commit `3de8f0d`._
+_Auto-generated on 2026-04-28 03:57 UTC from commit `90050c9`._
 
 ```
 .

--- a/crates/bsmcp-server/src/remember/identity.rs
+++ b/crates/bsmcp-server/src/remember/identity.rs
@@ -215,6 +215,7 @@ async fn create(ctx: &Context) -> Outcome {
     let book_description = format!("Identity book for the AI agent {}. Holds the manifest page.", name);
     let book_outcome = provision::find_or_create_book_on_shelf(
         &ctx.client,
+        ctx.index_db.as_ref(),
         hive_shelf_id,
         &book_name,
         &book_description,
@@ -240,6 +241,7 @@ async fn create(ctx: &Context) -> Outcome {
     );
     let page_outcome = provision::find_or_create_page(
         &ctx.client,
+        ctx.index_db.as_ref(),
         Some(book_id),
         None,
         "Identity",

--- a/crates/bsmcp-server/src/remember/provision.rs
+++ b/crates/bsmcp-server/src/remember/provision.rs
@@ -6,6 +6,7 @@
 //! rather than crashing the settings save.
 
 use bsmcp_common::bookstack::{BookStackClient, ContentType};
+use bsmcp_common::db::IndexDb;
 use serde_json::{json, Value};
 
 use super::naming::NamedResource;
@@ -84,12 +85,14 @@ pub async fn create_shelf(
 /// is given, falls back to bare create.
 pub async fn create_book(
     client: &BookStackClient,
+    index_db: &dyn IndexDb,
     resource: NamedResource,
     parent_shelf_id: Option<i64>,
 ) -> ProvisionResult {
     if let Some(shelf_id) = parent_shelf_id {
         return find_or_create_book_on_shelf(
             client,
+            index_db,
             shelf_id,
             resource.default_name(),
             resource.default_description(),
@@ -261,12 +264,13 @@ pub async fn ensure_book_on_shelf(
 /// the briefing's setup_nudge already prompts to fix).
 pub async fn create_named_book(
     client: &BookStackClient,
+    index_db: &dyn IndexDb,
     name: &str,
     description: &str,
     parent_shelf_id: Option<i64>,
 ) -> ProvisionResult {
     if let Some(shelf_id) = parent_shelf_id {
-        return find_or_create_book_on_shelf(client, shelf_id, name, description).await;
+        return find_or_create_book_on_shelf(client, index_db, shelf_id, name, description).await;
     }
     // No shelf — bare create. Without a known shelf to scope the dedup
     // lookup to, listing every book on the instance to match by name is
@@ -289,11 +293,12 @@ pub async fn create_named_book(
 /// re-runs reuse an existing page with the same name instead of duplicating.
 pub async fn create_named_page(
     client: &BookStackClient,
+    index_db: &dyn IndexDb,
     name: &str,
     parent_book_id: i64,
     markdown: &str,
 ) -> ProvisionResult {
-    find_or_create_page(client, Some(parent_book_id), None, name, markdown).await
+    find_or_create_page(client, index_db, Some(parent_book_id), None, name, markdown).await
 }
 
 /// Create a page inside a book or chapter, with the given markdown body.
@@ -304,6 +309,7 @@ pub async fn create_named_page(
 #[allow(dead_code)] // reserved for future identity/whoami auto-creation paths
 pub async fn create_page(
     client: &BookStackClient,
+    index_db: &dyn IndexDb,
     resource: NamedResource,
     parent_book_id: Option<i64>,
     parent_chapter_id: Option<i64>,
@@ -316,6 +322,7 @@ pub async fn create_page(
     }
     find_or_create_page(
         client,
+        index_db,
         parent_book_id,
         parent_chapter_id,
         resource.default_name(),
@@ -340,13 +347,33 @@ pub async fn create_page(
 /// Find a book on a shelf by exact name match, or create it and attach.
 /// Returns `FoundExisting` on hit, `Created` on miss, or a Denied/Failed
 /// outcome when BookStack rejects the request.
+///
+/// Phase 5c: tries the local index first (no roundtrip), then falls back
+/// to a live BookStack `get_shelf` walk when the index is empty/unavailable
+/// (worker hasn't run, postgres-stub deployment).
 pub async fn find_or_create_book_on_shelf(
     client: &BookStackClient,
+    index_db: &dyn IndexDb,
     shelf_id: i64,
     name: &str,
     description: &str,
 ) -> ProvisionResult {
-    // 1. Look up — pull the shelf, scan its books for an exact name match.
+    // 1a. Try the index — cheap, no BookStack roundtrip. A hit is
+    //     authoritative; a miss falls through to the live BookStack walk
+    //     in case the index is briefly stale (worker reconciles
+    //     asynchronously) or empty (fresh deployment, postgres stub).
+    if let Ok(books) = index_db.list_indexed_books_by_shelf(shelf_id).await {
+        for book in &books {
+            if book.name == name {
+                return ProvisionResult::FoundExisting {
+                    id: book.book_id,
+                    name: name.to_string(),
+                };
+            }
+        }
+    }
+
+    // 1b. Fall back to the live BookStack walk.
     match client.get_shelf(shelf_id).await {
         Ok(shelf) => {
             if let Some(books) = shelf.get("books").and_then(|v| v.as_array()) {
@@ -386,11 +413,24 @@ pub async fn find_or_create_book_on_shelf(
 #[allow(dead_code)]
 pub async fn find_or_create_chapter(
     client: &BookStackClient,
+    index_db: &dyn IndexDb,
     book_id: i64,
     name: &str,
     description: &str,
 ) -> ProvisionResult {
-    // 1. Look up — pull the book contents and scan for an existing chapter.
+    // 1a. Try the index — cheap, no BookStack roundtrip.
+    if let Ok(chapters) = index_db.list_indexed_chapters_by_book(book_id).await {
+        for chapter in &chapters {
+            if chapter.name == name {
+                return ProvisionResult::FoundExisting {
+                    id: chapter.chapter_id,
+                    name: name.to_string(),
+                };
+            }
+        }
+    }
+
+    // 1b. Fall back to the live BookStack walk.
     match client.get_book(book_id).await {
         Ok(book) => {
             if let Some(contents) = book.get("contents").and_then(|v| v.as_array()) {
@@ -435,12 +475,39 @@ pub async fn find_or_create_chapter(
 /// want to reuse it.
 pub async fn find_or_create_page(
     client: &BookStackClient,
+    index_db: &dyn IndexDb,
     parent_book_id: Option<i64>,
     parent_chapter_id: Option<i64>,
     name: &str,
     markdown: &str,
 ) -> ProvisionResult {
-    // 1. Look up in the specified parent.
+    if parent_book_id.is_none() && parent_chapter_id.is_none() {
+        return ProvisionResult::Failed {
+            reason: "find_or_create_page requires book_id or chapter_id".to_string(),
+        };
+    }
+
+    // 1a. Try the index — cheap, no BookStack roundtrip. Lookup is scoped
+    //     to the parent: chapter pages or book-root loose pages, never both.
+    let indexed = if let Some(chapter_id) = parent_chapter_id {
+        index_db.list_indexed_pages_by_chapter(chapter_id).await
+    } else if let Some(book_id) = parent_book_id {
+        index_db.list_indexed_pages_by_book_root(book_id).await
+    } else {
+        Ok(Vec::new())
+    };
+    if let Ok(pages) = indexed {
+        for page in &pages {
+            if page.name == name {
+                return ProvisionResult::FoundExisting {
+                    id: page.page_id,
+                    name: name.to_string(),
+                };
+            }
+        }
+    }
+
+    // 1b. Fall back to the live BookStack walk in the specified parent.
     let existing_id: Option<i64> = if let Some(chapter_id) = parent_chapter_id {
         match client.get_chapter(chapter_id).await {
             Ok(chapter) => find_named_page_in_array(&chapter, "pages", name),
@@ -452,9 +519,7 @@ pub async fn find_or_create_page(
             Err(e) => return classify_error(&e),
         }
     } else {
-        return ProvisionResult::Failed {
-            reason: "find_or_create_page requires book_id or chapter_id".to_string(),
-        };
+        unreachable!("guarded by the early-return above");
     };
 
     if let Some(id) = existing_id {

--- a/crates/bsmcp-server/src/remember/singletons.rs
+++ b/crates/bsmcp-server/src/remember/singletons.rs
@@ -125,6 +125,7 @@ pub async fn read_user(ctx: &Context) -> Outcome {
     let mut working_settings = ctx.settings.clone();
     let provision_result = user_provision::auto_provision_user_identity(
         &ctx.client,
+        ctx.index_db.as_ref(),
         globals.user_journals_shelf_id,
         &mut working_settings,
     )
@@ -213,6 +214,7 @@ pub async fn write_user(ctx: &Context) -> Outcome {
     let mut working_settings = ctx.settings.clone();
     let provision_result = user_provision::auto_provision_user_identity(
         &ctx.client,
+        ctx.index_db.as_ref(),
         globals.user_journals_shelf_id,
         &mut working_settings,
     )
@@ -330,6 +332,7 @@ async fn section_op_singleton(ctx: &Context, resource: &'static str, is_append: 
             let mut ws = ctx.settings.clone();
             let provision_result = user_provision::auto_provision_user_identity(
                 &ctx.client,
+                ctx.index_db.as_ref(),
                 globals.user_journals_shelf_id,
                 &mut ws,
             )

--- a/crates/bsmcp-server/src/remember/user_provision.rs
+++ b/crates/bsmcp-server/src/remember/user_provision.rs
@@ -19,6 +19,7 @@
 //! pass. That's how Task #9 (force user_journal to shelf) is enforced.
 
 use bsmcp_common::bookstack::BookStackClient;
+use bsmcp_common::db::IndexDb;
 use bsmcp_common::settings::UserSettings;
 
 use super::naming::NamedResource;
@@ -123,6 +124,7 @@ impl UserProvisionResult {
 /// incomplete" rather than crashing.
 pub async fn auto_provision_user_identity(
     client: &BookStackClient,
+    index_db: &dyn IndexDb,
     user_journals_shelf_id: Option<i64>,
     settings: &mut UserSettings,
 ) -> UserProvisionResult {
@@ -149,7 +151,7 @@ pub async fn auto_provision_user_identity(
     if settings.user_identity_book_id.is_none() {
         let name = NamedResource::UserIdentityBook.default_name_for_user(&user_id);
         let desc = NamedResource::UserIdentityBook.default_description();
-        let book = provision::create_named_book(client, &name, desc, user_journals_shelf_id).await;
+        let book = provision::create_named_book(client, index_db, &name, desc, user_journals_shelf_id).await;
         if let Some(id) = book.id() {
             settings.user_identity_book_id = Some(id);
             result.created_identity_book = Some(id);
@@ -166,7 +168,7 @@ pub async fn auto_provision_user_identity(
         if settings.user_identity_page_id.is_none() {
             let body = identity_page_template(&user_id);
             let page_name = NamedResource::UserIdentityPage.default_name_for_user(&user_id);
-            let page = provision::create_named_page(client, &page_name, book_id, &body).await;
+            let page = provision::create_named_page(client, index_db, &page_name, book_id, &body).await;
             if let Some(id) = page.id() {
                 settings.user_identity_page_id = Some(id);
                 result.created_identity_page = Some(id);
@@ -180,7 +182,7 @@ pub async fn auto_provision_user_identity(
     if settings.user_journal_book_id.is_none() {
         let name = NamedResource::UserJournalBook.default_name_for_user(&user_id);
         let desc = NamedResource::UserJournalBook.default_description();
-        let book = provision::create_named_book(client, &name, desc, user_journals_shelf_id).await;
+        let book = provision::create_named_book(client, index_db, &name, desc, user_journals_shelf_id).await;
         if let Some(id) = book.id() {
             settings.user_journal_book_id = Some(id);
             result.created_journal_book = Some(id);
@@ -204,7 +206,7 @@ pub async fn auto_provision_user_identity(
         if settings.user_journal_agent_page_id.is_none() {
             let body = journal_agent_template(&user_id, journal_book_id);
             let page_name = NamedResource::UserJournalAgentPage.default_name_for_user(&user_id);
-            let page = provision::create_named_page(client, &page_name, book_id, &body).await;
+            let page = provision::create_named_page(client, index_db, &page_name, book_id, &body).await;
             if let Some(id) = page.id() {
                 settings.user_journal_agent_page_id = Some(id);
                 result.created_journal_agent_page = Some(id);

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -496,7 +496,7 @@ pub async fn handle_settings_post(
     // Books that live on the Hive shelf.
     let hive_shelf = globals.hive_shelf_id;
     if settings.ai_identity_book_id.is_none() && checkbox_on(form.create_ai_identity_book) {
-        let r = provision::create_book(&client, NamedResource::IdentityBook, hive_shelf).await;
+        let r = provision::create_book(&client, state.index_db.as_ref(), NamedResource::IdentityBook, hive_shelf).await;
         provision_log.push(r.human(NamedResource::IdentityBook));
         if let Some(id) = r.id() {
             settings.ai_identity_book_id = Some(id);
@@ -506,14 +506,14 @@ pub async fn handle_settings_post(
         }
     }
     if settings.ai_hive_journal_book_id.is_none() && checkbox_on(form.create_ai_hive_journal_book) {
-        let r = provision::create_book(&client, NamedResource::JournalBook, hive_shelf).await;
+        let r = provision::create_book(&client, state.index_db.as_ref(), NamedResource::JournalBook, hive_shelf).await;
         provision_log.push(r.human(NamedResource::JournalBook));
         if let Some(id) = r.id() {
             settings.ai_hive_journal_book_id = Some(id);
         }
     }
     if settings.ai_collage_book_id.is_none() && checkbox_on(form.create_ai_collage_book) {
-        let r = provision::create_book(&client, NamedResource::CollageBook, hive_shelf).await;
+        let r = provision::create_book(&client, state.index_db.as_ref(), NamedResource::CollageBook, hive_shelf).await;
         provision_log.push(r.human(NamedResource::CollageBook));
         if let Some(id) = r.id() {
             settings.ai_collage_book_id = Some(id);
@@ -523,7 +523,7 @@ pub async fn handle_settings_post(
         }
     }
     if settings.ai_shared_collage_book_id.is_none() && checkbox_on(form.create_ai_shared_collage_book) {
-        let r = provision::create_book(&client, NamedResource::SharedCollageBook, hive_shelf).await;
+        let r = provision::create_book(&client, state.index_db.as_ref(), NamedResource::SharedCollageBook, hive_shelf).await;
         provision_log.push(r.human(NamedResource::SharedCollageBook));
         if let Some(id) = r.id() {
             settings.ai_shared_collage_book_id = Some(id);


### PR DESCRIPTION
## Summary

- **Phase 5c**: `find_or_create_book_on_shelf`, `find_or_create_chapter`, `find_or_create_page`, and the `create_*` wrappers in `provision.rs` now consult the local index first (no BookStack roundtrip) and fall back to the live shelf/book/chapter walk on miss/error. Threads `&dyn IndexDb` through `identity::create`, `auto_provision_user_identity`, and the `/settings` UI provisioning path.
- **CI recovery**: adds a `workflow_dispatch` trigger to `release.yml`'s `push-retag` job. PR #38's merge dropped its push event (zero workflow runs for SHA \`f5531df\`), leaving the dev stream tags stuck on Phase 4b's image. Manually retagged for now; going forward, \`gh workflow run \"Build and Release\" --ref development\` is the documented recovery path.
- DEVELOPMENT.md updated to match the new \`push-retag\` shape (replaces stale \`promote\` rows) and document the manual recovery row.

## Test plan

- [x] \`cargo check -p bsmcp-server\` — clean (no new warnings).
- [x] \`cargo test -p bsmcp-server\` — all 25 unit tests pass.
- [x] After merge, verify \`push-retag\` runs and dev stream tags advance to the new merge SHA. (If it drops again, run \`gh workflow run \"Build and Release\" --ref development\` to retry.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)