### PR TITLE
chore(release): bump workspace to v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-common"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-postgres"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-sqlite"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-embedder"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-worker"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bsmcp-common",
  "bsmcp-db-postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.11.0"
+version = "0.12.0"
 
 [profile.release]
 lto = true

--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-28 18:57 UTC from commit `bd87131` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-28 19:02 UTC from commit `ba94201` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-28 18:57 UTC from commit `bd87131`._
+_Auto-generated on 2026-05-28 19:02 UTC from commit `ba94201`._
 
 ```
 .


### PR DESCRIPTION
Bump workspace `version` to `0.12.0` ahead of the v0.11.0 → v0.12.0 release sync.

Per the [Change Lifecycle](https://kb.beesroadhouse.com/books/developer-operations-devops/page/change-lifecycle) rule "the manifest version is the next release target" — this is the version the next dev→release PR will tag.

## What's in v0.12.0 (already on development since v0.11.0)

- ci: route docker builds to self-hosted runner (#89)
- bug(ci): drop `[skip ci]` from SBOM/STRUCTURE auto-commit (#92, closes #73)
- improvement(semantic): scope shelf + chapter_move webhooks to affected books (#93, closes #76)
- improvement(mcp): trim per-tool hierarchy duplication + push precision-first in `semantic_search` (#94)
- refactor(ci): build-on-merge — drop PR-image-builds, drop retag, pin GH-hosted (#98, closes #96)

No breaking surface changes → minor bump.

## Files

- `Cargo.toml` — workspace `version` 0.11.0 → 0.12.0
- `Cargo.lock` — `cargo update -w` regen for the six workspace crates