### PR TITLE
bug(clippy): drop useless .into_iter() in stream::iter calls (semantic.rs)

### DIFF
--- a/SBOM.md
+++ b/SBOM.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials
 
-_Auto-generated on 2026-05-19 21:18 UTC from commit `e26fa3b` via `cargo metadata --locked`._
+_Auto-generated on 2026-05-28 18:57 UTC from commit `bd87131` via `cargo metadata --locked`._
 
 | Package | Version | License | Repository |
 |---------|---------|---------|------------|

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-_Auto-generated on 2026-05-19 21:18 UTC from commit `e26fa3b`._
+_Auto-generated on 2026-05-28 18:57 UTC from commit `bd87131`._
 
 ```
 .

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -674,7 +674,7 @@ impl SemanticState {
                 .filter(|pid| !blanket_cache.contains_key(pid))
                 .collect();
             if !missing.is_empty() {
-                let extras: Vec<(i64, MarkovBlanket)> = stream::iter(missing.into_iter())
+                let extras: Vec<(i64, MarkovBlanket)> = stream::iter(missing)
                     .map(|pid| async move {
                         self.db.get_markov_blanket(pid).await.ok().map(|b| (pid, b))
                     })
@@ -957,7 +957,7 @@ impl SemanticState {
         let mut blanket_cache: HashMap<i64, MarkovBlanket> = HashMap::new();
         if verbose {
             let final_pids: Vec<i64> = ranked.iter().map(|(pid, _)| *pid).collect();
-            let extras: Vec<(i64, MarkovBlanket)> = stream::iter(final_pids.into_iter())
+            let extras: Vec<(i64, MarkovBlanket)> = stream::iter(final_pids)
                 .map(|pid| async move {
                     self.db.get_markov_blanket(pid).await.ok().map(|b| (pid, b))
                 })


### PR DESCRIPTION
Two clippy::useless_conversion errors in `crates/bsmcp-server/src/semantic.rs` — both `stream::iter(x.into_iter())` where `x` is already `IntoIterator`.

- Line 677 (verbose-mode markov-blanket fetch for missing pids)
- Line 960 (verbose-mode markov-blanket fetch for final result set)

Pre-existing from #93 (heavy `semantic.rs` touch). Surfaced now because #98's new `verify-pr.yml` runs `cargo clippy --workspace --all-targets -- -D warnings` on PR pushes — first PR opened post-#98 (the v0.12.0 chore bump, #99) caught them.

Local clippy clean post-fix.

Blocks #99 (chore bump). Cut this first, then rebase #99 onto new dev HEAD.