### PR TITLE
chore(release): bump workspace to v0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-common"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-postgres"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-sqlite"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-embedder"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-server"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-worker"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "bsmcp-common",
  "bsmcp-db-postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.12.1"
+version = "0.12.2"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Workspace 0.12.1 → 0.12.2. Manifest version is the next release target per the [Change Lifecycle](https://kb.beesroadhouse.com/books/developer-operations-devops/page/change-lifecycle) rule.

## What's in v0.12.2

Docs-only release.

- #106 docs(readme): sweep missing env vars + add reranker/worker setup

No code, schema, or behavior changes. Image content for `:0.12.2` is bit-identical to `:0.12.1` except for the embedded README in the build context. Pull either; nothing forces an upgrade.