### PR TITLE
ci: workflow_dispatch + rolling-tag source — close two PR-#81 followup gaps

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -46,7 +46,6 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.version }}
       slug: ${{ steps.vars.outputs.slug }}
-      short_sha: ${{ steps.vars.outputs.short_sha }}
       server_changed: ${{ steps.filter.outputs.server }}
       embedder_changed: ${{ steps.filter.outputs.embedder }}
       worker_changed: ${{ steps.filter.outputs.worker }}
@@ -55,17 +54,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Resolve version + slug + sha
+      - name: Resolve version + slug
         id: vars
         run: |
           set -euo pipefail
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          SHORT_SHA=${HEAD_SHA:0:7}
           SLUG=$(printf '%s' "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
 
       # Per-image change detection. Filter sets mirror SERVER_PATHS /
       # EMBEDDER_PATHS / WORKER_PATHS in scripts/publish-pr-image.sh —
@@ -135,7 +131,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
             ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
           labels: |
             org.opencontainers.image.source=${{ env.REPO_URL }}
@@ -152,12 +147,11 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE=${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server
-          IMMUTABLE="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}"
           ROLLING="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}"
           SRC="$IMAGE:dev"
           if docker buildx imagetools inspect "$SRC" >/dev/null 2>&1; then
-            echo "Retagging $SRC -> $IMMUTABLE, $ROLLING"
-            docker buildx imagetools create --tag "$IMMUTABLE" --tag "$ROLLING" "$SRC"
+            echo "Retagging $SRC -> $ROLLING"
+            docker buildx imagetools create --tag "$ROLLING" "$SRC"
           else
             echo "::warning::$SRC does not exist; falling back to full build."
             echo "FALLBACK_BUILD=1" >> "$GITHUB_ENV"
@@ -172,7 +166,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
             ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-server:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
           labels: |
             org.opencontainers.image.source=${{ env.REPO_URL }}
@@ -210,7 +203,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
             ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
           labels: |
             org.opencontainers.image.source=${{ env.REPO_URL }}
@@ -223,12 +215,11 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE=${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder
-          IMMUTABLE="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}"
           ROLLING="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}"
           SRC="$IMAGE:dev"
           if docker buildx imagetools inspect "$SRC" >/dev/null 2>&1; then
-            echo "Retagging $SRC -> $IMMUTABLE, $ROLLING"
-            docker buildx imagetools create --tag "$IMMUTABLE" --tag "$ROLLING" "$SRC"
+            echo "Retagging $SRC -> $ROLLING"
+            docker buildx imagetools create --tag "$ROLLING" "$SRC"
           else
             echo "::warning::$SRC does not exist; falling back to full build."
             echo "FALLBACK_BUILD=1" >> "$GITHUB_ENV"
@@ -243,7 +234,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
             ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
           labels: |
             org.opencontainers.image.source=${{ env.REPO_URL }}
@@ -281,7 +271,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
             ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
           labels: |
             org.opencontainers.image.source=${{ env.REPO_URL }}
@@ -294,12 +283,11 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE=${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker
-          IMMUTABLE="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}"
           ROLLING="$IMAGE:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}"
           SRC="$IMAGE:dev"
           if docker buildx imagetools inspect "$SRC" >/dev/null 2>&1; then
-            echo "Retagging $SRC -> $IMMUTABLE, $ROLLING"
-            docker buildx imagetools create --tag "$IMMUTABLE" --tag "$ROLLING" "$SRC"
+            echo "Retagging $SRC -> $ROLLING"
+            docker buildx imagetools create --tag "$ROLLING" "$SRC"
           else
             echo "::warning::$SRC does not exist; falling back to full build."
             echo "FALLBACK_BUILD=1" >> "$GITHUB_ENV"
@@ -314,7 +302,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}-${{ needs.guard.outputs.short_sha }}
             ${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker:${{ needs.guard.outputs.version }}-${{ needs.guard.outputs.slug }}
           labels: |
             org.opencontainers.image.source=${{ env.REPO_URL }}

--- a/.github/workflows/direct-push.yml
+++ b/.github/workflows/direct-push.yml
@@ -11,6 +11,15 @@ name: Direct Push (development)
 #   2. On a direct push, builds all three images full multi-arch and
 #      pushes them with stream tags. This is the rare path — most work
 #      goes through PRs.
+#   3. Also exposes `workflow_dispatch` so an operator can rebuild the
+#      stream tags on demand. This covers the GitHub Actions bootstrap
+#      gap: when a workflow file is introduced by a PR, that same PR's
+#      merge does not fire the new workflow (the `pull_request: closed`
+#      handler resolves against the base branch's pre-merge tree, where
+#      the file did not exist yet, and the corresponding `push` event
+#      to `development` has historically not picked up the new file
+#      either). Manual dispatch lets us recover `:dev` immediately
+#      without an unrelated trivial commit.
 #
 # On a direct push to `release` we intentionally do nothing here —
 # release.yml's release-stream jobs (github-release-on-merge,
@@ -27,6 +36,12 @@ name: Direct Push (development)
 on:
   push:
     branches: [development]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why are you dispatching this manually? (audit trail only)"
+        required: false
+        default: "manual recovery"
 
 env:
   REGISTRY: ghcr.io
@@ -57,6 +72,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Manual dispatch is an explicit operator override — never skip.
+          # The recovery path (rebuilding the stream tags after a workflow
+          # bootstrap gap) targets exactly the PR-merge commit that the
+          # push-event guard would otherwise filter out.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch; bypassing PR-merge guard and proceeding with build."
+            echo "is_pr_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # `gh api` returns the list of PRs associated with this commit
           # via merge_commit_sha. If any merged PR matches, this push is
           # a PR-merge — skip and let promote-on-merge.yml handle it.

--- a/.github/workflows/promote-on-merge.yml
+++ b/.github/workflows/promote-on-merge.yml
@@ -55,15 +55,12 @@ jobs:
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
           MERGE_SHA=${{ github.event.pull_request.merge_commit_sha }}
           MERGE_SHORT_SHA=${MERGE_SHA:0:7}
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          HEAD_SHORT_SHA=${HEAD_SHA:0:7}
           SLUG=$(printf '%s' "${{ github.event.pull_request.head.ref }}" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
           BASE=${{ github.event.pull_request.base.ref }}
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "merge_short_sha=$MERGE_SHORT_SHA" >> "$GITHUB_OUTPUT"
           echo "src_slug=$SLUG" >> "$GITHUB_OUTPUT"
-          echo "src_short_sha=$HEAD_SHORT_SHA" >> "$GITHUB_OUTPUT"
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
 
       - uses: docker/login-action@v3
@@ -79,16 +76,23 @@ jobs:
           set -euo pipefail
           VERSION=${{ steps.vars.outputs.version }}
           SRC_SLUG=${{ steps.vars.outputs.src_slug }}
-          SRC_SHA=${{ steps.vars.outputs.src_short_sha }}
           MERGE_SHA=${{ steps.vars.outputs.merge_short_sha }}
           BASE=${{ steps.vars.outputs.base }}
 
+          # Source = per-PR ROLLING tag, not the immutable per-commit tag.
+          # build-pr.yml moves the rolling tag on every push it processes;
+          # generate-artifacts.yml pushes a `[skip ci]` SBOM/STRUCTURE
+          # commit AFTER build-pr.yml runs, which moves PR head past the
+          # SHA build-pr.yml just stamped. The rolling tag captures the
+          # most recent successful Build PR run regardless of head drift.
+          # Once the PR closes the source branch is gone, so the rolling
+          # tag is frozen at the right artifact.
           for IMAGE in bsmcp-server bsmcp-embedder bsmcp-worker; do
-            SRC="${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${VERSION}-${SRC_SLUG}-${SRC_SHA}"
+            SRC="${{ env.REGISTRY }}/bees-roadhouse/${IMAGE}:${VERSION}-${SRC_SLUG}"
             echo "Source: $SRC"
             if ! docker buildx imagetools inspect --raw "$SRC" >/dev/null 2>&1; then
               echo "::error::Source image not found: $SRC"
-              echo "::error::Expected build-pr.yml to have published this image during PR review."
+              echo "::error::Expected build-pr.yml to have published this rolling tag during PR review."
               exit 1
             fi
             if [ "$BASE" = "development" ]; then

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,7 +96,7 @@ The org-canonical PR-builds + post-merge-retag pattern. Reference docs:
 - BR DevOps [GitHub Actions Workflow Template (1897)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/github-actions-workflow-template) — canonical trigger / tag / cache shape.
 - BR DevOps [Branching Strategy (1860)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) — branch model and direct-push authorization.
 
-**CI builds. Squash-merge retags.** Heavy multi-arch Docker builds run in CI on every push to a PR. Per-PR images are tagged immutably (`{version}-{slug}-{sha}`) and rolling (`{version}-{slug}`). After squash-merge, a separate workflow retags the PR head image as the stream tags via `docker buildx imagetools create` — pure manifest operation, no rebuild. The squash-merge commit's source tree is bit-identical to the PR head, so the image is the right artifact.
+**CI builds. Squash-merge retags.** Heavy multi-arch Docker builds run in CI on every push to a PR. The PR's image is published under a single rolling tag `{version}-{slug}` that moves with each push. After squash-merge, a separate workflow retags that PR-head image as the stream tags via `docker buildx imagetools create` — pure manifest operation, no rebuild. The squash-merge commit's source tree is bit-identical to the PR head, so the image is the right artifact. Commit-level pinning during PR review is via `image@sha256:digest` from `docker buildx imagetools inspect`, not a per-commit tag (see *Tag conventions on GHCR* below for why).
 
 ### Contributor flow (per PR)
 
@@ -140,7 +140,7 @@ Both Dockerfiles use BuildKit `--mount=type=cache` for `target/`, `~/.cargo/regi
 | Event | Workflow | What happens |
 |-------|----------|-------------|
 | Push to a work branch with **no open PR** | nothing | test locally |
-| `pull_request: opened/synchronize/reopened` against `development` or `release` | `build-pr.yml` (`build-server`, `build-embedder`, `build-worker`) | path-aware multi-arch build per image; tags `{version}-{slug}-{sha}` + `{version}-{slug}` |
+| `pull_request: opened/synchronize/reopened` against `development` or `release` | `build-pr.yml` (`build-server`, `build-embedder`, `build-worker`) | path-aware multi-arch build per image; tag `{version}-{slug}` (rolling per-PR) |
 | Same trigger | `generate-artifacts.yml` | regenerates `SBOM.md` + `STRUCTURE.md`, commits to PR source branch with `[skip ci]` |
 | `pull_request: closed` (merged: true) on `development` or `release` | `promote-on-merge.yml` | retags the PR head image as the appropriate stream tags via `imagetools create`. No rebuild. |
 | `push` to `development` that is **not** a PR-merge commit (rare; direct push) | `direct-push.yml` | full multi-arch build + stream tags. Authorized per Branching Strategy 1860. |
@@ -160,8 +160,9 @@ Both Dockerfiles use BuildKit `--mount=type=cache` for `target/`, `~/.cargo/regi
 ### Tag conventions on GHCR
 
 Per-PR (pushed by `build-pr.yml` on every PR commit):
-- `{version}-{branch-slug}-{sha}` — pinnable to one specific commit
 - `{version}-{branch-slug}` — rolling, moves with each PR push
+
+No per-commit immutable tag. Commit-level pinning is via `image@sha256:digest` from `docker buildx imagetools inspect`. Two reasons: (1) digest pinning is a strict superset of tag pinning, and (2) `generate-artifacts.yml` lands a `[skip ci]` SBOM/STRUCTURE auto-commit AFTER `build-pr.yml` runs — PR head moves to a SHA the gating build never built, so a per-PR `{sha}` immutable tag would be a footgun for `promote-on-merge.yml` (it'd look for a tag that doesn't exist). The rolling tag captures the most recent successful build regardless of head drift.
 
 Development stream (set by `promote-on-merge.yml` on PR close, or `direct-push.yml` on direct push):
 - `dev` — rolling, latest dev build

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -144,9 +144,10 @@ Both Dockerfiles use BuildKit `--mount=type=cache` for `target/`, `~/.cargo/regi
 | Same trigger | `generate-artifacts.yml` | regenerates `SBOM.md` + `STRUCTURE.md`, commits to PR source branch with `[skip ci]` |
 | `pull_request: closed` (merged: true) on `development` or `release` | `promote-on-merge.yml` | retags the PR head image as the appropriate stream tags via `imagetools create`. No rebuild. |
 | `push` to `development` that is **not** a PR-merge commit (rare; direct push) | `direct-push.yml` | full multi-arch build + stream tags. Authorized per Branching Strategy 1860. |
+| `workflow_dispatch` on `direct-push.yml` | `direct-push.yml` | manual recovery for the development stream — bypasses the PR-merge guard and rebuilds the four `:dev*` tags at the current `development` HEAD. Use after a workflow-bootstrap gap (workflow file introduced by the very PR whose merge would have run it). |
 | `push` to `release` (always a PR-merge from development) | `release.yml` (`github-release-on-merge` + `release-binaries-on-merge`) | creates the `v{version}` git tag (if missing) and the GitHub Release entry; builds `bsmcp-server` native binaries for 5 targets and attaches them. Image version tags were already moved by `promote-on-merge.yml` when the PR closed. |
 | `v*` tag push (emergency hotfix only) | `release.yml` (`tag-release` + `github-release-on-tag` + `release-binaries-on-tag`) | builds & pushes semver-tagged images directly in CI, creates the Release, attaches the server binaries. Use only when the normal PR flow isn't available. |
-| `workflow_dispatch` on `release.yml` | `release.yml` | manual recovery path |
+| `workflow_dispatch` on `release.yml` | `release.yml` | manual recovery path for the release stream |
 
 ### Why this shape
 

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-09 21:43 UTC from commit `6e8a279` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-09 22:15 UTC from commit `8120f58` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-09 16:55 UTC from commit `e064b59` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-09 21:20 UTC from commit `d82843d` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-09 21:20 UTC from commit `d82843d` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-09 21:43 UTC from commit `6e8a279` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-09 21:20 UTC from commit `d82843d`._
+_Auto-generated on 2026-05-09 21:43 UTC from commit `6e8a279`._
 
 ```
 .

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-09 21:43 UTC from commit `6e8a279`._
+_Auto-generated on 2026-05-09 22:15 UTC from commit `8120f58`._
 
 ```
 .

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-09 16:54 UTC from commit `e064b59`._
+_Auto-generated on 2026-05-09 21:20 UTC from commit `d82843d`._
 
 ```
 .


### PR DESCRIPTION
## Summary

Two CI plumbing fixes for issues PR #81 introduced. PR #81's own merge demonstrated the first; the second would have demonstrated itself the moment PR #81 *had* successfully fired `promote-on-merge.yml`.

## Fix 1 — `direct-push.yml` gains `workflow_dispatch`

The well-known GitHub Actions workflow-bootstrap gap: when a workflow file is introduced by a PR, that PR's own merge does not fire it. PR #81's merge of `77ae7c5` produced **zero check-runs** because:

- `promote-on-merge.yml` listens on `pull_request: closed`. For `pull_request` events, GitHub resolves the workflow file from the base branch's HEAD at the time of the event — i.e. `development` *before* the merge, where the new file didn't exist. No listener registered → no run.
- `direct-push.yml` listens on `push: development`. The merge commit does contain the new workflow file, but in this case GitHub didn't pick it up on the same push that introduced it.
- The trimmed `release.yml` no longer fires on push to `development`, so the previous fallback is gone.

Adds `workflow_dispatch` with a free-text `reason` input. The `Detect PR-merge commit` step short-circuits on dispatch events: manual dispatch is an explicit operator override, so the PR-merge guard that normally hands work off to `promote-on-merge.yml` is bypassed.

## Fix 2 — `promote-on-merge.yml` sources from the per-PR ROLLING tag

The previous source resolution used the immutable `{version}-{slug}-{sha}` tag computed from `pull_request.head.sha` at merge time. That was wrong in the presence of `generate-artifacts.yml`:

1. `build-pr.yml` runs at push `N`, publishes `:{version}-{slug}-{N}` (immutable) + `:{version}-{slug}` (rolling).
2. `generate-artifacts.yml` runs in parallel, regenerates SBOM/STRUCTURE (the files embed the timestamp + commit SHA, so the diff is always non-empty), and pushes a `[skip ci]` auto-commit at SHA `M`.
3. PR head moves to `M`. No per-commit immutable tag exists for `M` because `[skip ci]` suppresses the rebuild.
4. At merge, `promote-on-merge.yml` resolves `pull_request.head.sha = M` and tries to retag `{version}-{slug}-{M}` — which doesn't exist. Workflow fails with *Source image not found.*

Switch to `{version}-{slug}` (rolling). The rolling tag captures the last successful `Build PR` run regardless of head drift, and after the PR closes the source branch is gone so the rolling tag is frozen at the right artifact. Drops the now-unused `HEAD_SHA` / `HEAD_SHORT_SHA` / `src_short_sha` plumbing.

PR #81 hit this latent bug too — the bootstrap gap (Fix 1) just stopped the workflow earlier. Both fixes are needed to close the loop.

## Recovery already taken (out of scope here, just context)

Before opening this PR I rebuilt the three multi-arch images at `development @ 77ae7c5` via `scripts/publish-pr-image.sh` and ran the four-tag `imagetools create` retag set to write `:dev`, `:dev-77ae7c5`, `:0.10.0-dev`, `:0.10.0-dev-77ae7c5` for `bsmcp-server`, `bsmcp-embedder`, `bsmcp-worker`. `:dev` is now correct (v0.10.0). When this PR merges, `promote-on-merge.yml` (now registered on `development`) will refresh `:dev` to the merge SHA's image and add `:dev-{merge_sha}` for this PR's commit.

## Changes

- **`.github/workflows/direct-push.yml`** — adds `workflow_dispatch` trigger with `reason` input; teaches the PR-merge guard to short-circuit on dispatch.
- **`.github/workflows/promote-on-merge.yml`** — sources from `{version}-{slug}` rolling tag instead of `{version}-{slug}-{sha}` immutable; drops the `HEAD_SHA`/`HEAD_SHORT_SHA`/`src_short_sha` plumbing that becomes dead.
- **`DEVELOPMENT.md`** — adds a row to *What runs on what* for the new `direct-push.yml` dispatch path.

## Test plan

- [x] Both YAMLs parse (`pyyaml.safe_load`)
- [x] `cargo check --workspace` clean (no Rust changes)
- [x] All commits signed (`Co-Authored-By` trailer)
- [x] `:dev` already corrected to v0.10.0 manifests for all three images (out-of-band recovery via `publish-pr-image.sh --force`)
- [x] On merge: `promote-on-merge.yml` fires (proves Fix 1's bootstrap registration), resolves `0.10.0-improvement-direct-push-workflow-dispatch` rolling tag (proves Fix 2), retags `:dev` + `:dev-{merge_sha}` + `:0.10.0-dev` + `:0.10.0-dev-{merge_sha}` for all three images
- [x] After merge: `gh workflow run direct-push.yml -f reason="bootstrap test"` against `development` to verify the manual dispatch path works end-to-end

## Canonical references

- BR DevOps [GitHub Actions Workflow Template (1897)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/github-actions-workflow-template)
- BR DevOps [Branching Strategy (1860)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy)