### PR TITLE
Worker: cascade missing-parent reconciles + clippy sweep + v0.9.0 schema migration

### DIFF
--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-06 20:47 UTC from commit `3549ef0` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-07 00:13 UTC from commit `4466b43` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-06 20:47 UTC from commit `3549ef0`._
+_Auto-generated on 2026-05-07 00:13 UTC from commit `4466b43`._
 
 ```
 .

--- a/crates/bsmcp-common/src/vector.rs
+++ b/crates/bsmcp-common/src/vector.rs
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_blob_roundtrip() {
-        let embedding = vec![1.0f32, -2.5, 0.0, 3.14159, f32::MAX, f32::MIN];
+        let embedding = vec![1.0f32, -2.5, 0.0, std::f32::consts::PI, f32::MAX, f32::MIN];
         let blob = embedding_to_blob(&embedding);
         let recovered = blob_to_embedding(&blob);
         assert_eq!(embedding, recovered);

--- a/crates/bsmcp-db-postgres/src/lib.rs
+++ b/crates/bsmcp-db-postgres/src/lib.rs
@@ -172,6 +172,44 @@ impl PostgresDb {
             sqlx::query(sql).execute(&pool).await.ok();
         }
 
+        // v0.9.0 cleanup migrations — drop the v1.0.0 memory-protocol
+        // surface that PR #66 reverted. Same logic as the SQLite backend;
+        // see the comment block there for the rationale. Idempotent.
+        for sql in [
+            "DROP TABLE IF EXISTS token_bindings CASCADE",
+            "DROP TABLE IF EXISTS sessions CASCADE",
+        ] {
+            sqlx::query(sql).execute(&pool).await.ok();
+        }
+
+        let stable_id_exists: bool = sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'user_settings' AND column_name = 'stable_id'
+            )",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap_or(false);
+
+        if stable_id_exists {
+            eprintln!(
+                "v0.9.0 migration: user_settings has v1.0.0 stable_id PK — \
+                 dropping and recreating with token_id_hash PK \
+                 (existing user_settings rows discarded; reconfigure via /settings)"
+            );
+            for sql in [
+                "DROP TABLE user_settings",
+                "CREATE TABLE user_settings (
+                    token_id_hash TEXT PRIMARY KEY,
+                    settings_json TEXT NOT NULL,
+                    updated_at BIGINT NOT NULL
+                )",
+            ] {
+                sqlx::query(sql).execute(&pool).await.ok();
+            }
+        }
+
         sqlx::query("INSERT INTO global_settings (id, updated_at) VALUES (1, 0) ON CONFLICT (id) DO NOTHING")
             .execute(&pool).await.ok();
 

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -217,6 +217,55 @@ impl SqliteDb {
             conn.execute_batch(sql).ok();
         }
 
+        // v0.9.0 cleanup migrations — drop the v1.0.0 memory-protocol
+        // surface that PR #66 reverted. Idempotent on rerun.
+        //
+        //   1. `token_bindings` (per-account-settings stable identity)
+        //      and `sessions` (Phase 2.8 session capture index) are
+        //      fully retired; consumers are gone, no data to preserve.
+        //   2. `user_settings` was reshaped between versions: v1.0.0
+        //      keyed by `stable_id` (FK to token_bindings.stable_id);
+        //      v0.9.0 reverts to PK `token_id_hash`. The earlier
+        //      `CREATE TABLE IF NOT EXISTS user_settings` was a no-op
+        //      on v1.0.0 instances (table already existed with the old
+        //      PK), so we detect the v1.0.0 column shape here and
+        //      rebuild from scratch.
+        //
+        // v1.0.0 deployments were mostly single-tenant test instances
+        // per the PR #66 rollback plan — wholesale reset of
+        // user_settings is acceptable; /settings reconfigures on first
+        // post-upgrade login.
+        for sql in [
+            "DROP TABLE IF EXISTS token_bindings",
+            "DROP TABLE IF EXISTS sessions",
+        ] {
+            conn.execute_batch(sql).ok();
+        }
+
+        let stable_id_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('user_settings') WHERE name = 'stable_id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+        if stable_id_count > 0 {
+            eprintln!(
+                "v0.9.0 migration: user_settings has v1.0.0 stable_id PK — \
+                 dropping and recreating with token_id_hash PK \
+                 (existing user_settings rows discarded; reconfigure via /settings)"
+            );
+            conn.execute_batch(
+                "DROP TABLE user_settings;
+                 CREATE TABLE user_settings (
+                     token_id_hash TEXT PRIMARY KEY,
+                     settings_json TEXT NOT NULL,
+                     updated_at INTEGER NOT NULL
+                 );",
+            )
+            .ok();
+        }
+
         // Issue #54 — job lifecycle columns on index_jobs. The matching
         // embed_jobs migration runs in init_semantic_tables. SQLite has no
         // ADD COLUMN IF NOT EXISTS, so the duplicate-column error is
@@ -2923,6 +2972,105 @@ mod lifecycle_tests {
         );
         let path = dir.join(unique);
         SqliteDb::open(&path, "test-encryption-key-thirty-two-chars-long")
+    }
+
+    /// v1.0.0 → v0.9.0 migration: simulate a v1.0.0-shape database
+    /// (user_settings keyed by stable_id, plus token_bindings and sessions
+    /// tables) and assert that opening it under v0.9.0 drops the orphan
+    /// tables and rebuilds user_settings with the token_id_hash PK.
+    #[test]
+    fn v090_migration_drops_v100_orphans_and_rebuilds_user_settings() {
+        let dir = env::temp_dir();
+        let unique = format!(
+            "bsmcp-test-mig-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let path = dir.join(&unique);
+
+        // Initial open creates the v0.9.0 schema.
+        let _ = SqliteDb::open(&path, "test-encryption-key-thirty-two-chars-long");
+
+        // Replace user_settings with the v1.0.0 shape and add the orphan
+        // companion tables to mimic what's on disk for a v1.0.0 deployer
+        // upgrading to v0.9.0.
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "DROP TABLE user_settings;
+             CREATE TABLE user_settings (
+                 stable_id TEXT PRIMARY KEY,
+                 token_id_hash TEXT NOT NULL,
+                 settings_json TEXT NOT NULL,
+                 updated_at INTEGER NOT NULL
+             );
+             CREATE TABLE token_bindings (
+                 stable_id TEXT PRIMARY KEY,
+                 token_id_hash TEXT NOT NULL UNIQUE,
+                 created_at INTEGER NOT NULL
+             );
+             CREATE TABLE sessions (
+                 session_id TEXT PRIMARY KEY,
+                 stable_id TEXT NOT NULL,
+                 started_at INTEGER NOT NULL
+             );
+             INSERT INTO user_settings VALUES ('stable-1', 'hash-1', '{}', 0);
+             INSERT INTO token_bindings VALUES ('stable-1', 'hash-1', 0);
+             INSERT INTO sessions VALUES ('sess-1', 'stable-1', 0);",
+        )
+        .unwrap();
+        drop(conn);
+
+        // Reopen — init runs the migration.
+        let _ = SqliteDb::open(&path, "test-encryption-key-thirty-two-chars-long");
+
+        let conn = rusqlite::Connection::open(&path).unwrap();
+
+        let token_bindings_exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='token_bindings'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(token_bindings_exists, 0, "token_bindings should be dropped");
+
+        let sessions_exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sessions'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(sessions_exists, 0, "sessions should be dropped");
+
+        let stable_id_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('user_settings') WHERE name = 'stable_id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stable_id_count, 0, "user_settings.stable_id column should be gone");
+
+        let pk_col: String = conn
+            .query_row(
+                "SELECT name FROM pragma_table_info('user_settings') WHERE pk > 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(pk_col, "token_id_hash", "user_settings PK should be token_id_hash");
+
+        let row_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM user_settings", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(row_count, 0, "wholesale reset: rows discarded per the migration contract");
+
+        drop(conn);
+        std::fs::remove_file(&path).ok();
     }
 
     #[tokio::test]

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -868,7 +868,7 @@ impl SemanticDb for SqliteDb {
         let ids = page_ids.to_vec();
         tokio::task::spawn_blocking(move || {
             let conn = conn.lock().unwrap();
-            let placeholders = std::iter::repeat("?").take(ids.len()).collect::<Vec<_>>().join(",");
+            let placeholders = std::iter::repeat_n("?", ids.len()).collect::<Vec<_>>().join(",");
             let sql = format!("SELECT page_id, book_id FROM pages WHERE page_id IN ({placeholders})");
             let mut stmt = conn.prepare(&sql).map_err(|e| format!("Prepare failed: {e}"))?;
             let params_vec: Vec<&dyn rusqlite::ToSql> =
@@ -893,7 +893,7 @@ impl SemanticDb for SqliteDb {
         let ids = page_ids.to_vec();
         tokio::task::spawn_blocking(move || {
             let conn = conn.lock().unwrap();
-            let placeholders = std::iter::repeat("?").take(ids.len()).collect::<Vec<_>>().join(",");
+            let placeholders = std::iter::repeat_n("?", ids.len()).collect::<Vec<_>>().join(",");
             let sql = format!(
                 "SELECT page_id, book_id, chapter_id, name, slug, content_hash, updated_at
                  FROM pages WHERE page_id IN ({placeholders})"
@@ -1568,14 +1568,14 @@ impl SemanticDb for SqliteDb {
             let need_pages_join = book_filter.is_some() || role_filter.is_some();
 
             if let Some(ref ids) = book_filter {
-                let placeholders = std::iter::repeat("?").take(ids.len()).collect::<Vec<_>>().join(",");
+                let placeholders = std::iter::repeat_n("?", ids.len()).collect::<Vec<_>>().join(",");
                 where_clauses.push(format!("p.book_id IN ({placeholders})"));
                 for id in ids {
                     params_dyn.push(Box::new(*id));
                 }
             }
             if let Some(ref roles) = role_filter {
-                let placeholders = std::iter::repeat("?").take(roles.len()).collect::<Vec<_>>().join(",");
+                let placeholders = std::iter::repeat_n("?", roles.len()).collect::<Vec<_>>().join(",");
                 where_clauses.push(format!(
                     "(p.acl_computed_at IS NULL
                       OR COALESCE(p.acl_default_open, 0) = 1
@@ -2922,8 +2922,7 @@ mod lifecycle_tests {
                 .as_nanos()
         );
         let path = dir.join(unique);
-        let db = SqliteDb::open(&path, "test-encryption-key-thirty-two-chars-long");
-        db
+        SqliteDb::open(&path, "test-encryption-key-thirty-two-chars-long")
     }
 
     #[tokio::test]

--- a/crates/bsmcp-embedder/src/main.rs
+++ b/crates/bsmcp-embedder/src/main.rs
@@ -227,7 +227,7 @@ async fn main() {
     // Worker identity — persistent UUID for job ownership
     let model_path = env::var("BSMCP_MODEL_PATH").unwrap_or_else(|_| "/data/models".into());
     let worker_data_dir = PathBuf::from(
-        env::var("BSMCP_EMBED_DATA_DIR").unwrap_or_else(|_| model_path)
+        env::var("BSMCP_EMBED_DATA_DIR").unwrap_or(model_path)
     );
     let worker_id = load_or_create_worker_id(&worker_data_dir);
     eprintln!("Embedder: worker_id={worker_id}");

--- a/crates/bsmcp-embedder/src/pipeline.rs
+++ b/crates/bsmcp-embedder/src/pipeline.rs
@@ -241,6 +241,10 @@ pub const DEFAULT_FAILURE_THRESHOLD: usize = 10;
 pub const DEFAULT_CONSECUTIVE_ABORT: usize = 10;
 
 /// Run the embedding pipeline for a job.
+// Tunables (delay/batch/abort thresholds) are pulled in from main rather
+// than reread from env each call. Bundling them into a config struct would
+// hide the call site, so the tradeoff favors keeping the explicit signature.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_pipeline(
     db: &Arc<dyn SemanticDb>,
     embedder: &Arc<dyn Embedder>,

--- a/crates/bsmcp-server/src/briefing/mod.rs
+++ b/crates/bsmcp-server/src/briefing/mod.rs
@@ -13,6 +13,10 @@
 //!                 first call per session, sticky bits thereafter — handled
 //!                 by `crate::session`).
 
+// `briefing/briefing.rs` holds the actual builder. Renaming would touch every
+// import; the inception is intentional as a sub-module within the briefing
+// namespace.
+#[allow(clippy::module_inception)]
 pub mod briefing;
 pub mod envelope;
 pub mod frontmatter;

--- a/crates/bsmcp-server/src/main.rs
+++ b/crates/bsmcp-server/src/main.rs
@@ -54,11 +54,12 @@ async fn main() {
 
     // Select database backend
     let backend_type = DbBackendType::from_env();
-    let (db, semantic_db, index_db): (
+    type DbHandles = (
         Arc<dyn DbBackend>,
         Option<Arc<dyn SemanticDb>>,
         Arc<dyn IndexDb>,
-    ) = match backend_type {
+    );
+    let (db, semantic_db, index_db): DbHandles = match backend_type {
         DbBackendType::Sqlite => {
             let db_path = env::var("BSMCP_DB_PATH")
                 .map(PathBuf::from)

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -1365,7 +1365,7 @@ fn replace_section_html(html: &str, heading: &str, new_content: &str, page_id: i
 
         if rest.len() > 2 {
             let level_char = rest.as_bytes()[2];
-            if level_char >= b'1' && level_char <= b'6' {
+            if (b'1'..=b'6').contains(&level_char) {
                 let level = (level_char - b'0') as usize;
                 let close_tag = format!("</h{}>", level);
                 if let Some(close_pos) = rest.find(&close_tag) {
@@ -1401,7 +1401,7 @@ fn replace_section_html(html: &str, heading: &str, new_content: &str, page_id: i
 
         if rest.len() > 2 {
             let level_char = rest.as_bytes()[2];
-            if level_char >= b'1' && level_char <= b'6' {
+            if (b'1'..=b'6').contains(&level_char) {
                 let level = (level_char - b'0') as usize;
                 if level <= heading_level {
                     end_pos = abs_pos;

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -314,6 +314,7 @@ impl SemanticState {
     /// `user_role_ids`: when `Some(&[..])`, applies a role-level ACL filter
     /// to candidates via `page_view_acl`. Pages whose ACL hasn't been
     /// computed are still included (the HTTP fallback below verifies them).
+    #[allow(clippy::too_many_arguments)]
     pub async fn search(
         &self,
         query: &str,

--- a/crates/bsmcp-server/src/settings_ui.rs
+++ b/crates/bsmcp-server/src/settings_ui.rs
@@ -304,7 +304,7 @@ fn parse_id_list(v: &Option<String>) -> Vec<i64> {
 
 fn parse_string_list(v: &Option<String>) -> Vec<String> {
     let Some(s) = v.as_deref() else { return Vec::new(); };
-    s.split(|c: char| c == ',' || c == '\n')
+    s.split([',', '\n'])
         .map(str::trim)
         .filter(|t| !t.is_empty())
         .map(String::from)

--- a/crates/bsmcp-server/src/sse.rs
+++ b/crates/bsmcp-server/src/sse.rs
@@ -100,6 +100,7 @@ impl Drop for Session {
 }
 
 impl AppState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         bookstack_url: String,
         db: Arc<dyn DbBackend>,

--- a/crates/bsmcp-worker/src/lib.rs
+++ b/crates/bsmcp-worker/src/lib.rs
@@ -535,7 +535,7 @@ impl IndexWorker {
                 _ => {}
             }
             idx += 1;
-            if idx % YIELD_EVERY == 0 {
+            if idx.is_multiple_of(YIELD_EVERY) {
                 tokio::task::yield_now().await;
             }
         }
@@ -599,7 +599,7 @@ impl IndexWorker {
                 count += 1;
             }
             idx += 1;
-            if idx % YIELD_EVERY == 0 {
+            if idx.is_multiple_of(YIELD_EVERY) {
                 tokio::task::yield_now().await;
             }
         }

--- a/crates/bsmcp-worker/src/lib.rs
+++ b/crates/bsmcp-worker/src/lib.rs
@@ -274,12 +274,20 @@ impl IndexWorker {
             "all" => self.walk_all(job.id).await,
             "delta" => self.walk_delta(job.id).await,
             scope if scope.starts_with("page:") => {
-                let id: i64 = scope
-                    .strip_prefix("page:")
-                    .ok_or("invalid page scope")?
-                    .parse()
-                    .map_err(|e| format!("invalid page scope id: {e}"))?;
+                let id = parse_scope_id(scope, "page:")?;
                 self.reconcile_page(id).await
+            }
+            scope if scope.starts_with("chapter:") => {
+                let id = parse_scope_id(scope, "chapter:")?;
+                self.reconcile_chapter(id).await
+            }
+            scope if scope.starts_with("book:") => {
+                let id = parse_scope_id(scope, "book:")?;
+                self.reconcile_book(id).await
+            }
+            scope if scope.starts_with("shelf:") => {
+                let id = parse_scope_id(scope, "shelf:")?;
+                self.reconcile_shelf(id).await
             }
             other => Err(format!("unknown scope: {other}")),
         }
@@ -603,6 +611,11 @@ impl IndexWorker {
     /// upserts the page row + cache row in one transaction. Used by:
     ///   - Phase 4c webhook handler (page event → enqueue page:{id} job)
     ///   - Phase 4c periodic delta walk (each delta page goes through here)
+    ///
+    /// If the parent book is missing from the index (initial walk hasn't
+    /// reached it yet, or the index is partially-stale), this cascades a
+    /// `book:{id}` reconcile job and fails the page job retryably so the
+    /// #54 retry-chain reconciler picks it back up after the parent lands.
     async fn reconcile_page(&self, page_id: i64) -> Result<(), String> {
         let page = self.bs_client.get_page(page_id).await?;
         let book_id = page
@@ -614,11 +627,18 @@ impl IndexWorker {
             .and_then(|v| v.as_i64())
             .filter(|&id| id != 0);
 
-        let parent_book = self.index_db.get_indexed_book(book_id).await?.ok_or_else(|| {
-            format!(
-                "parent book {book_id} not in index — initial full walk hasn't covered it yet"
-            )
-        })?;
+        let parent_book = match self.index_db.get_indexed_book(book_id).await? {
+            Some(b) => b,
+            None => {
+                return cascade_missing_parent(
+                    &self.index_db,
+                    &format!("book:{book_id}"),
+                    &format!("cascade_from_page:{page_id}"),
+                    &format!("page {page_id} parent book {book_id}"),
+                )
+                .await;
+            }
+        };
         let parent_chapter = if let Some(cid) = chapter_id {
             self.index_db.get_indexed_chapter(cid).await?
         } else {
@@ -642,6 +662,155 @@ impl IndexWorker {
             parent_book.identity_ouid.as_deref(),
         )
         .await
+    }
+
+    /// Single-chapter reconcile keyed off chapter id. Cascades a `book:{id}`
+    /// job (and fails retryably) when the parent book is missing from the
+    /// index — same self-heal shape as `reconcile_page`. Upserts only the
+    /// chapter row; descendant pages are reached by the next full/delta walk
+    /// or by their own `page:{id}` jobs.
+    async fn reconcile_chapter(&self, chapter_id: i64) -> Result<(), String> {
+        let chapter = self.bs_client.get_chapter(chapter_id).await?;
+        let book_id = chapter
+            .get("book_id")
+            .and_then(|v| v.as_i64())
+            .ok_or_else(|| format!("chapter {chapter_id} has no book_id"))?;
+
+        let parent_book = match self.index_db.get_indexed_book(book_id).await? {
+            Some(b) => b,
+            None => {
+                return cascade_missing_parent(
+                    &self.index_db,
+                    &format!("book:{book_id}"),
+                    &format!("cascade_from_chapter:{chapter_id}"),
+                    &format!("chapter {chapter_id} parent book {book_id}"),
+                )
+                .await;
+            }
+        };
+
+        let name = string_field(&chapter, "name");
+        let slug = string_field(&chapter, "slug");
+        let (chapter_kind, archive_year) = classify_chapter(&name, parent_book.book_kind);
+        self.index_db
+            .upsert_indexed_chapter(&IndexedChapter {
+                chapter_id,
+                book_id,
+                name,
+                slug,
+                identity_ouid: parent_book.identity_ouid.clone(),
+                chapter_kind,
+                archive_year,
+                indexed_at: current_unix(),
+                deleted: false,
+            })
+            .await
+    }
+
+    /// Single-book reconcile keyed off book id. When a configured global
+    /// shelf claims this book and that shelf isn't in the index yet,
+    /// cascades a `shelf:{id}` job and fails retryably. Otherwise upserts
+    /// the book row (and the manifest-derived identity_ouid for Identity
+    /// books). Descendants are not touched — the full walk or their own
+    /// per-id jobs handle that.
+    async fn reconcile_book(&self, book_id: i64) -> Result<(), String> {
+        let book = self.bs_client.get_book(book_id).await?;
+        // Best-effort shelf attribution: BookStack's `/api/books/{id}` does
+        // not return the parent shelf, so we probe each globally-configured
+        // shelf for this book id. If neither contains it (or globals are
+        // empty), the book is reconciled with shelf_id=None — the same
+        // shape `walk_book` uses when it can't classify a parent.
+        let globals = self.db.get_global_settings().await.unwrap_or_default();
+        let candidate_shelves: Vec<i64> =
+            [globals.hive_shelf_id, globals.user_journals_shelf_id]
+                .into_iter()
+                .flatten()
+                .collect();
+        let mut shelf_id: Option<i64> = None;
+        for sid in &candidate_shelves {
+            let shelf = match self.bs_client.get_shelf(*sid).await {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "IndexWorker: reconcile_book({book_id}) get_shelf({sid}) failed (non-fatal): {e}"
+                    );
+                    continue;
+                }
+            };
+            let contains = shelf
+                .get("books")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|b| b.get("id").and_then(|v| v.as_i64()))
+                        .any(|bid| bid == book_id)
+                })
+                .unwrap_or(false);
+            if contains {
+                shelf_id = Some(*sid);
+                break;
+            }
+        }
+
+        if let Some(sid) = shelf_id {
+            if self.index_db.get_indexed_shelf(sid).await?.is_none() {
+                return cascade_missing_parent(
+                    &self.index_db,
+                    &format!("shelf:{sid}"),
+                    &format!("cascade_from_book:{book_id}"),
+                    &format!("book {book_id} parent shelf {sid}"),
+                )
+                .await;
+            }
+        }
+
+        let shelf_kind = classify_shelf(
+            shelf_id.unwrap_or(0),
+            globals.hive_shelf_id,
+            globals.user_journals_shelf_id,
+        );
+        let name = string_field(&book, "name");
+        let slug = string_field(&book, "slug");
+        let book_kind = classify_book(&name, shelf_kind);
+        let identity_ouid = if matches!(book_kind, BookKind::Identity | BookKind::UserIdentity) {
+            self.find_book_identity_ouid(&book).await
+        } else {
+            None
+        };
+        self.index_db
+            .upsert_indexed_book(&IndexedBook {
+                book_id,
+                name,
+                slug,
+                shelf_id,
+                identity_ouid,
+                book_kind,
+                indexed_at: current_unix(),
+                deleted: false,
+            })
+            .await
+    }
+
+    /// Single-shelf reconcile keyed off shelf id. Top of the cascade
+    /// chain — no parent to check. Upserts only the shelf row.
+    async fn reconcile_shelf(&self, shelf_id: i64) -> Result<(), String> {
+        let shelf = self.bs_client.get_shelf(shelf_id).await?;
+        let globals = self.db.get_global_settings().await.unwrap_or_default();
+        let shelf_kind = classify_shelf(
+            shelf_id,
+            globals.hive_shelf_id,
+            globals.user_journals_shelf_id,
+        );
+        self.index_db
+            .upsert_indexed_shelf(&IndexedShelf {
+                shelf_id,
+                name: string_field(&shelf, "name"),
+                slug: string_field(&shelf, "slug"),
+                shelf_kind,
+                indexed_at: current_unix(),
+                deleted: false,
+            })
+            .await
     }
 
     /// Same as `reconcile_page` but takes parent classification + ouid from
@@ -852,6 +1021,53 @@ pub async fn reconcile_failed_embed_jobs(db: &Arc<dyn SemanticDb>, max_chain: us
 }
 
 // --- helpers ---
+
+/// Parse a scoped job id like "page:123" into the trailing integer.
+/// Used by `process_job` to dispatch per-id reconcile scopes.
+fn parse_scope_id(scope: &str, prefix: &str) -> Result<i64, String> {
+    scope
+        .strip_prefix(prefix)
+        .ok_or_else(|| format!("invalid scope: {scope}"))?
+        .parse()
+        .map_err(|e| format!("invalid scope id in {scope}: {e}"))
+}
+
+/// Self-heal entrypoint for missing-parent cases in `reconcile_page`,
+/// `reconcile_chapter`, and `reconcile_book`. Idempotently enqueues a
+/// reconcile job for the missing parent (the existing `create_index_job`
+/// dedup collapses pending/running/failed-open same-scope jobs onto one),
+/// emits a single log line, and returns a retryable error so the #54
+/// retry-chain reconciler picks the original job back up after the parent
+/// lands. The retry job created by that reconciler runs the same scope
+/// again, by which time the parent is in the index.
+///
+/// `parent_scope` — e.g. `"book:2113"` — must be a valid scope string the
+/// worker's `process_job` dispatch table understands. `triggered_by` is
+/// stored on the enqueued job for provenance (e.g. `"cascade_from_page:2116"`).
+/// `subject` is a short human-readable noun phrase ("page 2116 parent book 2113")
+/// used only in the returned error / log message.
+async fn cascade_missing_parent(
+    index_db: &Arc<dyn IndexDb>,
+    parent_scope: &str,
+    triggered_by: &str,
+    subject: &str,
+) -> Result<(), String> {
+    let (job_id, is_new) = index_db
+        .create_index_job(parent_scope, "both", triggered_by)
+        .await?;
+    if is_new {
+        eprintln!(
+            "IndexWorker: {subject} missing in index — enqueued cascade job {job_id} for {parent_scope} ({triggered_by})"
+        );
+    } else {
+        eprintln!(
+            "IndexWorker: {subject} missing in index — coalesced onto existing cascade job {job_id} for {parent_scope}"
+        );
+    }
+    Err(format!(
+        "{subject} not in index — enqueued {parent_scope} (job {job_id}); will retry"
+    ))
+}
 
 fn current_unix() -> i64 {
     SystemTime::now()
@@ -1094,5 +1310,114 @@ mod reconcile_tests {
         let j2_after = listed.iter().find(|j| j.id == j2).unwrap();
         assert_eq!(j2_after.status, "closed");
         assert_eq!(j2_after.resolved_status.as_deref(), Some("gave_up"));
+    }
+
+    /// Issue #72 — cascade-on-missing-parent.
+    ///
+    /// Concurrent page-level reconciles for two different pages whose
+    /// shared parent book is not yet indexed must coalesce onto a single
+    /// `book:N` cascade job (not one per child) and the original page
+    /// reconciles must surface a retryable error so the #54 reconciler
+    /// picks them up after the cascade book job lands.
+    ///
+    /// We test the helper directly rather than `reconcile_page` end-to-end
+    /// because `BookStackClient` is a concrete reqwest-backed struct with
+    /// no test stub — building one would balloon scope. The helper carries
+    /// 100% of the cascade behavior (idempotency + retryable error + log
+    /// line); the per-method call sites are thin wrappers around it.
+    #[tokio::test]
+    async fn cascade_missing_parent_coalesces_concurrent_children() {
+        let db = temp_db();
+        // Two different child pages discover the same missing parent book.
+        let r1 = cascade_missing_parent(
+            &db,
+            "book:2113",
+            "cascade_from_page:2116",
+            "page 2116 parent book 2113",
+        )
+        .await;
+        let r2 = cascade_missing_parent(
+            &db,
+            "book:2113",
+            "cascade_from_page:2117",
+            "page 2117 parent book 2113",
+        )
+        .await;
+        // Both children must surface a retryable error mentioning the
+        // cascade scope so the #54 reconciler treats them as failed-open.
+        let e1 = r1.expect_err("first child must fail-retryable");
+        let e2 = r2.expect_err("second child must fail-retryable");
+        assert!(e1.contains("book:2113"), "err mentions cascade scope: {e1}");
+        assert!(e2.contains("book:2113"), "err mentions cascade scope: {e2}");
+
+        // Exactly one pending `book:2113` job exists — no duplicates.
+        let pending = db.list_pending_index_jobs(50).await.unwrap();
+        let book_jobs: Vec<_> = pending.iter().filter(|j| j.scope == "book:2113").collect();
+        assert_eq!(
+            book_jobs.len(),
+            1,
+            "concurrent children must coalesce onto one cascade job, got {book_jobs:?}"
+        );
+
+        // Provenance: the surviving cascade job records the FIRST child's
+        // trigger string (subsequent children are no-ops via dedup, so
+        // their `triggered_by` is intentionally not preserved).
+        let cascade = book_jobs[0];
+        assert_eq!(cascade.triggered_by, "cascade_from_page:2116");
+        assert_eq!(cascade.kind, "both");
+        assert_eq!(cascade.status, "pending");
+    }
+
+    /// A second cascade for the same parent after the first has already
+    /// transitioned through `failed` (waiting on the reconciler) must
+    /// still coalesce — `create_index_job`'s dedup rule covers
+    /// failed-without-resolved-status as an active state.
+    #[tokio::test]
+    async fn cascade_coalesces_against_failed_open_parent_job() {
+        let db = temp_db();
+        cascade_missing_parent(
+            &db,
+            "book:9000",
+            "cascade_from_page:1",
+            "page 1 parent book 9000",
+        )
+        .await
+        .unwrap_err();
+        let pending_before = db.list_pending_index_jobs(50).await.unwrap();
+        let parent_id = pending_before
+            .iter()
+            .find(|j| j.scope == "book:9000")
+            .map(|j| j.id)
+            .expect("first cascade enqueued");
+        // Simulate the cascade job itself failing once (e.g. transient
+        // BookStack 5xx) — it's now failed-open, the reconciler hasn't
+        // run yet. A second child cascading the same parent must NOT
+        // double-enqueue.
+        db.fail_index_job(parent_id, "transient").await.unwrap();
+        cascade_missing_parent(
+            &db,
+            "book:9000",
+            "cascade_from_page:2",
+            "page 2 parent book 9000",
+        )
+        .await
+        .unwrap_err();
+        let all_jobs = db.list_index_jobs(50).await.unwrap();
+        let book_jobs: Vec<_> = all_jobs.iter().filter(|j| j.scope == "book:9000").collect();
+        assert_eq!(
+            book_jobs.len(),
+            1,
+            "failed-open parent job must absorb subsequent cascades, got {book_jobs:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_scope_id_round_trip() {
+        assert_eq!(parse_scope_id("page:42", "page:").unwrap(), 42);
+        assert_eq!(parse_scope_id("chapter:7", "chapter:").unwrap(), 7);
+        assert_eq!(parse_scope_id("book:2113", "book:").unwrap(), 2113);
+        assert_eq!(parse_scope_id("shelf:927", "shelf:").unwrap(), 927);
+        assert!(parse_scope_id("page:nope", "page:").is_err());
+        assert!(parse_scope_id("all", "page:").is_err());
     }
 }


### PR DESCRIPTION
Three concerns rolled into the v0.9.0 cleanup pass before #71 ships to release.

## 1. Worker cascade for missing parents — closes #72

`reconcile_page` / `reconcile_chapter` / `reconcile_book` previously returned a hard `Err` when an ancestor wasn't in the index, which the lifecycle layer retried until the retry chain capped — leaking log noise and never self-healing partial walks.

- New `cascade_missing_parent` helper: enqueues a `book:{id}` (or `shelf:{id}`) reconcile job with `triggered_by=cascade_from_{kind}:{id}` and fails the child job retryably so the lifecycle reconciler picks it back up once the parent lands.
- Idempotent against concurrent children of the same missing parent — the `(scope, status IN ('pending','running'))` uniqueness from #54 coalesces them onto a single cascade job.
- Two new tests:
  - `cascade_missing_parent_coalesces_concurrent_children`
  - `cascade_coalesces_against_failed_open_parent_job`

Net effect: webhook traffic during a full walk, silently-incomplete walks, and parent-recreated races all self-heal without operator intervention.

## 2. Clippy sweep — Rust 1.94.1 / `--all-targets`

PR #66 cleaned the default surface; #54's lifecycle work + a Rust toolchain bump exposed 15 additional lints under `--all-targets`. Mostly mechanical:

- `manual_repeat_n` → `std::iter::repeat_n("?", N)` (×4 in db-sqlite)
- `idx % YIELD_EVERY == 0` → `idx.is_multiple_of(YIELD_EVERY)` (×2 in worker)
- `RangeInclusive::contains` (×2 in server)
- `module_inception` allow on `briefing::briefing`
- `too_many_arguments` allows on the briefing builder + summary fns
- `type_complexity` alias on the per-tool toggle return shape
- `vec![..., 3.14159, ...]` → `vec![..., std::f32::consts::PI, ...]` in vector tests
- A few minor let-and-return / char-array splits

`cargo clippy --workspace --all-targets -- -D warnings` is now clean.

## 3. v1.0.0 → v0.9.0 schema migration

PR #66 reverted the v1.0.0 memory-protocol surface but didn't ship the matching SQL cleanup. v1.0.0 deployments upgrading to v0.9.0 carry orphan tables (`token_bindings`, `sessions`) and a `user_settings` keyed by the old `stable_id` PK — the post-revert `CREATE TABLE IF NOT EXISTS user_settings` was a no-op against the v1.0.0 shape, leaving the wrong schema on disk.

- `DROP TABLE IF EXISTS token_bindings` / `DROP TABLE IF EXISTS sessions` (Postgres adds `CASCADE`).
- Detect v1.0.0 `user_settings` shape via `pragma_table_info` (SQLite) or `information_schema.columns` (Postgres) checking for the `stable_id` column.
- On detection, drop and recreate `user_settings` with the v0.9.0 `token_id_hash` PK. Wholesale row reset is acceptable per the PR #66 rollback plan — v1.0.0 deployments were mostly single-tenant test instances; `/settings` reconfigures on first post-upgrade login.
- Mirrored across both backends.
- Covered by `v090_migration_drops_v100_orphans_and_rebuilds_user_settings` — seeds the v1.0.0 shape, opens the db under v0.9.0, asserts the orphan tables are gone and `user_settings.PK = token_id_hash`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — all green (worker reconcile_tests + new migration test pass)
- [ ] CI verify on the published PR image
- [ ] Manual smoke: deploy `:pr-XX` against a v1.0.0-shape database, confirm migration logs and `/settings` works post-upgrade

Closes #72.