### PR TITLE
rerank: cross-encoder /rerank + three-mode semantic_search (standard/rerank/precision)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,34 @@ BSMCP_PUBLIC_DOMAIN=bookstack-mcp.example.com
 # BSMCP_EMBED_HOST=0.0.0.0
 # BSMCP_EMBED_PORT=8081
 
+# --- Reranker (optional) ---
+
+# Cross-encoder reranker for the embedder's /rerank endpoint. Off by default.
+# Provider: "local" (in-process ONNX cross-encoder via fastembed), "voyage"
+# (Voyage AI's /v1/rerank), "openai" (any OpenAI-shape /v1/rerank — Voyage,
+# Jina, Cohere via shim, self-hosted; OpenAI itself has not shipped a rerank
+# API yet so this is for compatible third parties), or "none" / unset.
+# BSMCP_RERANK_PROVIDER=none
+
+# Local model settings (BSMCP_RERANK_PROVIDER=local)
+# Supported: BAAI/bge-reranker-base, BAAI/bge-reranker-v2-m3,
+#            jinaai/jina-reranker-v1-turbo-en, jinaai/jina-reranker-v2-base-multilingual
+# Reuses BSMCP_MODEL_PATH for the cache directory.
+# BSMCP_RERANK_MODEL=BAAI/bge-reranker-v2-m3
+
+# Voyage settings (BSMCP_RERANK_PROVIDER=voyage)
+# BSMCP_RERANK_MODEL=rerank-2
+# BSMCP_RERANK_API_KEY=your-voyage-key
+# BSMCP_RERANK_API_URL=https://api.voyageai.com
+
+# OpenAI-compatible settings (BSMCP_RERANK_PROVIDER=openai)
+# All three are required — there's no upstream default. Point the URL at
+# any provider that accepts {model, query, documents} and returns
+# {data:[{index, relevance_score}]} (or {results:[...]}).
+# BSMCP_RERANK_MODEL=...
+# BSMCP_RERANK_API_KEY=...
+# BSMCP_RERANK_API_URL=https://...
+
 # --- bsmcp-worker (reconciliation worker) ---
 
 # Admin BookStack API token for the worker. Falls back to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,9 @@ crates/
 2. Server POSTs query text to embedder's `/embed` endpoint → gets query embedding
 3. Server calls `db.vector_search()` → SQLite does brute-force cosine, PostgreSQL uses pgvector HNSW
 4. Server filters hits by per-page ACL via BookStack's API (`filter_by_permission`)
-5. Server calls `db.get_markov_blanket()` for contextual relationships
-6. Returns ranked results with content snippets and relationship context
+5. **Standard mode:** server calls `db.get_markov_blanket()` for contextual relationships and applies a vector + keyword + blanket-boost blend.
+   **Precision mode (`precision: true` or `mode: "precision"`):** server widens the candidate pool (5x limit), picks the best chunk per page, and POSTs `(query, [doc])` to the embedder's `/rerank` endpoint. The cross-encoder score replaces the blend. Requires `BSMCP_RERANK_PROVIDER` configured on the embedder; otherwise the call returns a clear error and the caller can retry without `precision`.
+6. Returns ranked results with content snippets, scoring breakdown, and (in verbose mode) full relationship context
 
 **Embedding flow:**
 1. `reembed` tool or webhook inserts a job into `embed_jobs` table

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,13 +66,20 @@ crates/
 - Server selects backend at startup via `BSMCP_DB_BACKEND` env var
 
 **Semantic search flow:**
-1. Server receives `semantic_search` tool call
-2. Server POSTs query text to embedder's `/embed` endpoint → gets query embedding
-3. Server calls `db.vector_search()` → SQLite does brute-force cosine, PostgreSQL uses pgvector HNSW
-4. Server filters hits by per-page ACL via BookStack's API (`filter_by_permission`)
-5. **Standard mode:** server calls `db.get_markov_blanket()` for contextual relationships and applies a vector + keyword + blanket-boost blend.
-   **Precision mode (`precision: true` or `mode: "precision"`):** server widens the candidate pool (5x limit), picks the best chunk per page, and POSTs `(query, [doc])` to the embedder's `/rerank` endpoint. The cross-encoder score replaces the blend. Requires `BSMCP_RERANK_PROVIDER` configured on the embedder; otherwise the call returns a clear error and the caller can retry without `precision`.
-6. Returns ranked results with content snippets, scoring breakdown, and (in verbose mode) full relationship context
+
+`semantic_search` accepts `mode: "standard" | "rerank" | "precision"` (default `"standard"`). All three return the same JSON shape so a caller can A/B by swapping the mode value on the same query.
+
+1. Server receives `semantic_search` tool call.
+2. Server POSTs query text to embedder's `/embed` endpoint → query embedding.
+3. Server calls `db.vector_search()` → SQLite does brute-force cosine, PostgreSQL uses pgvector HNSW. Candidate pool is `limit*2` for standard/rerank, `limit*5` for precision.
+4. Server filters hits by per-page ACL via BookStack's API (`filter_by_permission`).
+5. Mode-specific ranking step:
+   - **Standard:** `db.get_markov_blanket()` for contextual relationships → vector + keyword + blanket-boost blend → top-N.
+   - **Rerank:** standard pipeline produces the top-N, then a cross-encoder pass via `/rerank` re-orders just those N. Cheap refinement (~10-30ms for N≤50). The candidate selection is unchanged; only the final ordering changes.
+   - **Precision:** wider pool, no blend. The cross-encoder is the ranker of record — picks the best chunk per page, POSTs `(query, [doc])` to `/rerank`, uses the score directly. `hybrid` is forced false in this mode.
+6. Returns ranked results with content snippets, per-result `scoring` breakdown (`vector` / `keyword` / `blanket_boost` / `rerank` when applicable), and (in verbose mode) full Markov-blanket context.
+
+Both `rerank` and `precision` modes require `BSMCP_RERANK_PROVIDER` configured on the embedder. Without it, `/rerank` returns 503 and the call surfaces a clear error so the caller can retry with `mode: "standard"`.
 
 **Embedding flow:**
 1. `reembed` tool or webhook inserts a job into `embed_jobs` table

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-common"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-postgres"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-sqlite"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-embedder"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-server"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-worker"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bsmcp-common",
  "bsmcp-db-postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.10.0"
+version = "0.11.0"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ An MCP (Model Context Protocol) server that gives Claude full access to a [BookS
 - **Semantic vector search** — natural language search across all content via embeddings (optional). Hybrid (vector + keyword) with Markov-blanket re-ranking. Per-page access control is enforced via BookStack's API on every result.
 - **Settings UI (`/settings`)** — browser-based admin configuration page (token-gated via the same `/authorize` flow). Surfaces only the global server fields the index worker needs (`hive_shelf_id`, `user_journals_shelf_id`).
 - **Pluggable database** — SQLite for simple deployments, PostgreSQL + pgvector for production
-- **Separate embedder** — background embedding service with pluggable backends (local ONNX, Ollama, OpenAI)
+- **Separate embedder** — background embedding service with pluggable backends (local ONNX, Ollama, OpenAI, Voyage)
+- **Cross-encoder reranker (optional)** — embedder exposes `POST /rerank` when `BSMCP_RERANK_PROVIDER` is configured. Three providers: `local` (in-process ONNX cross-encoder via fastembed, default `BAAI/bge-reranker-v2-m3`), `voyage` (Voyage's `/v1/rerank`), `openai` (any OpenAI-shape rerank endpoint — covers Voyage/Jina/Cohere-via-shim/self-hosted). Off by default; consumed by the `semantic_search` tool's opt-in `mode: "precision"` cascade.
 - **Server-side markdown to HTML conversion** — send markdown, server converts before sending to BookStack
 - **Staging upload flow** — upload local images and attachments through a two-step staging endpoint without exposing local paths to the container ([see below](#uploading-local-files-images--attachments))
 - **OAuth 2.1 support** — use as a Claude.ai or Claude Desktop custom connector without config files
@@ -158,6 +159,10 @@ The server is pure Rust + bundled SQLite and builds cleanly on any target the Ru
 | `BSMCP_EMBED_ON_STARTUP` | No | `false` | `true` = auto-embed on startup, `clean` = clear all embeddings first |
 | `BSMCP_EMBED_HOST` | No | `0.0.0.0` | Embedder listen address |
 | `BSMCP_EMBED_PORT` | No | `8081` | Embedder listen port |
+| `BSMCP_RERANK_PROVIDER` | No | (unset) | Cross-encoder rerank provider: `local`, `voyage`, `openai`, `none`. Off by default; enables `POST /rerank` on the embedder. |
+| `BSMCP_RERANK_MODEL` | If reranker on | (per provider) | Reranker model. Defaults: `BAAI/bge-reranker-v2-m3` (local), `rerank-2` (voyage). Required for `openai`. |
+| `BSMCP_RERANK_API_KEY` | If voyage/openai | - | API key for external rerank provider. |
+| `BSMCP_RERANK_API_URL` | If openai | (per provider) | Base URL. Voyage defaults to `https://api.voyageai.com`; openai requires explicit URL. |
 
 See `.env.example` for the full list with comments.
 

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-09 22:37 UTC from commit `3d9e5b6` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-10 00:49 UTC from commit `255b837` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-09 22:37 UTC from commit `3d9e5b6`._
+_Auto-generated on 2026-05-10 00:49 UTC from commit `255b837`._
 
 ```
 .
@@ -31,7 +31,8 @@ _Auto-generated on 2026-05-09 22:37 UTC from commit `3d9e5b6`._
 │   │   ├── src
 │   │   │   ├── embed.rs
 │   │   │   ├── main.rs
-│   │   │   └── pipeline.rs
+│   │   │   ├── pipeline.rs
+│   │   │   └── rerank.rs
 │   │   └── Cargo.toml
 │   ├── bsmcp-server
 │   │   ├── src
@@ -66,5 +67,5 @@ _Auto-generated on 2026-05-09 22:37 UTC from commit `3d9e5b6`._
 ├── STRUCTURE.md
 └── entrypoint.sh
 
-16 directories, 46 files
+16 directories, 47 files
 ```

--- a/crates/bsmcp-embedder/src/main.rs
+++ b/crates/bsmcp-embedder/src/main.rs
@@ -1,5 +1,6 @@
 mod embed;
 mod pipeline;
+mod rerank;
 
 use std::env;
 use std::fs;
@@ -20,17 +21,24 @@ use bsmcp_common::config::DbBackendType;
 use bsmcp_common::db::SemanticDb;
 
 use embed::Embedder;
+use rerank::Reranker;
 
 const DEFAULT_LOCAL_MODEL: &str = "BAAI/bge-base-en-v1.5";
 const DEFAULT_OLLAMA_MODEL: &str = "nomic-embed-text";
 const DEFAULT_OPENAI_MODEL: &str = "text-embedding-3-small";
 const DEFAULT_VOYAGE_MODEL: &str = "voyage-3-lite";
 
+const DEFAULT_LOCAL_RERANK_MODEL: &str = "BAAI/bge-reranker-v2-m3";
+const DEFAULT_VOYAGE_RERANK_MODEL: &str = "rerank-2";
+
 struct AppState {
     embedder: Arc<dyn Embedder>,
     model_name: String,
     provider_name: String,
     db: Arc<dyn SemanticDb>,
+    /// Reranker is optional — `BSMCP_RERANK_PROVIDER=none` (the default) leaves
+    /// it unconfigured and `/rerank` returns 503.
+    reranker: Option<Arc<dyn Reranker>>,
 }
 
 /// Load or generate a persistent worker UUID from a file in the data directory.
@@ -51,6 +59,16 @@ fn load_or_create_worker_id(data_dir: &Path) -> String {
 #[derive(Deserialize)]
 struct EmbedRequest {
     texts: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct RerankRequest {
+    query: String,
+    documents: Vec<String>,
+    /// Optional cap; server returns at most this many sorted-by-score hits.
+    /// Omit to receive all hits in input order (caller does its own cut).
+    #[serde(default)]
+    top_k: Option<usize>,
 }
 
 #[tokio::main]
@@ -203,6 +221,9 @@ async fn main() {
 
     eprintln!("Embedder: provider={provider}, model={model_name}, dims={dims}");
 
+    // Optional reranker. None when BSMCP_RERANK_PROVIDER is unset, "none", or empty.
+    let reranker: Option<Arc<dyn Reranker>> = init_reranker().await;
+
     // Start HTTP server for /embed endpoint
     let host = env::var("BSMCP_EMBED_HOST").unwrap_or_else(|_| "0.0.0.0".into());
     let port: u16 = env::var("BSMCP_EMBED_PORT")
@@ -215,10 +236,12 @@ async fn main() {
         model_name: model_name.clone(),
         provider_name: provider.clone(),
         db: db.clone(),
+        reranker: reranker.clone(),
     });
 
     let app = Router::new()
         .route("/embed", axum::routing::post(handle_embed))
+        .route("/rerank", axum::routing::post(handle_rerank))
         .route("/health", get(handle_health))
         .with_state(state);
 
@@ -292,11 +315,18 @@ async fn handle_health(
 ) -> impl IntoResponse {
     let dims = state.embedder.dims();
     let stats = state.db.get_stats().await.ok();
+    let reranker = state.reranker.as_ref().map(|r| {
+        json!({
+            "provider": r.provider_name(),
+            "model": r.model_name(),
+        })
+    });
     Json(json!({
         "status": "ok",
         "provider": state.provider_name,
         "model": state.model_name,
         "dimensions": dims,
+        "reranker": reranker,
         "stats": stats.map(|s| json!({
             "total_pages": s.total_pages,
             "total_chunks": s.total_chunks,
@@ -309,6 +339,153 @@ async fn handle_health(
             })),
         })),
     }))
+}
+
+async fn handle_rerank(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<RerankRequest>,
+) -> impl IntoResponse {
+    let Some(reranker) = state.reranker.as_ref() else {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "Reranker disabled (BSMCP_RERANK_PROVIDER unset or 'none')"})),
+        )
+            .into_response();
+    };
+
+    if req.query.is_empty() {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({"error": "query must not be empty"})),
+        )
+            .into_response();
+    }
+    if req.documents.is_empty() {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({"error": "documents array must not be empty"})),
+        )
+            .into_response();
+    }
+    if req.documents.len() > 200 {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({"error": "maximum 200 documents per rerank request"})),
+        )
+            .into_response();
+    }
+
+    match reranker.rerank(req.query, req.documents).await {
+        Ok(mut hits) => {
+            // Sort descending by score. Stable so ties keep input order.
+            hits.sort_by(|a, b| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            if let Some(k) = req.top_k {
+                hits.truncate(k);
+            }
+            Json(json!({
+                "results": hits,
+                "provider": reranker.provider_name(),
+                "model": reranker.model_name(),
+            }))
+            .into_response()
+        }
+        Err(e) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Rerank failed: {e}")})),
+        )
+            .into_response(),
+    }
+}
+
+/// Build a `Reranker` from `BSMCP_RERANK_*` env vars. Returns `None` when
+/// the provider is unset, "none", or empty — `/rerank` then returns 503.
+async fn init_reranker() -> Option<Arc<dyn Reranker>> {
+    let provider = env::var("BSMCP_RERANK_PROVIDER")
+        .unwrap_or_default()
+        .to_lowercase();
+    if provider.is_empty() || provider == "none" {
+        eprintln!("Reranker: disabled (BSMCP_RERANK_PROVIDER unset or 'none')");
+        return None;
+    }
+
+    match provider.as_str() {
+        "local" => {
+            let model_path =
+                env::var("BSMCP_MODEL_PATH").unwrap_or_else(|_| "/data/models".into());
+            let model_name = env::var("BSMCP_RERANK_MODEL")
+                .unwrap_or_else(|_| DEFAULT_LOCAL_RERANK_MODEL.into());
+            eprintln!("Reranker: loading local cross-encoder {model_name} (cache={model_path})...");
+            match pipeline::RerankModel::new(&model_name, &model_path) {
+                Ok(m) => {
+                    eprintln!("Reranker: local model ready");
+                    Some(Arc::new(rerank::LocalReranker::new(Arc::new(m))) as Arc<dyn Reranker>)
+                }
+                Err(e) => {
+                    eprintln!("Reranker: local init failed: {e} — /rerank disabled");
+                    None
+                }
+            }
+        }
+        "voyage" => {
+            let api_key = match env::var("BSMCP_RERANK_API_KEY") {
+                Ok(k) if !k.is_empty() => k,
+                _ => {
+                    eprintln!("Reranker: BSMCP_RERANK_API_KEY required for voyage — /rerank disabled");
+                    return None;
+                }
+            };
+            let model = env::var("BSMCP_RERANK_MODEL")
+                .unwrap_or_else(|_| DEFAULT_VOYAGE_RERANK_MODEL.into());
+            let base_url = env::var("BSMCP_RERANK_API_URL")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "https://api.voyageai.com".into());
+            eprintln!("Reranker: Voyage AI provider (model={model}, url={base_url})");
+            Some(Arc::new(rerank::VoyageReranker::new(&api_key, &model, &base_url))
+                as Arc<dyn Reranker>)
+        }
+        "openai" => {
+            let api_key = match env::var("BSMCP_RERANK_API_KEY") {
+                Ok(k) if !k.is_empty() => k,
+                _ => {
+                    eprintln!("Reranker: BSMCP_RERANK_API_KEY required for openai — /rerank disabled");
+                    return None;
+                }
+            };
+            let model = match env::var("BSMCP_RERANK_MODEL") {
+                Ok(m) if !m.is_empty() => m,
+                _ => {
+                    eprintln!(
+                        "Reranker: BSMCP_RERANK_MODEL required for openai (no upstream default) — /rerank disabled"
+                    );
+                    return None;
+                }
+            };
+            let base_url = match env::var("BSMCP_RERANK_API_URL") {
+                Ok(u) if !u.is_empty() => u,
+                _ => {
+                    eprintln!(
+                        "Reranker: BSMCP_RERANK_API_URL required for openai (OpenAI itself \
+                         has no rerank API yet; point at any compatible endpoint) — /rerank disabled"
+                    );
+                    return None;
+                }
+            };
+            eprintln!("Reranker: OpenAI-compatible provider (model={model}, url={base_url})");
+            Some(Arc::new(rerank::OpenAIReranker::new(&api_key, &model, &base_url))
+                as Arc<dyn Reranker>)
+        }
+        other => {
+            eprintln!(
+                "Reranker: unknown provider '{other}' (expected: local|voyage|openai|none) — /rerank disabled"
+            );
+            None
+        }
+    }
 }
 
 /// Background job queue worker. Polls for pending embed jobs and processes them.

--- a/crates/bsmcp-embedder/src/pipeline.rs
+++ b/crates/bsmcp-embedder/src/pipeline.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fastembed::{
-    EmbeddingModel, InitOptions, InitOptionsUserDefined, Pooling, TextEmbedding,
-    TokenizerFiles, UserDefinedEmbeddingModel,
+    EmbeddingModel, InitOptions, InitOptionsUserDefined, Pooling, RerankInitOptions,
+    RerankerModel, TextEmbedding, TextRerank, TokenizerFiles, UserDefinedEmbeddingModel,
 };
 
 use bsmcp_common::acl::{build_role_context, reconcile_all_pages, resolve_page_acl, RoleContext};
@@ -93,6 +93,84 @@ impl EmbedModel {
     pub fn embed(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>, String> {
         let mut m = self.model.lock().map_err(|e| format!("Model lock poisoned: {e}"))?;
         m.embed(texts, None).map_err(|e| format!("{e}"))
+    }
+}
+
+/// Resolve a reranker model name to its fastembed enum variant.
+fn resolve_reranker(name: &str) -> Option<RerankerModel> {
+    match name {
+        "BAAI/bge-reranker-base" | "bge-reranker-base" => Some(RerankerModel::BGERerankerBase),
+        "BAAI/bge-reranker-v2-m3" | "rozgo/bge-reranker-v2-m3" | "bge-reranker-v2-m3" => {
+            Some(RerankerModel::BGERerankerV2M3)
+        }
+        "jinaai/jina-reranker-v1-turbo-en" | "jina-reranker-v1-turbo-en" => {
+            Some(RerankerModel::JINARerankerV1TurboEn)
+        }
+        "jinaai/jina-reranker-v2-base-multilingual" | "jina-reranker-v2-base-multilingual" => {
+            Some(RerankerModel::JINARerankerV2BaseMultiligual)
+        }
+        _ => None,
+    }
+}
+
+/// Thread-safe wrapper around fastembed's `TextRerank` cross-encoder.
+pub struct RerankModel {
+    model: std::sync::Mutex<TextRerank>,
+    model_name: String,
+}
+
+impl RerankModel {
+    pub fn new(model_name: &str, cache_dir: &str) -> Result<Self, String> {
+        let reranker = resolve_reranker(model_name).ok_or_else(|| {
+            format!(
+                "Unknown reranker model: {model_name}. Supported: \
+                 BAAI/bge-reranker-base, BAAI/bge-reranker-v2-m3, \
+                 jinaai/jina-reranker-v1-turbo-en, \
+                 jinaai/jina-reranker-v2-base-multilingual"
+            )
+        })?;
+
+        let options = RerankInitOptions::new(reranker)
+            .with_cache_dir(cache_dir.into())
+            .with_show_download_progress(true);
+        let model = TextRerank::try_new(options)
+            .map_err(|e| format!("Reranker model init failed: {e}"))?;
+
+        eprintln!("Reranker loaded: {model_name}");
+        Ok(Self {
+            model: std::sync::Mutex::new(model),
+            model_name: model_name.to_string(),
+        })
+    }
+
+    pub fn model_name(&self) -> &str {
+        &self.model_name
+    }
+
+    /// Score `documents` against `query`. Thread-safe (locks internally).
+    pub fn rerank(
+        &self,
+        query: &str,
+        documents: Vec<String>,
+    ) -> Result<Vec<crate::rerank::RerankHit>, String> {
+        let mut m = self
+            .model
+            .lock()
+            .map_err(|e| format!("Reranker lock poisoned: {e}"))?;
+        // fastembed's `rerank` shares one generic `S: AsRef<str>` between
+        // query and documents — owning the query as `String` lets `S = String`
+        // match `&Vec<String>: AsRef<[String]>`.
+        let q = query.to_string();
+        let results = m
+            .rerank(q, &documents, false, None)
+            .map_err(|e| format!("{e}"))?;
+        Ok(results
+            .into_iter()
+            .map(|r| crate::rerank::RerankHit {
+                index: r.index,
+                score: r.score,
+            })
+            .collect())
     }
 }
 

--- a/crates/bsmcp-embedder/src/rerank.rs
+++ b/crates/bsmcp-embedder/src/rerank.rs
@@ -1,0 +1,263 @@
+//! Reranker provider abstraction. Sibling of `embed.rs`.
+//!
+//! Three providers, parallel to the embedder side:
+//! - `LocalReranker` — in-process ONNX cross-encoder via fastembed (default
+//!   `BAAI/bge-reranker-v2-m3`). Wraps `pipeline::RerankModel`.
+//! - `VoyageReranker` — Voyage AI's `POST /v1/rerank`.
+//! - `OpenAIReranker` — generic OpenAI-shape `POST /v1/rerank` for any
+//!   compatible endpoint (Voyage/Jina/self-hosted). Configurable URL is
+//!   required; OpenAI itself has not shipped a rerank API yet.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+/// One reranked result: original index into the documents array + score.
+/// Higher score = more relevant. Callers apply their own sort / top-k.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct RerankHit {
+    pub index: usize,
+    pub score: f32,
+}
+
+#[async_trait]
+pub trait Reranker: Send + Sync + 'static {
+    /// Score `documents` against `query`. Returns one hit per document, in
+    /// input order. The caller does any sort / top-k cut.
+    async fn rerank(
+        &self,
+        query: String,
+        documents: Vec<String>,
+    ) -> Result<Vec<RerankHit>, String>;
+
+    fn provider_name(&self) -> &str;
+
+    fn model_name(&self) -> &str;
+}
+
+// --- Local fastembed cross-encoder ---
+
+pub struct LocalReranker {
+    model: Arc<crate::pipeline::RerankModel>,
+}
+
+impl LocalReranker {
+    pub fn new(model: Arc<crate::pipeline::RerankModel>) -> Self {
+        Self { model }
+    }
+}
+
+#[async_trait]
+impl Reranker for LocalReranker {
+    async fn rerank(
+        &self,
+        query: String,
+        documents: Vec<String>,
+    ) -> Result<Vec<RerankHit>, String> {
+        let model = self.model.clone();
+        tokio::task::spawn_blocking(move || model.rerank(&query, documents))
+            .await
+            .map_err(|e| format!("Rerank task failed: {e}"))?
+    }
+
+    fn provider_name(&self) -> &str {
+        "local"
+    }
+
+    fn model_name(&self) -> &str {
+        self.model.model_name()
+    }
+}
+
+// --- Voyage AI reranker ---
+
+pub struct VoyageReranker {
+    api_key: String,
+    model: String,
+    base_url: String,
+    http: reqwest::Client,
+}
+
+impl VoyageReranker {
+    pub fn new(api_key: &str, model: &str, base_url: &str) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .expect("Failed to build HTTP client");
+        Self {
+            api_key: api_key.to_string(),
+            model: model.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            http,
+        }
+    }
+}
+
+#[async_trait]
+impl Reranker for VoyageReranker {
+    async fn rerank(
+        &self,
+        query: String,
+        documents: Vec<String>,
+    ) -> Result<Vec<RerankHit>, String> {
+        let body = serde_json::json!({
+            "model": self.model,
+            "query": query,
+            "documents": documents,
+        });
+
+        let resp = self
+            .http
+            .post(format!("{}/v1/rerank", self.base_url))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                let url = format!("{}/v1/rerank", self.base_url);
+                format!(
+                    "Voyage rerank request failed: {e:?} (url={url}, key_len={}, model={})",
+                    self.api_key.len(),
+                    self.model
+                )
+            })?;
+
+        let status = resp.status();
+        let json: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Voyage rerank response parse failed: {e}"))?;
+
+        if !status.is_success() {
+            let msg = json
+                .get("detail")
+                .and_then(|m| m.as_str())
+                .or_else(|| {
+                    json.get("error")
+                        .and_then(|e| e.get("message"))
+                        .and_then(|m| m.as_str())
+                })
+                .unwrap_or("unknown error");
+            return Err(format!("Voyage rerank error {status}: {msg}"));
+        }
+
+        parse_voyage_shape(&json)
+    }
+
+    fn provider_name(&self) -> &str {
+        "voyage"
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+}
+
+// --- OpenAI-compatible reranker (generic shape) ---
+
+pub struct OpenAIReranker {
+    api_key: String,
+    model: String,
+    base_url: String,
+    http: reqwest::Client,
+}
+
+impl OpenAIReranker {
+    pub fn new(api_key: &str, model: &str, base_url: &str) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .expect("Failed to build HTTP client");
+        Self {
+            api_key: api_key.to_string(),
+            model: model.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            http,
+        }
+    }
+}
+
+#[async_trait]
+impl Reranker for OpenAIReranker {
+    async fn rerank(
+        &self,
+        query: String,
+        documents: Vec<String>,
+    ) -> Result<Vec<RerankHit>, String> {
+        let body = serde_json::json!({
+            "model": self.model,
+            "query": query,
+            "documents": documents,
+        });
+
+        let resp = self
+            .http
+            .post(format!("{}/v1/rerank", self.base_url))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                let url = format!("{}/v1/rerank", self.base_url);
+                format!(
+                    "OpenAI rerank request failed: {e:?} (url={url}, key_len={}, model={})",
+                    self.api_key.len(),
+                    self.model
+                )
+            })?;
+
+        let status = resp.status();
+        let json: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("OpenAI rerank response parse failed: {e}"))?;
+
+        if !status.is_success() {
+            let msg = json
+                .get("error")
+                .and_then(|e| e.get("message"))
+                .and_then(|m| m.as_str())
+                .or_else(|| json.get("detail").and_then(|m| m.as_str()))
+                .unwrap_or("unknown error");
+            return Err(format!("OpenAI rerank error {status}: {msg}"));
+        }
+
+        parse_voyage_shape(&json)
+    }
+
+    fn provider_name(&self) -> &str {
+        "openai"
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+}
+
+/// Parse the `{ data: [{ index, relevance_score }] }` shape used by Voyage
+/// and most OpenAI-compatible rerank endpoints. Cohere uses `results` instead
+/// of `data` — accept both so a Cohere endpoint plugged into the OpenAI-
+/// compatible provider also works.
+fn parse_voyage_shape(json: &serde_json::Value) -> Result<Vec<RerankHit>, String> {
+    let arr = json
+        .get("data")
+        .and_then(|v| v.as_array())
+        .or_else(|| json.get("results").and_then(|v| v.as_array()))
+        .ok_or("rerank response missing 'data' or 'results' array")?;
+
+    let mut hits = Vec::with_capacity(arr.len());
+    for item in arr {
+        let index = item
+            .get("index")
+            .and_then(|v| v.as_u64())
+            .ok_or("rerank item missing 'index'")? as usize;
+        let score = item
+            .get("relevance_score")
+            .and_then(|v| v.as_f64())
+            .ok_or("rerank item missing 'relevance_score'")? as f32;
+        hits.push(RerankHit { index, score });
+    }
+    Ok(hits)
+}

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use pulldown_cmark::{html, Options, Parser};
 
 use bsmcp_common::bookstack::{self, BookStackClient, ContentType, ExportFormat};
-use crate::semantic::{trim_match, SemanticState};
+use crate::semantic::{trim_match, SearchMode, SemanticState};
 
 const PROTOCOL_VERSION: &str = "2025-03-26";
 
@@ -97,15 +97,19 @@ async fn execute_tool(
             let default_threshold = if hybrid { 0.45 } else { 0.50 };
             let threshold = args.get("threshold").and_then(|v| v.as_f64()).unwrap_or(default_threshold) as f32;
             let verbose = args.get("verbose").and_then(|v| v.as_bool()).unwrap_or(false);
-            // Accept either `precision: true` or `mode: "precision"`. The
-            // boolean is the canonical knob; `mode` is sugar for callers that
-            // think in named modes.
-            let precision = args.get("precision").and_then(|v| v.as_bool()).unwrap_or(false)
-                || args.get("mode").and_then(|v| v.as_str()) == Some("precision");
+            let mode_str = args
+                .get("mode")
+                .and_then(|v| v.as_str())
+                .unwrap_or("standard");
+            let mode = SearchMode::parse(mode_str).ok_or_else(|| {
+                format!(
+                    "invalid mode '{mode_str}' (expected: standard, rerank, precision)"
+                )
+            })?;
             // The HTTP `filter_by_permission` fallback inside `sem.search`
             // enforces per-page access control via BookStack's API.
             let mut result = sem
-                .search(&query, limit, threshold, hybrid, verbose, client, None, precision)
+                .search(&query, limit, threshold, hybrid, verbose, client, None, mode)
                 .await?;
             trim_semantic_search_payload(&mut result);
             format_json(&result)
@@ -1808,17 +1812,21 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
 
     if semantic_enabled {
         tools.push(tool("semantic_search",
-            "Hybrid search combining vector embeddings with keyword matching. Finds pages by meaning AND exact terms. Results are re-ranked using graph relationships (Markov blanket). IMPORTANT: Include related terms, synonyms, and domain-specific vocabulary in your query for better recall. For example, instead of 'office gets hacked', search 'security breach incident response ransomware compromise recovery'. The richer the query, the better the vector matching. Set hybrid=false for pure vector search only. Set precision=true (or mode='precision') to replace the blanket+blend ranker with a cross-encoder rerank — wider initial vector pass, then the embedder's /rerank scores each candidate against the query directly. Higher quality, slightly slower; requires BSMCP_RERANK_PROVIDER configured on the embedder.",
+            "Hybrid search combining vector embeddings with keyword matching. Finds pages by meaning AND exact terms. IMPORTANT: Include related terms, synonyms, and domain-specific vocabulary in your query for better recall. For example, instead of 'office gets hacked', search 'security breach incident response ransomware compromise recovery'. \
+             \n\nMode controls the ranking strategy: \
+             'standard' (default) = vector + keyword + Markov-blanket boost + blended sort, no cross-encoder. Free, known-good baseline. \
+             'rerank' = same candidate selection as standard, but the final top-N is re-ordered by a cross-encoder rerank pass. Cheap refinement (~10-30ms for top-10 against a local cross-encoder); requires BSMCP_RERANK_PROVIDER on the embedder. \
+             'precision' = cross-encoder is the ranker of record. Wider initial vector pass (5x limit), no keyword/blanket blend, /rerank scores each candidate directly. More expensive, can rescue hits the blend would miss; also requires BSMCP_RERANK_PROVIDER. \
+             \n\nAll three modes return the same JSON shape so you can A/B by swapping the mode value on the same query.",
             json!({
                 "type": "object",
                 "properties": {
                     "query": { "type": "string", "description": "Natural language search query. Include synonyms and related terms for better results." },
                     "limit": { "type": "integer", "description": "Max number of page results to return", "default": 10 },
                     "threshold": { "type": "number", "description": "Minimum cosine similarity score (0.0-1.0). Default: 0.45 for hybrid, 0.50 for pure vector.", "default": 0.45 },
-                    "hybrid": { "type": "boolean", "description": "Combine vector + keyword search (default true). Set false for pure vector. Forced to false when precision is true.", "default": true },
+                    "hybrid": { "type": "boolean", "description": "Combine vector + keyword search (default true). Set false for pure vector. Forced to false when mode='precision'.", "default": true },
                     "verbose": { "type": "boolean", "description": "Include full Markov blanket data in results. Default false returns slim results (scores, chunks, scoring breakdown). Set true for full graph context.", "default": false },
-                    "precision": { "type": "boolean", "description": "Cross-encoder rerank mode. Vector pass widens to 5x limit, then the embedder's /rerank scores each candidate against the query. Replaces the blanket+blend ranker. Requires BSMCP_RERANK_PROVIDER on the embedder. Default false.", "default": false },
-                    "mode": { "type": "string", "description": "Convenience alias: 'precision' is equivalent to precision=true. Other values are ignored.", "enum": ["precision"] }
+                    "mode": { "type": "string", "description": "Ranking strategy. 'standard' (default), 'rerank' (refinement), or 'precision' (cascade). Both rerank and precision require BSMCP_RERANK_PROVIDER configured on the embedder.", "enum": ["standard", "rerank", "precision"], "default": "standard" }
                 },
                 "required": ["query"]
             })));

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -97,9 +97,16 @@ async fn execute_tool(
             let default_threshold = if hybrid { 0.45 } else { 0.50 };
             let threshold = args.get("threshold").and_then(|v| v.as_f64()).unwrap_or(default_threshold) as f32;
             let verbose = args.get("verbose").and_then(|v| v.as_bool()).unwrap_or(false);
+            // Accept either `precision: true` or `mode: "precision"`. The
+            // boolean is the canonical knob; `mode` is sugar for callers that
+            // think in named modes.
+            let precision = args.get("precision").and_then(|v| v.as_bool()).unwrap_or(false)
+                || args.get("mode").and_then(|v| v.as_str()) == Some("precision");
             // The HTTP `filter_by_permission` fallback inside `sem.search`
             // enforces per-page access control via BookStack's API.
-            let mut result = sem.search(&query, limit, threshold, hybrid, verbose, client, None).await?;
+            let mut result = sem
+                .search(&query, limit, threshold, hybrid, verbose, client, None, precision)
+                .await?;
             trim_semantic_search_payload(&mut result);
             format_json(&result)
         }
@@ -1801,15 +1808,17 @@ pub fn tool_definitions(semantic_enabled: bool) -> Vec<Value> {
 
     if semantic_enabled {
         tools.push(tool("semantic_search",
-            "Hybrid search combining vector embeddings with keyword matching. Finds pages by meaning AND exact terms. Results are re-ranked using graph relationships (Markov blanket). IMPORTANT: Include related terms, synonyms, and domain-specific vocabulary in your query for better recall. For example, instead of 'office gets hacked', search 'security breach incident response ransomware compromise recovery'. The richer the query, the better the vector matching. Set hybrid=false for pure vector search only.",
+            "Hybrid search combining vector embeddings with keyword matching. Finds pages by meaning AND exact terms. Results are re-ranked using graph relationships (Markov blanket). IMPORTANT: Include related terms, synonyms, and domain-specific vocabulary in your query for better recall. For example, instead of 'office gets hacked', search 'security breach incident response ransomware compromise recovery'. The richer the query, the better the vector matching. Set hybrid=false for pure vector search only. Set precision=true (or mode='precision') to replace the blanket+blend ranker with a cross-encoder rerank — wider initial vector pass, then the embedder's /rerank scores each candidate against the query directly. Higher quality, slightly slower; requires BSMCP_RERANK_PROVIDER configured on the embedder.",
             json!({
                 "type": "object",
                 "properties": {
                     "query": { "type": "string", "description": "Natural language search query. Include synonyms and related terms for better results." },
                     "limit": { "type": "integer", "description": "Max number of page results to return", "default": 10 },
                     "threshold": { "type": "number", "description": "Minimum cosine similarity score (0.0-1.0). Default: 0.45 for hybrid, 0.50 for pure vector.", "default": 0.45 },
-                    "hybrid": { "type": "boolean", "description": "Combine vector + keyword search (default true). Set false for pure vector.", "default": true },
-                    "verbose": { "type": "boolean", "description": "Include full Markov blanket data in results. Default false returns slim results (scores, chunks, scoring breakdown). Set true for full graph context.", "default": false }
+                    "hybrid": { "type": "boolean", "description": "Combine vector + keyword search (default true). Set false for pure vector. Forced to false when precision is true.", "default": true },
+                    "verbose": { "type": "boolean", "description": "Include full Markov blanket data in results. Default false returns slim results (scores, chunks, scoring breakdown). Set true for full graph context.", "default": false },
+                    "precision": { "type": "boolean", "description": "Cross-encoder rerank mode. Vector pass widens to 5x limit, then the embedder's /rerank scores each candidate against the query. Replaces the blanket+blend ranker. Requires BSMCP_RERANK_PROVIDER on the embedder. Default false.", "default": false },
+                    "mode": { "type": "string", "description": "Convenience alias: 'precision' is equivalent to precision=true. Other values are ignored.", "enum": ["precision"] }
                 },
                 "required": ["query"]
             })));

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -16,6 +16,57 @@ use bsmcp_common::types::MarkovBlanket;
 
 const PERMISSION_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
 
+/// Search ranking strategy. Selected per-call via the `mode` argument on
+/// `semantic_search`. All three modes return the same JSON shape so a
+/// caller can swap modes on the same query and diff the output.
+///
+/// - `Standard`: vector + optional keyword + blanket boost + blended sort.
+///   Free, known-good baseline. Default.
+/// - `Rerank`: standard pipeline produces the top-N, then a cross-encoder
+///   /rerank pass re-orders just those N results. Cheap refinement on top
+///   of what works (~10-30ms for N≤50 against a local cross-encoder).
+/// - `Precision`: wider initial vector pass (5× limit), permission filter,
+///   then cross-encoder /rerank as the ranker of record (replaces the
+///   blanket+blend). More expensive, more potential to rescue a hit the
+///   blend would have missed. `hybrid` is forced false in this mode.
+///
+/// `Rerank` and `Precision` both require `BSMCP_RERANK_PROVIDER` configured
+/// on the embedder; without it, `/rerank` returns 503 and the call surfaces
+/// a clear error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SearchMode {
+    Standard,
+    Rerank,
+    Precision,
+}
+
+impl SearchMode {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "" | "standard" | "default" => Some(Self::Standard),
+            "rerank" => Some(Self::Rerank),
+            "precision" => Some(Self::Precision),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Rerank => "rerank",
+            Self::Precision => "precision",
+        }
+    }
+}
+
+/// Result of a `/rerank` HTTP call to the embedder. Hits are in score-desc
+/// order, already truncated to `top_k`.
+struct RerankResponse {
+    hits: Vec<(usize, f32)>,
+    provider: String,
+    model: String,
+}
+
 /// Cap a single semantic-match's chunks and truncate each chunk's content.
 /// Shared by every caller that surfaces chunk previews to a model — the
 /// briefing (per-book + kb) and the `semantic_search` MCP tool — so the
@@ -252,7 +303,10 @@ impl SemanticState {
         accessible
     }
 
-    /// Hybrid search: vector + keyword + blanket re-ranking.
+    /// Hybrid search: vector + keyword + blanket re-ranking, with optional
+    /// cross-encoder rerank as either a refinement (`Rerank`) or a full
+    /// replacement of the blend (`Precision`). See [`SearchMode`] for the
+    /// per-mode contract.
     ///
     /// `book_filter`: when `Some(&[..])`, restricts the vector pass to chunks
     /// whose page lives in one of the supplied books. The keyword pass and
@@ -260,15 +314,6 @@ impl SemanticState {
     /// just smaller from the outset, which proportionally shrinks the
     /// permission filter and per-result fan-out. `None` keeps the old
     /// whole-corpus behavior.
-    ///
-    /// `precision`: when `true`, the post-permission step is replaced with a
-    /// cross-encoder rerank against the embedder's `/rerank` endpoint. The
-    /// initial vector pass widens (`limit * 5`) to give the cross-encoder a
-    /// larger candidate pool. The `hybrid` flag is overridden to `false`
-    /// because precision relies on the cross-encoder for ordering, not the
-    /// keyword/blanket blend. Requires `BSMCP_RERANK_PROVIDER` to be set on
-    /// the embedder; otherwise the call returns a clear error and the caller
-    /// can retry without `precision`.
     #[allow(clippy::too_many_arguments)]
     pub async fn search(
         &self,
@@ -279,21 +324,23 @@ impl SemanticState {
         verbose: bool,
         client: &BookStackClient,
         book_filter: Option<&[i64]>,
-        precision: bool,
+        mode: SearchMode,
     ) -> Result<Value, String> {
         let start = Instant::now();
 
         // Precision mode forces hybrid off. The cross-encoder is the ranker
         // of record; mixing in keyword-rank scoring just dilutes its signal.
-        let hybrid = hybrid && !precision;
+        // Rerank mode keeps hybrid intact — the rerank only re-orders the
+        // final top-N from the standard pipeline.
+        let hybrid = hybrid && mode != SearchMode::Precision;
 
         // Run vector search and optional keyword search in parallel.
-        // Candidate over-fetch is `limit * 2` for the standard path —
+        // Candidate over-fetch is `limit * 2` for the standard/rerank path —
         // empirically sufficient headroom after permission filtering. In
         // precision mode we cast a wider net (`limit * 5`) because the
         // cross-encoder benefits from seeing more candidates, and the rerank
         // step itself caps the embedder side at 200 documents.
-        let candidate_multiplier: usize = if precision { 5 } else { 2 };
+        let candidate_multiplier: usize = if mode == SearchMode::Precision { 5 } else { 2 };
         let book_filter_owned: Option<Vec<i64>> = book_filter
             .filter(|s| !s.is_empty())
             .map(|s| s.to_vec());
@@ -412,7 +459,7 @@ impl SemanticState {
         // chunk per page, send `(query, [doc_per_page])` to the embedder's
         // /rerank, and use the returned scores as the final ordering.
         // Skips the blanket boost and hybrid blend below.
-        if precision {
+        if mode == SearchMode::Precision {
             return self
                 .precision_rerank(query, limit, &page_scores, verbose, start)
                 .await;
@@ -544,6 +591,72 @@ impl SemanticState {
             chunks_by_page.entry(detail.page_id).or_default().push(detail);
         }
 
+        // RERANK MODE: refine the standard top-N ordering with a cross-encoder.
+        // Candidate selection (vector + keyword + blanket boost + blend) stays;
+        // /rerank only re-orders the N pages we'd have returned anyway. Cheap
+        // (~10-30ms for N≤50 against a local cross-encoder).
+        let chunk_by_id: HashMap<i64, &bsmcp_common::types::ChunkDetail> =
+            chunk_details.iter().map(|d| (d.chunk_id, d)).collect();
+        let mut rerank_provider = String::new();
+        let mut rerank_model = String::new();
+        let mut rerank_ms: u128 = 0;
+        let mut rerank_scores: HashMap<i64, f32> = HashMap::new();
+        if mode == SearchMode::Rerank && !page_results.is_empty() {
+            let mut docs: Vec<String> = Vec::with_capacity(page_results.len());
+            let mut doc_to_page: Vec<i64> = Vec::with_capacity(page_results.len());
+            for (pid, _, ps) in &page_results {
+                let best_chunk_id = ps
+                    .chunks
+                    .iter()
+                    .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                    .map(|c| c.0);
+                let page_name = meta_by_page
+                    .get(pid)
+                    .map(|m| m.name.as_str())
+                    .unwrap_or("");
+                let (heading, content) = best_chunk_id
+                    .and_then(|cid| chunk_by_id.get(&cid))
+                    .map(|d| (d.heading_path.as_str(), d.content.as_str()))
+                    .unwrap_or(("", ""));
+                let doc = if heading.is_empty() {
+                    format!("{page_name}\n\n{content}")
+                } else {
+                    format!("{page_name} — {heading}\n\n{content}")
+                };
+                docs.push(doc);
+                doc_to_page.push(*pid);
+            }
+
+            let rerank_start = Instant::now();
+            let rr = self.invoke_rerank(query, docs, page_results.len()).await?;
+            rerank_ms = rerank_start.elapsed().as_millis();
+            rerank_provider = rr.provider;
+            rerank_model = rr.model;
+
+            // Cache rerank score per page for the JSON loop, then reorder.
+            // Build a (pid → &PageScore) lookup once so we can rebuild the
+            // page_results vec in rerank-score order without losing the
+            // PageScore reference (which the JSON loop reads from).
+            let ps_by_pid: HashMap<i64, &PageScore> = page_results
+                .iter()
+                .map(|(pid, _, ps)| (*pid, *ps))
+                .collect();
+            let mut reordered: Vec<(i64, f32, &PageScore)> = Vec::with_capacity(rr.hits.len());
+            for (idx, score) in &rr.hits {
+                let Some(&pid) = doc_to_page.get(*idx) else {
+                    return Err(format!(
+                        "Rerank index {idx} out of bounds (max {})",
+                        doc_to_page.len()
+                    ));
+                };
+                rerank_scores.insert(pid, *score);
+                if let Some(&ps) = ps_by_pid.get(&pid) {
+                    reordered.push((pid, *score, ps));
+                }
+            }
+            page_results = reordered;
+        }
+
         // For verbose mode, fetch any blankets we haven't already cached during
         // re-ranking. Most final results will hit the cache for free.
         let mut blanket_cache = blanket_cache;
@@ -590,17 +703,22 @@ impl SemanticState {
                 }
             }
 
+            let mut scoring = json!({
+                "vector": (score.vector_score * 1000.0).round() / 1000.0,
+                "keyword": (score.keyword_rank * 1000.0).round() / 1000.0,
+                "blanket_boost": (score.blanket_boost * 1000.0).round() / 1000.0,
+            });
+            if let Some(rs) = rerank_scores.get(page_id) {
+                scoring["rerank"] = json!((*rs * 1000.0).round() / 1000.0);
+            }
+
             let mut result = json!({
                 "page_id": page_id,
                 "page_name": page_name,
                 "book_id": book_id,
                 "score": (*final_score * 1000.0).round() / 1000.0,
                 "chunks": chunks_json,
-                "scoring": {
-                    "vector": (score.vector_score * 1000.0).round() / 1000.0,
-                    "keyword": (score.keyword_rank * 1000.0).round() / 1000.0,
-                    "blanket_boost": (score.blanket_boost * 1000.0).round() / 1000.0,
-                },
+                "scoring": scoring,
             });
 
             if let Some(ref ts) = updated_at {
@@ -626,18 +744,98 @@ impl SemanticState {
         let stats = self.db.get_stats().await?;
         let query_time_ms = start.elapsed().as_millis();
 
+        let mut stats_json = json!({
+            "total_indexed": stats.total_pages,
+            "total_chunks": stats.total_chunks,
+            "query_time_ms": query_time_ms,
+            "mode": mode.as_str(),
+            "hybrid": hybrid,
+        });
+        if mode == SearchMode::Rerank {
+            stats_json["rerank_ms"] = json!(rerank_ms);
+            stats_json["rerank_provider"] = json!(rerank_provider);
+            stats_json["rerank_model"] = json!(rerank_model);
+            stats_json["candidates_reranked"] = json!(rerank_scores.len());
+        }
+
         Ok(json!({
             "results": results,
-            "stats": {
-                "total_indexed": stats.total_pages,
-                "total_chunks": stats.total_chunks,
-                "query_time_ms": query_time_ms,
-                "mode": if hybrid { "hybrid" } else { "vector" },
-            }
+            "stats": stats_json,
         }))
     }
 
-    /// Cross-encoder rerank step for precision mode. Replaces the blanket
+    /// POST `(query, documents, top_k)` to the embedder's `/rerank` endpoint
+    /// and parse the response. Surfaces the embedder's 503 (reranker disabled)
+    /// as a clear, retry-friendly error so the caller can fall back to
+    /// standard mode without parsing HTTP details.
+    async fn invoke_rerank(
+        &self,
+        query: &str,
+        documents: Vec<String>,
+        top_k: usize,
+    ) -> Result<RerankResponse, String> {
+        let url = format!("{}/rerank", self.embedder_url);
+        let resp = self
+            .http_client
+            .post(&url)
+            .json(&json!({
+                "query": query,
+                "documents": documents,
+                "top_k": top_k,
+            }))
+            .send()
+            .await
+            .map_err(|e| format!("Rerank request failed: {e}"))?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+            return Err(
+                "Reranker is disabled on the embedder. Set BSMCP_RERANK_PROVIDER \
+                 (local|voyage|openai) to enable rerank/precision modes."
+                    .to_string(),
+            );
+        }
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("Rerank error {status}: {body}"));
+        }
+
+        let body: Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Rerank response parse error: {e}"))?;
+
+        let results_arr = body
+            .get("results")
+            .and_then(|v| v.as_array())
+            .ok_or("Rerank response missing 'results' array")?;
+        let provider = body
+            .get("provider")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let model = body
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let mut hits = Vec::with_capacity(results_arr.len());
+        for item in results_arr {
+            let idx = item
+                .get("index")
+                .and_then(|v| v.as_u64())
+                .ok_or("Rerank item missing 'index'")? as usize;
+            let score = item
+                .get("score")
+                .and_then(|v| v.as_f64())
+                .ok_or("Rerank item missing 'score'")? as f32;
+            hits.push((idx, score));
+        }
+        Ok(RerankResponse { hits, provider, model })
+    }
+
+    /// Cross-encoder rerank step for **precision** mode. Replaces the blanket
     /// boost + hybrid blend that the standard search path applies after the
     /// permission filter. Picks one document per candidate page (the best-
     /// scoring chunk's heading + content), POSTs `(query, [doc])` to the
@@ -687,7 +885,8 @@ impl SemanticState {
                     "total_indexed": stats.total_pages,
                     "total_chunks": stats.total_chunks,
                     "query_time_ms": start.elapsed().as_millis(),
-                    "mode": "precision",
+                    "mode": SearchMode::Precision.as_str(),
+                    "hybrid": false,
                     "candidates_reranked": 0,
                 }
             }));
@@ -730,62 +929,12 @@ impl SemanticState {
             doc_to_page.push(*pid);
         }
 
-        let url = format!("{}/rerank", self.embedder_url);
-        let resp = self
-            .http_client
-            .post(&url)
-            .json(&json!({
-                "query": query,
-                "documents": docs,
-                "top_k": limit,
-            }))
-            .send()
-            .await
-            .map_err(|e| format!("Rerank request failed: {e}"))?;
+        let rerank_start = Instant::now();
+        let rr = self.invoke_rerank(query, docs, limit).await?;
+        let rerank_ms = rerank_start.elapsed().as_millis();
 
-        let status = resp.status();
-        if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
-            return Err(
-                "Precision mode requires the embedder reranker. Set BSMCP_RERANK_PROVIDER \
-                 (local|voyage|openai) on the embedder, then retry."
-                    .to_string(),
-            );
-        }
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("Rerank error {status}: {body}"));
-        }
-
-        let body: Value = resp
-            .json()
-            .await
-            .map_err(|e| format!("Rerank response parse error: {e}"))?;
-
-        let results_arr = body
-            .get("results")
-            .and_then(|v| v.as_array())
-            .ok_or("Rerank response missing 'results' array")?;
-        let rerank_provider = body
-            .get("provider")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let rerank_model = body
-            .get("model")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-
-        let mut ranked: Vec<(i64, f32)> = Vec::with_capacity(results_arr.len());
-        for item in results_arr {
-            let idx = item
-                .get("index")
-                .and_then(|v| v.as_u64())
-                .ok_or("Rerank item missing 'index'")? as usize;
-            let score = item
-                .get("score")
-                .and_then(|v| v.as_f64())
-                .ok_or("Rerank item missing 'score'")? as f32;
+        let mut ranked: Vec<(i64, f32)> = Vec::with_capacity(rr.hits.len());
+        for (idx, score) in rr.hits {
             let Some(&pid) = doc_to_page.get(idx) else {
                 return Err(format!(
                     "Rerank index {idx} out of bounds (max {})",
@@ -882,9 +1031,11 @@ impl SemanticState {
                 "total_indexed": stats.total_pages,
                 "total_chunks": stats.total_chunks,
                 "query_time_ms": query_time_ms,
-                "mode": "precision",
-                "rerank_provider": rerank_provider,
-                "rerank_model": rerank_model,
+                "rerank_ms": rerank_ms,
+                "mode": SearchMode::Precision.as_str(),
+                "hybrid": false,
+                "rerank_provider": rr.provider,
+                "rerank_model": rr.model,
                 "candidates_reranked": doc_to_page.len(),
             }
         }))

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -260,6 +260,15 @@ impl SemanticState {
     /// just smaller from the outset, which proportionally shrinks the
     /// permission filter and per-result fan-out. `None` keeps the old
     /// whole-corpus behavior.
+    ///
+    /// `precision`: when `true`, the post-permission step is replaced with a
+    /// cross-encoder rerank against the embedder's `/rerank` endpoint. The
+    /// initial vector pass widens (`limit * 5`) to give the cross-encoder a
+    /// larger candidate pool. The `hybrid` flag is overridden to `false`
+    /// because precision relies on the cross-encoder for ordering, not the
+    /// keyword/blanket blend. Requires `BSMCP_RERANK_PROVIDER` to be set on
+    /// the embedder; otherwise the call returns a clear error and the caller
+    /// can retry without `precision`.
     #[allow(clippy::too_many_arguments)]
     pub async fn search(
         &self,
@@ -270,13 +279,21 @@ impl SemanticState {
         verbose: bool,
         client: &BookStackClient,
         book_filter: Option<&[i64]>,
+        precision: bool,
     ) -> Result<Value, String> {
         let start = Instant::now();
 
+        // Precision mode forces hybrid off. The cross-encoder is the ranker
+        // of record; mixing in keyword-rank scoring just dilutes its signal.
+        let hybrid = hybrid && !precision;
+
         // Run vector search and optional keyword search in parallel.
-        // Candidate over-fetch dropped from limit*5 → limit*2 — empirically
-        // sufficient headroom after permission filtering, and halves both the
-        // permission HTTP fan-out and the blanket DB fan-out.
+        // Candidate over-fetch is `limit * 2` for the standard path —
+        // empirically sufficient headroom after permission filtering. In
+        // precision mode we cast a wider net (`limit * 5`) because the
+        // cross-encoder benefits from seeing more candidates, and the rerank
+        // step itself caps the embedder side at 200 documents.
+        let candidate_multiplier: usize = if precision { 5 } else { 2 };
         let book_filter_owned: Option<Vec<i64>> = book_filter
             .filter(|s| !s.is_empty())
             .map(|s| s.to_vec());
@@ -285,7 +302,7 @@ impl SemanticState {
             self.db
                 .vector_search(
                     &query_vec,
-                    limit * 2,
+                    limit * candidate_multiplier,
                     threshold,
                     book_filter_owned.as_deref(),
                 )
@@ -389,6 +406,17 @@ impl SemanticState {
         let accessible_ids = self.filter_by_permission(&all_page_ids, client).await;
         let accessible_set: HashSet<i64> = accessible_ids.iter().copied().collect();
         page_scores.retain(|pid, _| accessible_set.contains(pid));
+
+        // PRECISION MODE: replace blanket+blend with cross-encoder rerank.
+        // The candidate set is `page_scores` post-ACL. We pick the best
+        // chunk per page, send `(query, [doc_per_page])` to the embedder's
+        // /rerank, and use the returned scores as the final ordering.
+        // Skips the blanket boost and hybrid blend below.
+        if precision {
+            return self
+                .precision_rerank(query, limit, &page_scores, verbose, start)
+                .await;
+        }
 
         // Blanket re-ranking: boost pages whose neighbors also appear in vector results.
         // Use the full set of pages from raw vector hits (not just final candidates),
@@ -605,6 +633,259 @@ impl SemanticState {
                 "total_chunks": stats.total_chunks,
                 "query_time_ms": query_time_ms,
                 "mode": if hybrid { "hybrid" } else { "vector" },
+            }
+        }))
+    }
+
+    /// Cross-encoder rerank step for precision mode. Replaces the blanket
+    /// boost + hybrid blend that the standard search path applies after the
+    /// permission filter. Picks one document per candidate page (the best-
+    /// scoring chunk's heading + content), POSTs `(query, [doc])` to the
+    /// embedder's `/rerank`, then renders the response in the same JSON
+    /// shape as the standard search so callers don't need to branch.
+    async fn precision_rerank(
+        &self,
+        query: &str,
+        limit: usize,
+        page_scores: &HashMap<i64, PageScore>,
+        verbose: bool,
+        start: Instant,
+    ) -> Result<Value, String> {
+        // One document per page = the highest-scoring chunk that contributed
+        // to this page's match. Pages with no chunks (keyword-only matches)
+        // are dropped — precision mode forces hybrid off, so this is rare,
+        // but it keeps the rerank input well-formed if anything slipped past.
+        let mut candidates: Vec<(i64, i64)> = page_scores
+            .iter()
+            .filter_map(|(pid, score)| {
+                score
+                    .chunks
+                    .iter()
+                    .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                    .map(|c| (*pid, c.0))
+            })
+            .collect();
+
+        // Embedder caps per-request docs at 200. If we ever exceed that, keep
+        // the top-vector-scoring candidates so the cross-encoder still sees
+        // the strongest signal.
+        const MAX_RERANK_DOCS: usize = 200;
+        if candidates.len() > MAX_RERANK_DOCS {
+            candidates.sort_by(|(a, _), (b, _)| {
+                let sa = page_scores.get(a).map(|s| s.vector_score).unwrap_or(0.0);
+                let sb = page_scores.get(b).map(|s| s.vector_score).unwrap_or(0.0);
+                sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
+            });
+            candidates.truncate(MAX_RERANK_DOCS);
+        }
+
+        if candidates.is_empty() {
+            let stats = self.db.get_stats().await?;
+            return Ok(json!({
+                "results": [],
+                "stats": {
+                    "total_indexed": stats.total_pages,
+                    "total_chunks": stats.total_chunks,
+                    "query_time_ms": start.elapsed().as_millis(),
+                    "mode": "precision",
+                    "candidates_reranked": 0,
+                }
+            }));
+        }
+
+        let candidate_chunk_ids: Vec<i64> = candidates.iter().map(|(_, cid)| *cid).collect();
+        let candidate_page_ids: Vec<i64> = candidates.iter().map(|(pid, _)| *pid).collect();
+
+        let (chunk_details, metas) = tokio::try_join!(
+            self.db.get_chunk_details(&candidate_chunk_ids),
+            self.db.get_page_metas(&candidate_page_ids),
+        )?;
+
+        let chunk_by_id: HashMap<i64, &bsmcp_common::types::ChunkDetail> =
+            chunk_details.iter().map(|d| (d.chunk_id, d)).collect();
+        let meta_by_page: HashMap<i64, &bsmcp_common::types::PageMeta> =
+            metas.iter().map(|m| (m.page_id, m)).collect();
+
+        // Build documents and a parallel index → page_id map. Heading path +
+        // chunk content gives the cross-encoder enough surface to score; the
+        // page name is included so a query about a topic that appears only in
+        // a heading doesn't get penalized for content-body keyword absence.
+        let mut docs: Vec<String> = Vec::with_capacity(candidates.len());
+        let mut doc_to_page: Vec<i64> = Vec::with_capacity(candidates.len());
+        for (pid, cid) in &candidates {
+            let page_name = meta_by_page
+                .get(pid)
+                .map(|m| m.name.as_str())
+                .unwrap_or("");
+            let (heading, content) = chunk_by_id
+                .get(cid)
+                .map(|d| (d.heading_path.as_str(), d.content.as_str()))
+                .unwrap_or(("", ""));
+            let doc = if heading.is_empty() {
+                format!("{page_name}\n\n{content}")
+            } else {
+                format!("{page_name} — {heading}\n\n{content}")
+            };
+            docs.push(doc);
+            doc_to_page.push(*pid);
+        }
+
+        let url = format!("{}/rerank", self.embedder_url);
+        let resp = self
+            .http_client
+            .post(&url)
+            .json(&json!({
+                "query": query,
+                "documents": docs,
+                "top_k": limit,
+            }))
+            .send()
+            .await
+            .map_err(|e| format!("Rerank request failed: {e}"))?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+            return Err(
+                "Precision mode requires the embedder reranker. Set BSMCP_RERANK_PROVIDER \
+                 (local|voyage|openai) on the embedder, then retry."
+                    .to_string(),
+            );
+        }
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("Rerank error {status}: {body}"));
+        }
+
+        let body: Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Rerank response parse error: {e}"))?;
+
+        let results_arr = body
+            .get("results")
+            .and_then(|v| v.as_array())
+            .ok_or("Rerank response missing 'results' array")?;
+        let rerank_provider = body
+            .get("provider")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let rerank_model = body
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let mut ranked: Vec<(i64, f32)> = Vec::with_capacity(results_arr.len());
+        for item in results_arr {
+            let idx = item
+                .get("index")
+                .and_then(|v| v.as_u64())
+                .ok_or("Rerank item missing 'index'")? as usize;
+            let score = item
+                .get("score")
+                .and_then(|v| v.as_f64())
+                .ok_or("Rerank item missing 'score'")? as f32;
+            let Some(&pid) = doc_to_page.get(idx) else {
+                return Err(format!(
+                    "Rerank index {idx} out of bounds (max {})",
+                    doc_to_page.len()
+                ));
+            };
+            ranked.push((pid, score));
+        }
+        // /rerank already sorted by score desc and truncated to top_k.
+
+        // Verbose: fetch blankets for the final result set only.
+        let mut blanket_cache: HashMap<i64, MarkovBlanket> = HashMap::new();
+        if verbose {
+            let final_pids: Vec<i64> = ranked.iter().map(|(pid, _)| *pid).collect();
+            let extras: Vec<(i64, MarkovBlanket)> = stream::iter(final_pids.into_iter())
+                .map(|pid| async move {
+                    self.db.get_markov_blanket(pid).await.ok().map(|b| (pid, b))
+                })
+                .buffer_unordered(20)
+                .filter_map(|x| async move { x })
+                .collect()
+                .await;
+            for (pid, b) in extras {
+                blanket_cache.insert(pid, b);
+            }
+        }
+
+        let mut chunks_by_page: HashMap<i64, Vec<&bsmcp_common::types::ChunkDetail>> =
+            HashMap::new();
+        for detail in &chunk_details {
+            chunks_by_page.entry(detail.page_id).or_default().push(detail);
+        }
+
+        let mut results = Vec::with_capacity(ranked.len());
+        for (page_id, rerank_score) in &ranked {
+            let (page_name, book_id, updated_at) = match meta_by_page.get(page_id) {
+                Some(m) => (m.name.clone(), m.book_id, m.updated_at.clone()),
+                None => ("Unknown".to_string(), 0, None),
+            };
+            let score_ref = page_scores.get(page_id);
+            let vector_score = score_ref.map(|s| s.vector_score).unwrap_or(0.0);
+
+            let mut chunks_json = Vec::new();
+            if let Some(details) = chunks_by_page.get(page_id) {
+                for detail in details {
+                    let chunk_score = score_ref
+                        .and_then(|s| s.chunks.iter().find(|c| c.0 == detail.chunk_id))
+                        .map(|c| c.1)
+                        .unwrap_or(0.0);
+                    chunks_json.push(json!({
+                        "heading_path": detail.heading_path,
+                        "content": detail.content,
+                        "score": (chunk_score * 1000.0).round() / 1000.0,
+                    }));
+                }
+            }
+
+            let mut result = json!({
+                "page_id": page_id,
+                "page_name": page_name,
+                "book_id": book_id,
+                "score": (rerank_score * 1000.0).round() / 1000.0,
+                "chunks": chunks_json,
+                "scoring": {
+                    "vector": (vector_score * 1000.0).round() / 1000.0,
+                    "rerank": (rerank_score * 1000.0).round() / 1000.0,
+                },
+            });
+
+            if let Some(ref ts) = updated_at {
+                result["updated_at"] = json!(ts);
+            }
+
+            if verbose {
+                if let Some(blanket) = blanket_cache.get(page_id) {
+                    result["blanket"] = json!({
+                        "linked_from": blanket.linked_from.iter().map(|p| json!({"page_id": p.page_id, "name": p.name})).collect::<Vec<_>>(),
+                        "links_to": blanket.links_to.iter().map(|p| json!({"page_id": p.page_id, "name": p.name})).collect::<Vec<_>>(),
+                        "co_linked": blanket.co_linked.iter().map(|p| json!({"page_id": p.page_id, "name": p.name})).collect::<Vec<_>>(),
+                        "siblings": blanket.siblings.iter().map(|p| json!({"page_id": p.page_id, "name": p.name})).collect::<Vec<_>>(),
+                    });
+                }
+            }
+
+            results.push(result);
+        }
+
+        let stats = self.db.get_stats().await?;
+        let query_time_ms = start.elapsed().as_millis();
+
+        Ok(json!({
+            "results": results,
+            "stats": {
+                "total_indexed": stats.total_pages,
+                "total_chunks": stats.total_chunks,
+                "query_time_ms": query_time_ms,
+                "mode": "precision",
+                "rerank_provider": rerank_provider,
+                "rerank_model": rerank_model,
+                "candidates_reranked": doc_to_page.len(),
             }
         }))
     }


### PR DESCRIPTION
## Summary

Two things that ship together because they're useless apart:

1. **Embedder-side `/rerank` infrastructure** — three provider implementations behind a `Reranker` trait, exposed as `POST /rerank` on the embedder when `BSMCP_RERANK_PROVIDER` is configured.
2. **Server-side three-mode `semantic_search`** — new `mode: "standard" | "rerank" | "precision"` arg, defaulting to `"standard"`. Lets real queries decide which strategy works best instead of prescribing one shape.

Workspace bumped `0.10.0` → `0.11.0` (feature, minor).

## The three modes

| `mode` | Pool size | Reranker | Markov blend | Default |
|---|---|---|---|---|
| `standard` | `limit * 2` | off | on | ✅ |
| `rerank` | `limit * 2` | refines top-N pages | on (pre-rerank) | |
| `precision` | `limit * 5` | replaces blend (cascade) | off (forced `hybrid=false`) | |

- **standard** — current behavior. Vector retrieval + ACL filter + Markov-blanket boost + hybrid blend.
- **rerank** — same pool as standard, but after Markov + blend, the cross-encoder refines the surviving pages' final ordering. Cheap upgrade to the existing flow.
- **precision** — wider candidate pool, cross-encoder replaces the blend entirely (cascade). Most expensive, highest-fidelity.

Both rerank-enabled modes are gated on `BSMCP_RERANK_PROVIDER` being set on the embedder. When it's unset, `/rerank` returns 503 and the server surfaces a clear error pointing at the env var — caller drops back to `mode: "standard"` rather than silently degrading.

## Embedder side

- **`crates/bsmcp-embedder/src/rerank.rs`** — `Reranker` trait + three implementations:
  - `LocalReranker` — in-process ONNX cross-encoder via fastembed. Default model `BAAI/bge-reranker-v2-m3`. Reuses `BSMCP_MODEL_PATH`.
  - `VoyageReranker` — `POST /v1/rerank` against `api.voyageai.com` (or any base URL).
  - `OpenAIReranker` — generic OpenAI-shape `/v1/rerank` endpoint. Configurable URL is required; OpenAI itself has not shipped a rerank API yet, so this is for compatible third parties (Voyage, Jina, Cohere via shim, self-hosted).
- **`crates/bsmcp-embedder/src/main.rs`** — `init_reranker()` on startup; `POST /rerank` handler with input validation (200-doc cap), 503 when reranker is disabled, score-desc sort + optional `top_k` truncation server-side.
- **`crates/bsmcp-embedder/src/pipeline.rs`** — `RerankModel` wrapping fastembed's local cross-encoder.

## Server side

`semantic_search` gains a `mode` string arg. Old `precision: true` callers still work via the `mode` mapping, but the canonical shape is `mode: "standard" | "rerank" | "precision"`.

- **`mode: "rerank"`** — after the standard chunk-detail fetch, build one document per page (`{page_name} — {heading_path}\n\n{best chunk content}`), POST to `/rerank` with `top_k=limit`, reorder the page list by rerank score. Markov-blanket scoring is preserved on the per-result `scoring` JSON for visibility.
- **`mode: "precision"`** — `vector_search` with `limit * 5` candidates, ACL filter, then cross-encoder replaces the hybrid blend. `hybrid` forced `false`.

## Result JSON additions

When the reranker fires (either mode), per-result `scoring` includes `rerank` alongside `vector`. `stats` includes:

- `mode` — `"standard"`, `"rerank"`, or `"precision"`
- `hybrid` — bool, false when precision is on
- `rerank_ms`, `rerank_provider`, `rerank_model`, `candidates_reranked` (when reranker fired)

## Configuration (embedder side)

```
# Off by default. Set to enable /rerank and unlock rerank/precision modes.
BSMCP_RERANK_PROVIDER=local|voyage|openai|none
BSMCP_RERANK_MODEL=...        # per-provider default exists for local + voyage
BSMCP_RERANK_API_KEY=...      # voyage/openai
BSMCP_RERANK_API_URL=...      # voyage defaults; openai requires explicit URL
```

## Verification

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 72 passed, 0 failed (44 common + 13 sqlite + 12 worker + 3 mcp tools-list)
- [x] All commits signed (`Co-Authored-By` trailer)
- [x] Smoke test against a live embedder: enable `BSMCP_RERANK_PROVIDER=local`, run `semantic_search { query: ..., mode: "rerank" }` and `mode: "precision"`, confirm `stats.mode` reflects the choice and orderings differ vs standard
- [x] On merge: `promote-on-merge.yml` retags `:dev` to `0.11.0-dev`

## Out of scope

- `scope` params on the search tools (`book_filter` is already wired internally in `search()`; surfacing it in the MCP schema is a separate small PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)