### PR TITLE
ci: refactor to org-canonical PR-builds + post-merge-retag pattern

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,323 @@
+name: Build PR
+
+# Per-PR multi-arch image builds. Fires on every push to a PR (open,
+# synchronize, reopen). Builds three images in parallel — bsmcp-server,
+# bsmcp-embedder, bsmcp-worker — and pushes them to GHCR with both the
+# per-commit immutable tag (`{version}-{slug}-{sha}`) and the per-PR
+# rolling tag (`{version}-{slug}`).
+#
+# This is the gating workflow. After this PR lands, follow up by adding
+# build-server / build-embedder / build-worker as required status checks
+# on the org's `Default Branch Protection` and `Release Branch Protection`
+# rulesets.
+#
+# Path-aware fast path: each per-image job uses `dorny/paths-filter@v3`
+# to decide whether the binary's build deps were touched by this PR. If
+# nothing relevant changed, the job retags `:dev` (the latest published
+# stream image) as the per-PR tags instead of doing the 15-min cross-arch
+# build. ~2s vs ~15min.
+#
+# Falls back to a full build when `:dev` doesn't exist yet (cold start
+# / pre-first-release).
+#
+# Canonical references:
+#   https://kb.beesroadhouse.com/books/developer-operations-devops/page/github-actions-workflow-template (1897)
+#   https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy           (1860)
+
+on:
+  pull_request:
+    branches: [development, release]
+    types: [opened, synchronize, reopened]
+
+env:
+  REGISTRY: ghcr.io
+  REPO_URL: https://github.com/bees-roadhouse/bookstack-mcp
+
+concurrency:
+  group: build-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # Skip the whole workflow for external fork PRs — forks can't push to
+  # ghcr.io/bees-roadhouse/* and the verify gate would never pass.
+  guard:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      version: ${{ steps.vars.outputs.version }}
+      slug: ${{ steps.vars.outputs.slug }}
+      short_sha: ${{ steps.vars.outputs.short_sha }}
+      server_changed: ${{ steps.filter.outputs.server }}
+      embedder_changed: ${{ steps.filter.outputs.embedder }}
+      worker_changed: ${{ steps.filter.outputs.worker }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Resolve version + slug + sha
+        id: vars
+        run: |
+          set -euo pipefail
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          SHORT_SHA=${HEAD_SHA:0:7}
+          SLUG=$(printf '%s' "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+      # Per-image change detection. Filter sets mirror SERVER_PATHS /
+      # EMBEDDER_PATHS / WORKER_PATHS in scripts/publish-pr-image.sh —
+      # keep them in sync if either side changes.
+      - name: Detect per-image changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          base: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          filters: |
+            server:
+              - 'crates/bsmcp-server/**'
+              - 'crates/bsmcp-common/**'
+              - 'crates/bsmcp-db-sqlite/**'
+              - 'crates/bsmcp-db-postgres/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'docker/Dockerfile.server'
+              - 'entrypoint.sh'
+            embedder:
+              - 'crates/bsmcp-embedder/**'
+              - 'crates/bsmcp-common/**'
+              - 'crates/bsmcp-db-sqlite/**'
+              - 'crates/bsmcp-db-postgres/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'docker/Dockerfile.embedder'
+              - 'entrypoint.sh'
+            worker:
+              - 'crates/bsmcp-worker/**'
+              - 'crates/bsmcp-common/**'
+              - 'crates/bsmcp-db-sqlite/**'
+              - 'crates/bsmcp-db-postgres/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'docker/Dockerfile.worker'
+              - 'entrypoint.sh'
+
+  build-server:
+    needs: [guard]
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push (full)
+        if: needs.guard.outputs.server_changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.server
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
+          labels: |
+            org.opencontainers.image.source=${{ env.REPO_URL }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server
+
+      # Fast path: nothing relevant to the server changed in this PR.
+      # Retag the published `:dev` image as the per-PR tags. Multi-arch
+      # manifest is preserved by `imagetools create`. Falls back to a
+      # full build if `:dev` doesn't exist (cold start).
+      - name: Retag from :dev (fast path)
+        if: needs.guard.outputs.server_changed != 'true'
+        run: |
+          set -euo pipefail
+          IMAGE=${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server
+          IMMUTABLE="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}"
+          ROLLING="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}"
+          SRC="$IMAGE:dev"
+          if docker buildx imagetools inspect "$SRC" >/dev/null 2>&1; then
+            echo "Retagging $SRC -> $IMMUTABLE, $ROLLING"
+            docker buildx imagetools create --tag "$IMMUTABLE" --tag "$ROLLING" "$SRC"
+          else
+            echo "::warning::$SRC does not exist; falling back to full build."
+            echo "FALLBACK_BUILD=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Fallback full build (cold-start)
+        if: needs.guard.outputs.server_changed != 'true' && env.FALLBACK_BUILD == '1'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.server
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
+          labels: |
+            org.opencontainers.image.source=${{ env.REPO_URL }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server
+
+  build-embedder:
+    needs: [guard]
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push (full)
+        if: needs.guard.outputs.embedder_changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.embedder
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
+          labels: |
+            org.opencontainers.image.source=${{ env.REPO_URL }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          cache-from: type=gha,scope=embedder
+          cache-to: type=gha,mode=max,scope=embedder
+
+      - name: Retag from :dev (fast path)
+        if: needs.guard.outputs.embedder_changed != 'true'
+        run: |
+          set -euo pipefail
+          IMAGE=${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder
+          IMMUTABLE="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}"
+          ROLLING="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}"
+          SRC="$IMAGE:dev"
+          if docker buildx imagetools inspect "$SRC" >/dev/null 2>&1; then
+            echo "Retagging $SRC -> $IMMUTABLE, $ROLLING"
+            docker buildx imagetools create --tag "$IMMUTABLE" --tag "$ROLLING" "$SRC"
+          else
+            echo "::warning::$SRC does not exist; falling back to full build."
+            echo "FALLBACK_BUILD=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Fallback full build (cold-start)
+        if: needs.guard.outputs.embedder_changed != 'true' && env.FALLBACK_BUILD == '1'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.embedder
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
+          labels: |
+            org.opencontainers.image.source=${{ env.REPO_URL }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          cache-from: type=gha,scope=embedder
+          cache-to: type=gha,mode=max,scope=embedder
+
+  build-worker:
+    needs: [guard]
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push (full)
+        if: needs.guard.outputs.worker_changed == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.worker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
+          labels: |
+            org.opencontainers.image.source=${{ env.REPO_URL }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
+
+      - name: Retag from :dev (fast path)
+        if: needs.guard.outputs.worker_changed != 'true'
+        run: |
+          set -euo pipefail
+          IMAGE=${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker
+          IMMUTABLE="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}"
+          ROLLING="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}"
+          SRC="$IMAGE:dev"
+          if docker buildx imagetools inspect "$SRC" >/dev/null 2>&1; then
+            echo "Retagging $SRC -> $IMMUTABLE, $ROLLING"
+            docker buildx imagetools create --tag "$IMMUTABLE" --tag "$ROLLING" "$SRC"
+          else
+            echo "::warning::$SRC does not exist; falling back to full build."
+            echo "FALLBACK_BUILD=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Fallback full build (cold-start)
+        if: needs.guard.outputs.worker_changed != 'true' && env.FALLBACK_BUILD == '1'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.worker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
+            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
+          labels: |
+            org.opencontainers.image.source=${{ env.REPO_URL }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker

--- a/.github/workflows/direct-push.yml
+++ b/.github/workflows/direct-push.yml
@@ -1,0 +1,135 @@
+name: Direct Push (development)
+
+# Direct pushes to `development` are authorized per BR DevOps Branching
+# Strategy (page 1860, §Direct Pushes to Development Are Authorized) for
+# scaffolding, small touchups, and emergency hotfixes. promote-on-merge
+# only fires on `pull_request: closed`, so direct pushes need their own
+# build path or `:dev` would never advance for them.
+#
+# This workflow:
+#   1. Skips PR-merge commits (those are handled by promote-on-merge.yml).
+#   2. On a direct push, builds all three images full multi-arch and
+#      pushes them with stream tags. This is the rare path — most work
+#      goes through PRs.
+#
+# On a direct push to `release` we intentionally do nothing here —
+# release.yml's release-stream jobs (github-release-on-merge,
+# release-binaries-on-merge) handle that branch on `push: release`,
+# and they currently expect promote-on-merge to have already moved
+# the version tags. If a direct push to `release` ever becomes a
+# real workflow, add a `release` arm here mirroring the development
+# build + the same imagetools retag set as promote-on-merge.
+#
+# Canonical references:
+#   https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy             (1860)
+#   https://kb.beesroadhouse.com/books/developer-operations-devops/page/github-actions-workflow-template (1897)
+
+on:
+  push:
+    branches: [development]
+
+env:
+  REGISTRY: ghcr.io
+  REPO_URL: https://github.com/bees-roadhouse/bookstack-mcp
+
+concurrency:
+  group: direct-push-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Skip PR squash-merge commits — promote-on-merge.yml retags the PR
+  # head image atomically when the PR closes. We can detect those via
+  # the GitHub API: a commit that is the merge_commit_sha of a merged
+  # PR shouldn't trigger a fresh build here.
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      is_pr_merge: ${{ steps.check.outputs.is_pr_merge }}
+      version: ${{ steps.vars.outputs.version }}
+      slug: ${{ steps.vars.outputs.slug }}
+      short_sha: ${{ steps.vars.outputs.short_sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect PR-merge commit
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # `gh api` returns the list of PRs associated with this commit
+          # via merge_commit_sha. If any merged PR matches, this push is
+          # a PR-merge — skip and let promote-on-merge.yml handle it.
+          MATCH=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '[.[] | select(.merged_at != null and .merge_commit_sha == "${{ github.sha }}")] | length')
+          if [ "$MATCH" -gt 0 ]; then
+            echo "Push is a PR-merge commit; promote-on-merge.yml owns this. Skipping."
+            echo "is_pr_merge=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Push is a direct push (no merged PR matches); proceeding with build."
+            echo "is_pr_merge=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve version + slug + sha
+        id: vars
+        run: |
+          set -euo pipefail
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
+          SHORT_SHA=${GITHUB_SHA:0:7}
+          # Slug == branch name == "development" for this workflow; keep
+          # the substitution generic in case future arms add `release`.
+          SLUG=$(printf '%s' "${GITHUB_REF#refs/heads/}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: [guard]
+    if: needs.guard.outputs.is_pr_merge == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: bsmcp-server
+            dockerfile: docker/Dockerfile.server
+            scope: server
+          - image: bsmcp-embedder
+            dockerfile: docker/Dockerfile.embedder
+            scope: embedder
+          - image: bsmcp-worker
+            dockerfile: docker/Dockerfile.worker
+            scope: worker
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push (full)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}:dev
+            ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}:dev-${{ needs.guard.outputs.short_sha }}
+            ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}:${{ needs.guard.outputs.version }}-dev
+            ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}:${{ needs.guard.outputs.version }}-dev-${{ needs.guard.outputs.short_sha }}
+          labels: |
+            org.opencontainers.image.source=${{ env.REPO_URL }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.scope }}

--- a/.github/workflows/promote-on-merge.yml
+++ b/.github/workflows/promote-on-merge.yml
@@ -1,0 +1,109 @@
+name: Promote on Merge
+
+# Fires when a PR closes with merged: true. Looks up the PR head image
+# (built by build-pr.yml) and retags it with the appropriate stream
+# tags. Pure manifest operation via `docker buildx imagetools create` —
+# no rebuild. The PR head's source tree is bit-identical to the squash-
+# merge commit on the target branch, so the image is the right artifact.
+#
+# Tag map (development merges):
+#   :dev                                rolling latest dev
+#   :dev-{merge_sha}                    immutable per-merge
+#   :{version}-dev                      versioned dev rolling
+#   :{version}-dev-{merge_sha}          versioned dev immutable
+#
+# Tag map (release merges):
+#   :{version}                          immutable semver
+#   :{version}-{merge_sha}              immutable per-merge
+#   :release                            rolling release pointer
+#   :latest                             rolling latest pointer
+#
+# After this workflow, release.yml takes over for the GitHub Release
+# entry on `push: release` and the v* tag emergency hotfix path.
+#
+# Canonical reference:
+#   https://kb.beesroadhouse.com/books/developer-operations-devops/page/github-actions-workflow-template (1897, §Tag Promotion)
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [development, release]
+
+env:
+  REGISTRY: ghcr.io
+
+concurrency:
+  group: promote-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Resolve source + stream tags
+        id: vars
+        run: |
+          set -euo pipefail
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
+          MERGE_SHA=${{ github.event.pull_request.merge_commit_sha }}
+          MERGE_SHORT_SHA=${MERGE_SHA:0:7}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          HEAD_SHORT_SHA=${HEAD_SHA:0:7}
+          SLUG=$(printf '%s' "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
+          BASE=${{ github.event.pull_request.base.ref }}
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "merge_short_sha=$MERGE_SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "src_slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "src_short_sha=$HEAD_SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Retag stream tags
+        run: |
+          set -euo pipefail
+          VERSION=${{ steps.vars.outputs.version }}
+          SRC_SLUG=${{ steps.vars.outputs.src_slug }}
+          SRC_SHA=${{ steps.vars.outputs.src_short_sha }}
+          MERGE_SHA=${{ steps.vars.outputs.merge_short_sha }}
+          BASE=${{ steps.vars.outputs.base }}
+
+          for IMAGE in bsmcp-server bsmcp-embedder bsmcp-worker; do
+            SRC="${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${VERSION}-${SRC_SLUG}-${SRC_SHA}"
+            echo "Source: $SRC"
+            if ! docker buildx imagetools inspect --raw "$SRC" >/dev/null 2>&1; then
+              echo "::error::Source image not found: $SRC"
+              echo "::error::Expected build-pr.yml to have published this image during PR review."
+              exit 1
+            fi
+            if [ "$BASE" = "development" ]; then
+              docker buildx imagetools create \
+                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:dev" \
+                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:dev-${MERGE_SHA}" \
+                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${VERSION}-dev" \
+                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${VERSION}-dev-${MERGE_SHA}" \
+                "$SRC"
+            else
+              docker buildx imagetools create \
+                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${VERSION}" \
+                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${VERSION}-${MERGE_SHA}" \
+                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:release" \
+                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:latest" \
+                "$SRC"
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,323 +1,48 @@
-name: Build and Release
+name: Release
 
-# Contributor-uploads-image, retag-only-in-CI model:
+# Release-stream concerns. Triggers:
 #
-#   1. Contributor runs scripts/publish-pr-image.sh BEFORE pushing any commit
-#      to ANY branch (PR work or direct-to-development/release). Script builds
-#      multi-arch images and pushes to GHCR with `{version}-{slug}-{sha}` and
-#      `{version}-{slug}`. CI never builds images.
+#   1. push: release          → after promote-on-merge.yml has retagged
+#                               the version tags, this workflow creates
+#                               the GitHub Release entry and attaches
+#                               native bsmcp-server binaries for 5
+#                               targets. No image rebuild — the version
+#                               tags already point at the right manifest.
 #
-#   2. PR opened/updated against development or release  ->  `build-*` jobs
-#      run lightweight verification: confirm the image manifest exists at the
-#      expected per-PR tag and is multi-arch (linux/amd64 + linux/arm64).
-#      Required status checks "build-server" and "build-embedder" gate the
-#      PR merge.
+#   2. push: tag v*           → emergency hotfix path. Builds and pushes
+#                               semver-tagged images directly, then
+#                               creates the matching GitHub Release.
+#                               Use only when the normal release flow
+#                               (PR development → release, then merge)
+#                               isn't available — typically because a
+#                               regression on `release` needs a bypass.
 #
-#   3. Push to development or release (PR squash-merge OR direct push) ->
-#      `push-retag` looks up the source image (via the GitHub API for PR
-#      merges; via the branch's own slug+SHA for direct pushes) and retags
-#      it with the appropriate stream tags. Pure manifest operation, no
-#      rebuild.
+#   3. workflow_dispatch       → manual recovery path.
 #
-#   4. Push to release  ->  `github-release-on-merge` creates the GitHub
-#      Release entry, then `release-binaries-on-merge` builds `bsmcp-server`
-#      native binaries for 5 targets and attaches them. The embedder is
-#      NOT released as a bare binary — Docker only.
+# build-pr.yml is the gating workflow for PRs. promote-on-merge.yml
+# moves the rolling tags. This workflow only handles the release stream.
 #
-#   5. v* tag push (emergency hotfix path)  ->  `tag-release` builds and
-#      pushes semver-tagged images directly in CI. Only build path that
-#      runs in CI; use only when the contributor cannot push images
-#      themselves.
-#
-# Tag map (after push to development, regardless of PR-merge or direct push):
-#   :dev                              rolling, latest dev
-#   :dev-{push_sha}                   immutable per-push
-#   :{version}-dev                    versioned dev rolling
-#   :{version}-dev-{push_sha}         versioned dev immutable per-push
-#
-# Tag map (after push to release):
-#   :{version}                        immutable semver
-#   :{version}-{push_sha}             immutable per-push
-#   :release, :latest                 rolling release pointers
-#
-# `{push_sha}` is the SHA of the commit on the target branch — for a PR
-# squash-merge this is the new merge commit, NOT the PR head SHA. The
-# source image being retagged was built against the PR head's tree, but
-# they're bit-identical (squash-merge preserves the working tree).
+# Canonical references:
+#   https://kb.beesroadhouse.com/books/developer-operations-devops/page/github-actions-workflow-template (1897)
+#   https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy             (1860)
 
 on:
-  pull_request:
-    branches: [development, release]
-    types: [opened, synchronize, reopened, closed]
   push:
-    branches: [development, release]
+    branches: [release]
     tags:
       - 'v*'
-  # Manual trigger for push-retag — used when a push event drops (GitHub
-  # Actions occasionally fails to fire workflow runs for squash-merge
-  # commits). Run via `gh workflow run "Build and Release" --ref development`.
-  # Only push-retag respects this trigger; PR build-* jobs and tag-release
-  # gate on their own event types and stay no-ops.
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
 
 jobs:
-  build-server:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Resolve expected tag
-        id: vars
-        run: |
-          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          SHORT_SHA=${HEAD_SHA:0:7}
-          SLUG=$(printf '%s' "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
-          echo "tag=${VERSION}-${SLUG}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-          echo "image=${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify image exists and is multi-arch
-        run: |
-          REF="${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.tag }}"
-          echo "Inspecting $REF"
-          if ! docker buildx imagetools inspect --raw "$REF" > manifest.json 2>/tmp/err; then
-            echo "::error::Image not found at $REF"
-            echo "::error::Run scripts/publish-pr-image.sh on your branch to build and push it. See DEVELOPMENT.md."
-            cat /tmp/err
-            exit 1
-          fi
-          # Manifest list must include both linux/amd64 and linux/arm64.
-          ARCHES=$(jq -r '.manifests[]?.platform | "\(.os)/\(.architecture)"' manifest.json | sort -u | tr '\n' ' ')
-          echo "Found arches: $ARCHES"
-          for want in linux/amd64 linux/arm64; do
-            if ! echo " $ARCHES " | grep -q " $want "; then
-              echo "::error::Image is missing platform $want — manifest had: $ARCHES"
-              exit 1
-            fi
-          done
-          echo "OK: $REF is multi-arch (linux/amd64 + linux/arm64)"
-
-  build-embedder:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Resolve expected tag
-        id: vars
-        run: |
-          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          SHORT_SHA=${HEAD_SHA:0:7}
-          SLUG=$(printf '%s' "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
-          echo "tag=${VERSION}-${SLUG}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-          echo "image=${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify image exists and is multi-arch
-        run: |
-          REF="${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.tag }}"
-          echo "Inspecting $REF"
-          if ! docker buildx imagetools inspect --raw "$REF" > manifest.json 2>/tmp/err; then
-            echo "::error::Image not found at $REF"
-            echo "::error::Run scripts/publish-pr-image.sh on your branch to build and push it. See DEVELOPMENT.md."
-            cat /tmp/err
-            exit 1
-          fi
-          ARCHES=$(jq -r '.manifests[]?.platform | "\(.os)/\(.architecture)"' manifest.json | sort -u | tr '\n' ' ')
-          echo "Found arches: $ARCHES"
-          for want in linux/amd64 linux/arm64; do
-            if ! echo " $ARCHES " | grep -q " $want "; then
-              echo "::error::Image is missing platform $want — manifest had: $ARCHES"
-              exit 1
-            fi
-          done
-          echo "OK: $REF is multi-arch (linux/amd64 + linux/arm64)"
-
-  build-worker:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Resolve expected tag
-        id: vars
-        run: |
-          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          SHORT_SHA=${HEAD_SHA:0:7}
-          SLUG=$(printf '%s' "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
-          echo "tag=${VERSION}-${SLUG}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-          echo "image=${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify image exists and is multi-arch
-        run: |
-          REF="${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.tag }}"
-          echo "Inspecting $REF"
-          if ! docker buildx imagetools inspect --raw "$REF" > manifest.json 2>/tmp/err; then
-            echo "::error::Image not found at $REF"
-            echo "::error::Run scripts/publish-pr-image.sh on your branch to build and push it. See DEVELOPMENT.md."
-            cat /tmp/err
-            exit 1
-          fi
-          ARCHES=$(jq -r '.manifests[]?.platform | "\(.os)/\(.architecture)"' manifest.json | sort -u | tr '\n' ' ')
-          echo "Found arches: $ARCHES"
-          for want in linux/amd64 linux/arm64; do
-            if ! echo " $ARCHES " | grep -q " $want "; then
-              echo "::error::Image is missing platform $want — manifest had: $ARCHES"
-              exit 1
-            fi
-          done
-          echo "OK: $REF is multi-arch (linux/amd64 + linux/arm64)"
-
-  # --- Push-to-stream retag ---
-  #
-  # Fires on every push to development or release — covers BOTH direct
-  # pushes AND PR-merge squash commits (which create a new commit on the
-  # target branch = a push event).
-  #
-  # NO CI rebuild. The contributor's `publish-pr-image.sh` already pushed a
-  # multi-arch image to GHCR for the source branch's commit; this job
-  # locates that image and retags it with the appropriate stream tags. If
-  # the source image doesn't exist (contributor forgot to publish before
-  # pushing), the job fails loudly so the contributor knows.
-  #
-  # Source resolution:
-  #   - Squash-merge of a PR onto development/release → look up the merged
-  #     PR via the GitHub API to recover the original head ref + sha. The
-  #     contributor's per-PR image lives at `{version}-{pr_slug}-{pr_sha}`.
-  #   - Direct push to development/release → the contributor must have run
-  #     publish-pr-image.sh on that branch beforehand, producing
-  #     `{version}-{branch_slug}-{push_sha}`.
-  push-retag:
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/release')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Resolve source image + stream tags
-        id: vars
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
-          PUSH_SHORT_SHA=${GITHUB_SHA:0:7}
-          BRANCH=${GITHUB_REF#refs/heads/}
-
-          # Try to find a merged PR whose merge_commit matches this push.
-          # The squash-merge case lands here: the contributor's image is at
-          # the PR head's slug+sha, not the merge commit's slug+sha.
-          PR_INFO=$(gh pr list \
-            --repo ${{ github.repository }} \
-            --state merged \
-            --base "$BRANCH" \
-            --search "merge:$GITHUB_SHA" \
-            --json headRefName,headRefOid \
-            --jq '.[0]')
-          if [ -n "$PR_INFO" ] && [ "$PR_INFO" != "null" ]; then
-            SRC_REF=$(echo "$PR_INFO" | jq -r '.headRefName')
-            SRC_FULL_SHA=$(echo "$PR_INFO" | jq -r '.headRefOid')
-            SRC_SHORT_SHA=${SRC_FULL_SHA:0:7}
-            echo "Resolved source from merged PR: ref=$SRC_REF sha=$SRC_SHORT_SHA"
-          else
-            # Direct push: source image was published by the contributor
-            # under the development/release branch's own slug + push SHA.
-            SRC_REF="$BRANCH"
-            SRC_SHORT_SHA="$PUSH_SHORT_SHA"
-            echo "Direct push: ref=$SRC_REF sha=$SRC_SHORT_SHA"
-          fi
-          SRC_SLUG=$(printf '%s' "$SRC_REF" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
-
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "push_short_sha=$PUSH_SHORT_SHA" >> "$GITHUB_OUTPUT"
-          echo "src_slug=$SRC_SLUG" >> "$GITHUB_OUTPUT"
-          echo "src_short_sha=$SRC_SHORT_SHA" >> "$GITHUB_OUTPUT"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Retag stream tags
-        run: |
-          set -euo pipefail
-          for IMAGE in bsmcp-server bsmcp-embedder bsmcp-worker; do
-            SRC="${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.src_slug }}-${{ steps.vars.outputs.src_short_sha }}"
-            echo "Source: $SRC"
-            if ! docker buildx imagetools inspect --raw "$SRC" >/dev/null 2>&1; then
-              echo "::error::Source image not found: $SRC"
-              echo "::error::The contributor must run scripts/publish-pr-image.sh on their branch BEFORE pushing the commit. See DEVELOPMENT.md."
-              exit 1
-            fi
-            if [ "${{ steps.vars.outputs.branch }}" = "development" ]; then
-              docker buildx imagetools create \
-                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:dev" \
-                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:dev-${{ steps.vars.outputs.push_short_sha }}" \
-                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${{ steps.vars.outputs.version }}-dev" \
-                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${{ steps.vars.outputs.version }}-dev-${{ steps.vars.outputs.push_short_sha }}" \
-                "$SRC"
-            else
-              docker buildx imagetools create \
-                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${{ steps.vars.outputs.version }}" \
-                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.push_short_sha }}" \
-                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:release" \
-                --tag "${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:latest" \
-                "$SRC"
-            fi
-          done
-
-  # `promote` removed — push-retag (above) covers both PR-merge and direct-
-  # push retagging. Squash-merge produces a push event on the target branch,
-  # which fires push-retag, which looks up the source PR via the GitHub API
-  # and retags from the contributor's per-PR image. Single mechanism, no
-  # dependence on `pull_request: closed` events firing.
-
-  # Triggered by the push that lands on `release` (PR squash-merge or
-  # direct push). Runs after push-retag so the released images are
-  # already tagged with the version when the GitHub Release entry is
-  # written.
+  # GitHub Release on push: release. Runs after promote-on-merge.yml
+  # has already retagged the version tags. Creates the v{version} git
+  # tag (if missing) and the GitHub Release entry; release-binaries-on-
+  # merge attaches native binaries.
   github-release-on-merge:
     if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-    needs: [push-retag]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -363,6 +88,7 @@ jobs:
             ```
             docker pull ghcr.io/bees-roadhouse/bsmcp-server:${{ steps.vars.outputs.version }}
             docker pull ghcr.io/bees-roadhouse/bsmcp-embedder:${{ steps.vars.outputs.version }}
+            docker pull ghcr.io/bees-roadhouse/bsmcp-worker:${{ steps.vars.outputs.version }}
             ```
 
             Or pin to the rolling release tag:
@@ -370,6 +96,7 @@ jobs:
             ```
             docker pull ghcr.io/bees-roadhouse/bsmcp-server:release
             docker pull ghcr.io/bees-roadhouse/bsmcp-embedder:release
+            docker pull ghcr.io/bees-roadhouse/bsmcp-worker:release
             ```
 
             ## Native binaries (`bsmcp-server` only)
@@ -452,6 +179,9 @@ jobs:
           tag_name: ${{ needs.github-release-on-merge.outputs.tag }}
           files: ${{ env.ARCHIVE }}
 
+  # Emergency hotfix path: a `v*` tag was pushed directly. Build the
+  # semver-tagged images and create the GitHub Release. This is the
+  # only path in this workflow that builds images.
   tag-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -459,6 +189,7 @@ jobs:
       contents: write
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         include:
           - image: bsmcp-server
@@ -467,6 +198,9 @@ jobs:
           - image: bsmcp-embedder
             dockerfile: docker/Dockerfile.embedder
             scope: embedder
+          - image: bsmcp-worker
+            dockerfile: docker/Dockerfile.worker
+            scope: worker
     steps:
       - uses: actions/checkout@v4
 
@@ -518,6 +252,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.vars.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -541,6 +277,7 @@ jobs:
             ```
             docker pull ghcr.io/bees-roadhouse/bsmcp-server:${{ steps.vars.outputs.version }}
             docker pull ghcr.io/bees-roadhouse/bsmcp-embedder:${{ steps.vars.outputs.version }}
+            docker pull ghcr.io/bees-roadhouse/bsmcp-worker:${{ steps.vars.outputs.version }}
             ```
 
             ## Native binaries (`bsmcp-server` only)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,29 +91,33 @@ Direct pushes to `development` stay available — use them for small atomic chan
 
 ## CI/CD
 
-**Contributor-uploads-image.** Heavy multi-arch Docker builds run on the **contributor's machine**, not in CI. Before pushing a PR commit, run `scripts/publish-pr-image.sh` to build and push the per-PR images to GHCR. CI then runs lightweight verification jobs that confirm the images exist and are multi-arch — that's the merge gate. The SBOM/STRUCTURE auto-commit still runs on every PR commit (it's quick).
+The org-canonical PR-builds + post-merge-retag pattern. Reference docs:
 
-This trades CI minutes for a small contributor onboarding step. The gate is preserved (PRs cannot merge without verified images); the build cost moves to the engineer who actually edited the source.
+- BR DevOps [GitHub Actions Workflow Template (1897)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/github-actions-workflow-template) — canonical trigger / tag / cache shape.
+- BR DevOps [Branching Strategy (1860)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) — branch model and direct-push authorization.
+
+**CI builds. Squash-merge retags.** Heavy multi-arch Docker builds run in CI on every push to a PR. Per-PR images are tagged immutably (`{version}-{slug}-{sha}`) and rolling (`{version}-{slug}`). After squash-merge, a separate workflow retags the PR head image as the stream tags via `docker buildx imagetools create` — pure manifest operation, no rebuild. The squash-merge commit's source tree is bit-identical to the PR head, so the image is the right artifact.
 
 ### Contributor flow (per PR)
 
 ```
 1. git checkout -b improvement/my-change
-2. ... commit work ...
-3. scripts/publish-pr-image.sh        # build + push multi-arch images to GHCR
-4. git push -u origin improvement/my-change
-5. Open PR; build-server / build-embedder / build-worker verify checks should pass
-6. On every subsequent commit, re-run scripts/publish-pr-image.sh before pushing
-7. Squash-merge into development; delete the work branch
+2. ... commit work, sign each commit ...
+3. git push -u origin improvement/my-change
+4. Open PR; build-server / build-embedder / build-worker run on every PR push
+5. Squash-merge into development; delete the work branch
+6. promote-on-merge.yml retags the PR head image as :dev / :{version}-dev
 ```
 
-If you push the commit before pushing the image, the verify check fails with a clear error pointing at the script. Run it, then re-trigger the check (push an empty commit or click "Re-run jobs" in GitHub Actions).
+No local image build needed. `scripts/publish-pr-image.sh` is still in the repo as an out-of-band escape hatch for emergency hotfixes when CI is unavailable, but it's not part of the normal flow.
 
-### Path-aware fast path (`scripts/publish-pr-image.sh`)
+### Path-aware fast path (CI)
 
-The publish script diffs your branch against `origin/development` and skips the rebuild for any binary whose dependency files didn't change. It retags the latest published `:dev` image as the per-PR tags instead — a manifest-only operation that takes seconds.
+`build-pr.yml` uses [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter) to detect which binaries' build deps were touched by the PR. When nothing relevant changed for a given binary, the job retags `:dev` (the latest published stream image) as the per-PR tags instead of doing the 15-min cross-arch build. ~2s vs ~15min.
 
-What counts as "changed paths":
+Falls back to a full build automatically when `:dev` doesn't exist (cold start or pre-first-release).
+
+What counts as "changed paths" per binary:
 
 | Binary | Paths that trigger a rebuild |
 |---|---|
@@ -121,65 +125,57 @@ What counts as "changed paths":
 | `bsmcp-embedder` | `crates/bsmcp-embedder/`, `crates/bsmcp-common/`, `crates/bsmcp-db-sqlite/`, `crates/bsmcp-db-postgres/`, `Cargo.toml`, `Cargo.lock`, `docker/Dockerfile.embedder`, `entrypoint.sh` |
 | `bsmcp-worker` | `crates/bsmcp-worker/`, `crates/bsmcp-common/`, `crates/bsmcp-db-sqlite/`, `crates/bsmcp-db-postgres/`, `Cargo.toml`, `Cargo.lock`, `docker/Dockerfile.worker`, `entrypoint.sh` |
 
-Note that PRs touching `crates/bsmcp-server/` only — typical for server-side work — skip the embedder rebuild entirely. That's the change that takes a typical PR from ~25 min of multi-arch build time down to ~10 min.
-
-Override with `scripts/publish-pr-image.sh both --force` if you need to force a full rebuild (e.g., to validate a Dockerfile change that the path filter would otherwise miss).
-
-**Direct push to `development` or `release` always forces a rebuild** regardless of path filter results. The path-aware retag-from-`:dev` shortcut is correct for PR work (the contributor's per-PR image already encodes the PR head's tree, which is bit-identical to the squash-merge commit). But for a direct push to a canonical branch, retagging an older image's manifest would leave `org.opencontainers.image.revision` pointing at the older commit, which drifts from the SHA actually being pushed. The script auto-forces the build in this case so the resulting image's revision label matches the push SHA.
+The same path-set is mirrored in `scripts/publish-pr-image.sh` (`SERVER_PATHS` / `EMBEDDER_PATHS` / `WORKER_PATHS`). Keep them in sync — the script is a manual fallback for the same logic.
 
 ### Cargo target / registry caching
 
-Both Dockerfiles use BuildKit `--mount=type=cache` for `target/`, `~/.cargo/registry`, and `~/.cargo/git`. The first build is still cold (~15 min on linux/arm64 via QEMU), but subsequent builds reuse the dep-tree compilation across PR pushes. Cache mount IDs include `$TARGETPLATFORM` so linux/amd64 and linux/arm64 don't poison each other's caches.
+Both Dockerfiles use BuildKit `--mount=type=cache` for `target/`, `~/.cargo/registry`, and `~/.cargo/git`. CI uses scoped GHA cache (`scope=server`, `scope=embedder`, `scope=worker`) so parallel jobs don't evict each other's layers. Cache mount IDs include `$TARGETPLATFORM` so linux/amd64 and linux/arm64 don't poison each other's caches.
 
 ### Embedder is opt-in for deployments
 
 `bsmcp-embedder` is required only when running the **built-in** embedder provider (the default `BSMCP_EMBED_PROVIDER=local` ONNX model). Deployments configured for external providers (`ollama`, `openai`) don't need the embedder container at all — `bsmcp-server` talks to the external endpoint directly.
-
-**One-time setup:**
-
-```bash
-# Multi-platform builder
-docker buildx create --name multiarch --use --bootstrap
-
-# GHCR login (PAT needs write:packages scope)
-echo $GHCR_PAT | docker login ghcr.io -u <gh-user> --password-stdin
-```
 
 ### What runs on what
 
 | Event | Workflow | What happens |
 |-------|----------|-------------|
 | Push to a work branch with **no open PR** | nothing | test locally |
-| `pull_request: opened/synchronize/reopened` against `development` or `release` | `release.yml` (`build-server`, `build-embedder`, `build-worker` verify jobs) | confirms the contributor's per-PR images exist on GHCR with both `linux/amd64` and `linux/arm64`. ~30 seconds. No build. |
+| `pull_request: opened/synchronize/reopened` against `development` or `release` | `build-pr.yml` (`build-server`, `build-embedder`, `build-worker`) | path-aware multi-arch build per image; tags `{version}-{slug}-{sha}` + `{version}-{slug}` |
 | Same trigger | `generate-artifacts.yml` | regenerates `SBOM.md` + `STRUCTURE.md`, commits to PR source branch with `[skip ci]` |
-| `push` to `development` (squash-merge or direct push) | `release.yml` (`push-retag`) | retags the contributor's per-PR image to `:dev`, `:dev-{push_sha}`, `:{version}-dev`, `:{version}-dev-{push_sha}`. No rebuild. |
-| `push` to `release` (squash-merge or direct push) | `release.yml` (`push-retag` + `github-release-on-merge` + `release-binaries-on-merge`) | retags to `:{version}`, `:{version}-{push_sha}`, `:release`, `:latest`; creates GitHub Release; builds `bsmcp-server` native binaries for 5 targets and attaches them to the Release. |
-| `v*` tag push (emergency hotfix only) | `release.yml` (`tag-release` + `github-release-on-tag` + `release-binaries-on-tag`) | builds & pushes semver-tagged images directly in CI (the only build path that still runs in CI), creates the Release, attaches the server binaries. Use only when the contributor cannot push images themselves. |
-| `workflow_dispatch` on `release.yml`, ref = `development` or `release` | `release.yml` (`push-retag`) | manual recovery path when a `push` event drops (GitHub Actions occasionally fails to fire workflow runs for squash-merge commits). Run via `gh workflow run "Build and Release" --ref development`. |
+| `pull_request: closed` (merged: true) on `development` or `release` | `promote-on-merge.yml` | retags the PR head image as the appropriate stream tags via `imagetools create`. No rebuild. |
+| `push` to `development` that is **not** a PR-merge commit (rare; direct push) | `direct-push.yml` | full multi-arch build + stream tags. Authorized per Branching Strategy 1860. |
+| `push` to `release` (always a PR-merge from development) | `release.yml` (`github-release-on-merge` + `release-binaries-on-merge`) | creates the `v{version}` git tag (if missing) and the GitHub Release entry; builds `bsmcp-server` native binaries for 5 targets and attaches them. Image version tags were already moved by `promote-on-merge.yml` when the PR closed. |
+| `v*` tag push (emergency hotfix only) | `release.yml` (`tag-release` + `github-release-on-tag` + `release-binaries-on-tag`) | builds & pushes semver-tagged images directly in CI, creates the Release, attaches the server binaries. Use only when the normal PR flow isn't available. |
+| `workflow_dispatch` on `release.yml` | `release.yml` | manual recovery path |
 
 ### Why this shape
 
-- **CI verifies, contributor builds.** The merge gate is preserved: a PR cannot merge unless its per-PR images exist on GHCR. The actual build work moves out of CI onto the engineer's machine, where it amortizes over the local build cache and saves ~15 min of CI minutes per PR push.
-- **Stable job names (`build-server`, `build-embedder`, `build-worker`).** Branch protection's required status checks reference these names; renaming them would silently disable the gate until the rule is updated. The job names lie a little — they verify, not build — but the trade-off is worth it.
-- **Retag instead of rebuild on merge.** A squash-merge to development produces a new commit SHA, but its source tree is identical to the PR head. The contributor's image is bit-identical to what a CI build would produce, so promote just moves the rolling tag.
+- **CI builds, not contributor.** Build work runs in CI on every PR push. Engineers don't need a local multi-arch builder or a GHCR PAT to get their PR through review. Cost: ~15 min of CI minutes per PR push (mitigated by the path-aware fast path for docs/config-only PRs, which retag in ~2s).
+- **Squash-merge retags, doesn't rebuild.** The squash-merge commit's source tree is bit-identical to the PR head, so the PR head image is the right artifact. `promote-on-merge.yml` moves the rolling tags atomically; the registry handles the cleanup of the old manifest.
+- **Direct push to development has its own workflow.** Page 1860 authorizes direct pushes for scaffolding and hotfixes; page 1897 doesn't explicitly cover that case (it documents the squash-merge path only). `direct-push.yml` fills that gap with a full build + stream-tag push, gated to skip PR-merge commits so promote-on-merge owns those.
 - **Native binaries: server only.** `bsmcp-server` is pure Rust + bundled SQLite and cross-compiles cleanly. `bsmcp-embedder` depends on `fastembed` → ONNX Runtime → a per-platform C++ shared library; bare binaries would need ONNX Runtime installed on the host. Container is the only supported distribution for the embedder.
-- **External fork PRs are not supported under this model.** Forks cannot push to `ghcr.io/bees-roadhouse/*`, so fork PRs cannot satisfy the verify gate. If outside contribution becomes a real workflow, a maintainer will need to manually build/push the contributor's branch (or use the emergency `v*` tag path).
+- **External fork PRs are skipped.** Forks cannot push to `ghcr.io/bees-roadhouse/*`. `build-pr.yml`, `promote-on-merge.yml`, and `generate-artifacts.yml` all gate on `head.repo.full_name == github.repository`.
 
 ### Tag conventions on GHCR
 
-Per-PR (pushed by the contributor via `scripts/publish-pr-image.sh`):
+Per-PR (pushed by `build-pr.yml` on every PR commit):
 - `{version}-{branch-slug}-{sha}` — pinnable to one specific commit
 - `{version}-{branch-slug}` — rolling, moves with each PR push
 
-Development stream (after merge to development):
+Development stream (set by `promote-on-merge.yml` on PR close, or `direct-push.yml` on direct push):
 - `dev` — rolling, latest dev build
-- `{version}-dev` — version-level dev tag
+- `dev-{merge_sha}` — immutable per-merge / per-push
+- `{version}-dev` — version-level dev rolling
+- `{version}-dev-{merge_sha}` — version-level dev immutable
 
-Release stream (after merge to release or `v*` tag):
+Release stream (set by `promote-on-merge.yml` on `development → release` PR close):
 - `latest` — rolling, latest release
 - `release` — alias for `latest`
-- `{version}` — pinned semver (e.g., `0.7.4`)
-- `{major}.{minor}`, `{major}` — broader semver pointers (only emitted on `v*` tag push)
+- `{version}` — pinned semver (e.g., `0.10.0`)
+- `{version}-{merge_sha}` — immutable per-release-merge
+
+Tag-push hotfix (`v*` tag → `release.yml` `tag-release`):
+- `{version}`, `{major}.{minor}`, `{major}` — full semver hierarchy
 
 Images are published to `ghcr.io/bees-roadhouse/bsmcp-server`, `ghcr.io/bees-roadhouse/bsmcp-embedder`, and `ghcr.io/bees-roadhouse/bsmcp-worker` for `linux/amd64` and `linux/arm64`.
 
@@ -199,15 +195,14 @@ Each archive contains the `bsmcp-server` (or `.exe`) binary plus `README.md` and
 
 ### Branch protection
 
-Protection lives at the **organization level** via a GitHub Ruleset (`Release Branch Protection`) targeting `refs/heads/release` on every repo in `bees-roadhouse`:
+Protection lives at the **organization level** via two GitHub Rulesets that apply to every repo in `bees-roadhouse`:
 
-- `pull_request` (0 required approvals — the gate is CI status, not approver count)
-- `non_fast_forward` (blocks force-push)
-- `deletion` (blocks branch delete)
+- `Default Branch Protection` (`~DEFAULT_BRANCH`) — `pull_request` (1 approval, thread resolution), `non_fast_forward`, `deletion`. Bypass: `OrganizationAdmin` in `pull_request` mode.
+- `Release Branch Protection` (`refs/heads/release`, `refs/heads/release/*`, `refs/heads/release-*`) — `pull_request` (1 approval, merge-commit only, thread resolution), `non_fast_forward`, `deletion`. Bypass: `OrganizationAdmin` in `pull_request` mode.
 
-`development` is **intentionally unprotected** — direct pushes stay authorized so scaffolding, hotfixes, and small atomic changes don't get stuck in PR ceremony. CI runs on every push regardless, so regressions are still caught.
+`development` rules trigger only on PR-merge — direct pushes stay authorized. CI runs on every PR push regardless, so regressions are caught before merge.
 
-Required status checks (`build-server`, `build-embedder`) gate the merge into `release` once the PR is open. They now verify rather than build, but the contract from the protection rule's perspective is unchanged.
+Required status checks for `build-server` / `build-embedder` / `build-worker` are **not** wired up yet. After this CI rework lands and the new check names stabilize, a follow-up will add them to both rulesets.
 
 ### Commit signing
 

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-08 16:55 UTC from commit `7be349d` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-09 16:55 UTC from commit `e064b59` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-08 16:55 UTC from commit `7be349d`._
+_Auto-generated on 2026-05-09 16:54 UTC from commit `e064b59`._
 
 ```
 .

--- a/scripts/publish-pr-image.sh
+++ b/scripts/publish-pr-image.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
-# Build & push multi-arch images for the current branch's HEAD commit.
-# CI's verify-on-PR step expects these to exist before it will pass.
+# Optional. CI now builds images on every PR push (.github/workflows/
+# build-pr.yml). Use this script when you need to publish out-of-band:
+#   - Emergency hotfixes when CI is unavailable.
+#   - Local pre-PR experimentation against a non-PR branch.
+#   - Reproducing a specific PR head image locally for debugging.
 #
-# Path-aware fast path: when the PR's diff against `origin/development`
+# For the normal PR flow, just push your branch — build-pr.yml takes
+# over from there. See DEVELOPMENT.md for the canonical CI/CD shape.
+#
+# Path-aware fast path: when the branch's diff against `origin/development`
 # (or `origin/release` when targeting that) doesn't touch any file that
 # affects a given binary, we skip the rebuild and instead retag the
-# latest published `:dev` image as the per-PR tags. The CI verify step
-# only checks tag existence + multi-arch manifest shape — it doesn't
-# care whether the image was newly-built or retagged. Tag-only ops are
-# free; full builds on linux/arm64 take 15+ minutes.
+# latest published `:dev` image as the per-PR tags. Mirrors the same
+# logic build-pr.yml runs in CI via dorny/paths-filter@v3 — keep the
+# SERVER_PATHS / EMBEDDER_PATHS / WORKER_PATHS arrays here in sync with
+# the filter blocks in build-pr.yml. Tag-only ops are free; full builds
+# on linux/arm64 take 15+ minutes.
 #
 # Prerequisites:
 #   - docker + docker buildx with a multi-platform builder configured


### PR DESCRIPTION
## Summary

Move bookstack-mcp's CI/CD to the org-canonical pattern documented in BR DevOps [page 1897](https://kb.beesroadhouse.com/books/developer-operations-devops/page/github-actions-workflow-template). The previous contributor-pushes-image / CI-only-retags model hit a silent failure on PR #79 — head SHA \`038ee12\` merged without \`scripts/publish-pr-image.sh\` having been run on it, the post-merge \`push-retag\` job failed because the source image didn't exist in GHCR, and \`:dev\` stayed pointed at v0.9.0 (\`2cc6bf3\`).

## Changes

- **\`build-pr.yml\` (new)** — \`pull_request: opened/synchronize/reopened\` builds three multi-arch images in parallel via [\`dorny/paths-filter@v3\`](https://github.com/dorny/paths-filter). Per-image cache scopes (\`scope=server|embedder|worker\`). Path-aware fast path retags from \`:dev\` (~2s) when no relevant build deps changed; falls back to a full build automatically on cold-start. Tags \`{version}-{slug}-{sha}\` immutable + \`{version}-{slug}\` rolling. Fork PRs are skipped (forks can't push to \`ghcr.io/bees-roadhouse/*\`).
- **\`promote-on-merge.yml\` (new)** — \`pull_request: closed\` + \`merged: true\` retags the PR head image as the appropriate stream tags via \`docker buildx imagetools create\`. Pure manifest operation. Stream tag map: development → \`:dev\`, \`:dev-{merge_sha}\`, \`:{version}-dev\`, \`:{version}-dev-{merge_sha}\`; release → \`:{version}\`, \`:{version}-{merge_sha}\`, \`:release\`, \`:latest\`.
- **\`direct-push.yml\` (new)** — \`push: development\` builds full multi-arch + stream tags for direct pushes. Skips PR-merge commits (those are owned by \`promote-on-merge.yml\`). Covers the scaffolding/hotfix path that [page 1860](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) authorizes but page 1897 doesn't explicitly cover.
- **\`release.yml\` (trimmed)** — kept only release-stream concerns: \`push: release\` (GitHub Release + native binaries) and \`v*\` tag (emergency hotfix images + Release). The old \`build-*\` verify jobs and \`push-retag\` are gone.
- **\`scripts/publish-pr-image.sh\`** — header rewritten to demote it to a manual escape hatch. Body unchanged; \`SERVER_PATHS\` / \`EMBEDDER_PATHS\` / \`WORKER_PATHS\` continue to mirror the workflow filters.
- **\`DEVELOPMENT.md\`** — CI/CD section rewritten end-to-end. Cross-links 1897 and 1860.

## Deviations from canonical (page 1897)

Page 1897 §Trigger Configuration says builds fire on \`pull_request\` only and explicitly does not cover direct pushes — the assumption is squash-merge to development produces a bit-identical artifact, so retag is enough. Page 1860 separately authorizes direct pushes to development for scaffolding/hotfixes. Those don't have a PR head image to retag, so this PR adds \`direct-push.yml\` as a third workflow specifically for that case. Gated to skip PR-merge commits via the GitHub commits-pulls API check, so the two paths don't double-build.

## Recovery of \`:dev\` (currently stale at v0.9.0 \`2cc6bf3\`)

I went with **Option A — skip recovery**. When this PR merges, \`promote-on-merge.yml\` will retag \`:dev\` to whatever the PR head image is (v0.10.0+canonical-CI). Until then \`:dev\` stays wrong. Failure window is small and the new workflow itself shouldn't take long to land. If you'd rather restore correctness immediately, say the word and I'll run \`scripts/publish-pr-image.sh --force\` from \`development\` (commit \`47799cc\`) plus an \`imagetools create\` retag set.

## Follow-ups (separate PRs / tasks)

- Add \`build-server\` / \`build-embedder\` / \`build-worker\` as required status checks on the org's \`Default Branch Protection\` and \`Release Branch Protection\` rulesets — once the new check names prove green over a few PRs.
- The PR #70 rerank work is in flight on a separate branch and is not affected by this change.

## Test plan

- [x] \`cargo check --workspace\` clean
- [x] All five workflow YAMLs parse (PyYAML safe_load + job-name enumeration)
- [x] Path filter logic mirrors \`scripts/publish-pr-image.sh\`'s \`SERVER_PATHS\` / \`EMBEDDER_PATHS\` / \`WORKER_PATHS\` arrays
- [x] Commit signed (ED25519 via 1Password SSH agent)
- [ ] Watch \`build-pr.yml\` jobs run on this PR's synchronize event
- [ ] Confirm \`{version}-{slug}-{sha}\` and \`{version}-{slug}\` tags land in GHCR for all three images
- [ ] Confirm path-aware fast path triggered for non-binary changes (this PR touches only \`.github/\`, \`scripts/\`, \`DEVELOPMENT.md\` — all three images should fast-path retag from \`:dev\`)
- [ ] On merge: confirm \`promote-on-merge.yml\` retags \`:dev\` and version-tagged stream tags

## Canonical references

- BR DevOps [GitHub Actions Workflow Template (1897)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/github-actions-workflow-template)
- BR DevOps [Branching Strategy (1860)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)