### PR TITLE
ci: route docker build jobs to self-hosted runner

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -104,7 +104,7 @@ jobs:
   build-server:
     needs: [guard]
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, nate-wsl]
     permissions:
       contents: read
       packages: write
@@ -176,7 +176,7 @@ jobs:
   build-embedder:
     needs: [guard]
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, nate-wsl]
     permissions:
       contents: read
       packages: write
@@ -244,7 +244,7 @@ jobs:
   build-worker:
     needs: [guard]
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, nate-wsl]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/direct-push.yml
+++ b/.github/workflows/direct-push.yml
@@ -111,7 +111,7 @@ jobs:
   build:
     needs: [guard]
     if: needs.guard.outputs.is_pr_merge == 'false'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, nate-wsl]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
   # only path in this workflow that builds images.
   tag-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, nate-wsl]
     permissions:
       contents: write
       packages: write

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-10 01:57 UTC from commit `b2f0c8f` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-12 21:50 UTC from commit `fe4295b` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-10 01:57 UTC from commit `b2f0c8f`._
+_Auto-generated on 2026-05-12 21:49 UTC from commit `fe4295b`._
 
 ```
 .


### PR DESCRIPTION
## Summary

Routes heavy Docker buildx multi-arch jobs to the new self-hosted runner pool (label `nate-wsl`). Light orchestration jobs stay on GitHub-hosted.

| Workflow | Job | Before | After |
|---|---|---|---|
| build-pr.yml | guard | ubuntu-latest | (unchanged) |
| build-pr.yml | build-server | ubuntu-latest | self-hosted |
| build-pr.yml | build-embedder | ubuntu-latest | self-hosted |
| build-pr.yml | build-worker | ubuntu-latest | self-hosted |
| direct-push.yml | guard | ubuntu-latest | (unchanged) |
| direct-push.yml | build | ubuntu-latest | self-hosted |
| promote-on-merge.yml | promote | ubuntu-latest | (unchanged — manifest retag only) |
| release.yml | github-release-on-merge | ubuntu-latest | (unchanged) |
| release.yml | release-binaries-on-merge | matrix | (unchanged — native binaries on mac/win/ubuntu) |
| release.yml | tag-release | ubuntu-latest | self-hosted |
| release.yml | github-release-on-tag | ubuntu-latest | (unchanged) |
| release.yml | release-binaries-on-tag | matrix | (unchanged) |

`platforms: linux/amd64,linux/arm64` preserved everywhere — arm64 still emulated via QEMU on the runner host, but no per-job time limit.

## Why

Multi-arch Rust builds under QEMU on GitHub-hosted runners are slow enough to risk the 6h job timeout. Self-hosted runs amd64 natively (fast) and emulates arm64 (slow but completes). Light jobs stay on GH-hosted so a single-host outage doesn't break PR gating or the release binary matrix.

Canonical references in the workflow comments (BR DevOps pages 1860 and 1905) were preserved without modification — design unchanged, only the runner target.

## Test plan

- [ ] Open a no-op PR against `development` — confirm build-pr.yml's three build jobs schedule on `nate-wsl` and complete.
- [ ] Direct push to `development` (or trivial commit + revert) — confirm direct-push.yml's build matrix runs on self-hosted.
- [ ] Confirm promote-on-merge still runs on GH-hosted and the `:dev` tag advances after a PR merges.
- [ ] (When next semver release happens) confirm tag-release fires on self-hosted; github-release-on-tag + release-binaries-on-tag fire on GH-hosted.

## Notes

- Runner registered at org-level (`bees-roadhouse`), labels: `self-hosted, Linux, X64, rust, docker, nate-wsl`.
- Currently single host (Nate's workstation, WSL2 Ubuntu). If `nate-wsl` is offline, jobs targeting it queue rather than fail — keep this in mind during workstation downtime. We can add more runners with the same label to scale.

🤖 Generated with Apis (Claude Opus 4.7)