### PR TITLE
improvement(compose): track dev images + wire missing env-var interpolations

### DIFF
--- a/docker/docker-compose.sqlite.yml
+++ b/docker/docker-compose.sqlite.yml
@@ -4,7 +4,7 @@
 
 services:
   bsmcp-server:
-    image: ghcr.io/bees-roadhouse/bsmcp-server:0.7.0
+    image: ghcr.io/bees-roadhouse/bsmcp-server:dev
     volumes:
       - bsmcp-data:/data
     environment:
@@ -21,15 +21,20 @@ services:
       BSMCP_SEMANTIC_SEARCH: ${BSMCP_SEMANTIC_SEARCH:-true}
       BSMCP_EMBEDDER_URL: ${BSMCP_EMBEDDER_URL:-http://bsmcp-embedder:8081}
       BSMCP_WEBHOOK_SECRET: ${BSMCP_WEBHOOK_SECRET}
+      BSMCP_ACCESS_TOKEN_TTL: ${BSMCP_ACCESS_TOKEN_TTL:-2592000}
+      BSMCP_REFRESH_TOKEN_TTL: ${BSMCP_REFRESH_TOKEN_TTL:-7776000}
       BSMCP_BACKUP_INTERVAL: ${BSMCP_BACKUP_INTERVAL:-24}
       BSMCP_BACKUP_PATH: /data/backups
+      BSMCP_BOOKSTACK_RATE_LIMIT_PER_MIN: ${BSMCP_BOOKSTACK_RATE_LIMIT_PER_MIN:-180}
+      BSMCP_DEFAULT_TIMEZONE: ${BSMCP_DEFAULT_TIMEZONE:-}
+      BSMCP_LOG_FORMAT: ${BSMCP_LOG_FORMAT:-}
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
     ports:
       - "${BSMCP_PORT:-8080}:${BSMCP_PORT:-8080}"
 
   bsmcp-embedder:
-    image: ghcr.io/bees-roadhouse/bsmcp-embedder:0.7.0
+    image: ghcr.io/bees-roadhouse/bsmcp-embedder:dev
     cpus: ${BSMCP_EMBED_CPUS:-0}
     volumes:
       - bsmcp-data:/data
@@ -42,7 +47,11 @@ services:
       BSMCP_EMBED_TOKEN_ID: ${BSMCP_EMBED_TOKEN_ID}
       BSMCP_EMBED_TOKEN_SECRET: ${BSMCP_EMBED_TOKEN_SECRET}
       BSMCP_MODEL_PATH: /data/models
+      BSMCP_EMBED_PROVIDER: ${BSMCP_EMBED_PROVIDER:-local}
       BSMCP_EMBED_MODEL: ${BSMCP_EMBED_MODEL:-BAAI/bge-base-en-v1.5}
+      BSMCP_EMBED_API_KEY: ${BSMCP_EMBED_API_KEY:-}
+      BSMCP_EMBED_API_URL: ${BSMCP_EMBED_API_URL:-}
+      BSMCP_EMBED_DIMS: ${BSMCP_EMBED_DIMS:-}
       BSMCP_EMBED_BATCH_SIZE: ${BSMCP_EMBED_BATCH_SIZE:-32}
       BSMCP_EMBED_DELAY_MS: ${BSMCP_EMBED_DELAY_MS:-50}
       BSMCP_EMBED_ON_STARTUP: ${BSMCP_EMBED_ON_STARTUP:-false}
@@ -52,6 +61,13 @@ services:
       BSMCP_EMBED_CONSECUTIVE_ABORT: ${BSMCP_EMBED_CONSECUTIVE_ABORT:-10}
       BSMCP_EMBED_HOST: ${BSMCP_EMBED_HOST:-0.0.0.0}
       BSMCP_EMBED_PORT: ${BSMCP_EMBED_PORT:-8081}
+      # Cross-encoder reranker (powers semantic_search mode=rerank|precision).
+      # Provider: local (in-process ONNX via fastembed) | voyage | openai-compatible | none.
+      BSMCP_RERANK_PROVIDER: ${BSMCP_RERANK_PROVIDER:-none}
+      BSMCP_RERANK_MODEL: ${BSMCP_RERANK_MODEL:-}
+      BSMCP_RERANK_API_KEY: ${BSMCP_RERANK_API_KEY:-}
+      BSMCP_RERANK_API_URL: ${BSMCP_RERANK_API_URL:-}
+      BSMCP_LOG_FORMAT: ${BSMCP_LOG_FORMAT:-}
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
 
@@ -59,7 +75,7 @@ services:
   # SQLite file as the server (single writer at a time; the worker and
   # server coordinate via the queue's per-job claim row).
   bsmcp-worker:
-    image: ghcr.io/bees-roadhouse/bsmcp-worker:0.7.3
+    image: ghcr.io/bees-roadhouse/bsmcp-worker:dev
     volumes:
       - bsmcp-data:/data
     environment:
@@ -70,6 +86,12 @@ services:
       BSMCP_INDEX_TOKEN_ID: ${BSMCP_INDEX_TOKEN_ID:-${BSMCP_EMBED_TOKEN_ID:-}}
       BSMCP_INDEX_TOKEN_SECRET: ${BSMCP_INDEX_TOKEN_SECRET:-${BSMCP_EMBED_TOKEN_SECRET:-}}
       BSMCP_INDEX_DELTA_INTERVAL_SECONDS: ${BSMCP_INDEX_DELTA_INTERVAL_SECONDS:-300}
+      # Job lifecycle housekeeper (applies to both index_jobs + embed_jobs).
+      BSMCP_JOB_TIMEOUT_SECS: ${BSMCP_JOB_TIMEOUT_SECS:-3600}
+      BSMCP_JOB_RECONCILE_SECS: ${BSMCP_JOB_RECONCILE_SECS:-300}
+      BSMCP_JOB_MAX_RETRY_CHAIN: ${BSMCP_JOB_MAX_RETRY_CHAIN:-5}
+      BSMCP_JOB_CLOSE_GRACE_SECS: ${BSMCP_JOB_CLOSE_GRACE_SECS:-30}
+      BSMCP_LOG_FORMAT: ${BSMCP_LOG_FORMAT:-}
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       retries: 5
 
   bsmcp-server:
-    image: ghcr.io/bees-roadhouse/bsmcp-server:0.7.0
+    image: ghcr.io/bees-roadhouse/bsmcp-server:dev
     environment:
       BSMCP_DB_BACKEND: postgres
       BSMCP_DATABASE_URL: postgres://bsmcp:${BSMCP_DB_PASSWORD}@bsmcp-postgres/bsmcp
@@ -33,6 +33,9 @@ services:
       BSMCP_REFRESH_TOKEN_TTL: ${BSMCP_REFRESH_TOKEN_TTL:-7776000}
       BSMCP_BACKUP_INTERVAL: ${BSMCP_BACKUP_INTERVAL:-}
       BSMCP_BACKUP_PATH: ${BSMCP_BACKUP_PATH:-/data/backups}
+      BSMCP_BOOKSTACK_RATE_LIMIT_PER_MIN: ${BSMCP_BOOKSTACK_RATE_LIMIT_PER_MIN:-180}
+      BSMCP_DEFAULT_TIMEZONE: ${BSMCP_DEFAULT_TIMEZONE:-}
+      BSMCP_LOG_FORMAT: ${BSMCP_LOG_FORMAT:-}
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
     ports:
@@ -42,7 +45,7 @@ services:
         condition: service_healthy
 
   bsmcp-embedder:
-    image: ghcr.io/bees-roadhouse/bsmcp-embedder:0.7.0
+    image: ghcr.io/bees-roadhouse/bsmcp-embedder:dev
     cpus: ${BSMCP_EMBED_CPUS:-0}
     volumes:
       - bsmcp-models:/data/models
@@ -68,6 +71,13 @@ services:
       BSMCP_EMBED_CONSECUTIVE_ABORT: ${BSMCP_EMBED_CONSECUTIVE_ABORT:-10}
       BSMCP_EMBED_HOST: ${BSMCP_EMBED_HOST:-0.0.0.0}
       BSMCP_EMBED_PORT: ${BSMCP_EMBED_PORT:-8081}
+      # Cross-encoder reranker (powers semantic_search mode=rerank|precision).
+      # Provider: local (in-process ONNX via fastembed) | voyage | openai-compatible | none.
+      BSMCP_RERANK_PROVIDER: ${BSMCP_RERANK_PROVIDER:-none}
+      BSMCP_RERANK_MODEL: ${BSMCP_RERANK_MODEL:-}
+      BSMCP_RERANK_API_KEY: ${BSMCP_RERANK_API_KEY:-}
+      BSMCP_RERANK_API_URL: ${BSMCP_RERANK_API_URL:-}
+      BSMCP_LOG_FORMAT: ${BSMCP_LOG_FORMAT:-}
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
     depends_on:
@@ -78,7 +88,7 @@ services:
   # the server (both processes touch index_jobs / bookstack_pages /
   # page_cache). Runs only when an admin BookStack token is configured.
   bsmcp-worker:
-    image: ghcr.io/bees-roadhouse/bsmcp-worker:0.7.3
+    image: ghcr.io/bees-roadhouse/bsmcp-worker:dev
     environment:
       BSMCP_DB_BACKEND: postgres
       BSMCP_DATABASE_URL: postgres://bsmcp:${BSMCP_DB_PASSWORD}@bsmcp-postgres/bsmcp
@@ -89,6 +99,12 @@ services:
       BSMCP_INDEX_TOKEN_ID: ${BSMCP_INDEX_TOKEN_ID:-${BSMCP_EMBED_TOKEN_ID:-}}
       BSMCP_INDEX_TOKEN_SECRET: ${BSMCP_INDEX_TOKEN_SECRET:-${BSMCP_EMBED_TOKEN_SECRET:-}}
       BSMCP_INDEX_DELTA_INTERVAL_SECONDS: ${BSMCP_INDEX_DELTA_INTERVAL_SECONDS:-300}
+      # Job lifecycle housekeeper (applies to both index_jobs + embed_jobs).
+      BSMCP_JOB_TIMEOUT_SECS: ${BSMCP_JOB_TIMEOUT_SECS:-3600}
+      BSMCP_JOB_RECONCILE_SECS: ${BSMCP_JOB_RECONCILE_SECS:-300}
+      BSMCP_JOB_MAX_RETRY_CHAIN: ${BSMCP_JOB_MAX_RETRY_CHAIN:-5}
+      BSMCP_JOB_CLOSE_GRACE_SECS: ${BSMCP_JOB_CLOSE_GRACE_SECS:-30}
+      BSMCP_LOG_FORMAT: ${BSMCP_LOG_FORMAT:-}
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
     depends_on:


### PR DESCRIPTION
The BR deployment is silently drifting from the repo for two reasons:

1. **Image tags pinned at 0.7.0 / 0.7.3.** None of the work since then — briefing strip (v0.10.0), semantic-search modes (v0.11.0), the deterministic SBOM / aarch64 fix / fmt gate / docs sweep / `_meta.time` / directory tool / precision cascade / tracing (v0.12.x) — is actually running on instances pulling these compose files. Switch to `:dev` so the development-stream images roll forward automatically.

2. **Several env vars exist on the binary side but aren't named in the compose `environment:` blocks.** Compose only forwards what it explicitly names; Portainer / shell env settings for vars not in the block are silently dropped at deploy time. That's why `BSMCP_RERANK_*` set in Portainer wasn't reaching the embedder.

## Vars wired through

### Postgres compose

- **bsmcp-server:** added `BSMCP_BOOKSTACK_RATE_LIMIT_PER_MIN`, `BSMCP_DEFAULT_TIMEZONE` (post-#67), `BSMCP_LOG_FORMAT` (post-#90 Phase 1).
- **bsmcp-embedder:** added all four `BSMCP_RERANK_*` vars (provider/model/api_key/api_url) so rerank + precision modes are configurable, plus `BSMCP_LOG_FORMAT`.
- **bsmcp-worker:** added the four `BSMCP_JOB_*` lifecycle vars (timeout/reconcile/max_retry_chain/close_grace), plus `BSMCP_LOG_FORMAT`.

### SQLite compose

Same additions as Postgres, plus catching up the parity gap with the Postgres compose:

- **bsmcp-server:** also added `BSMCP_ACCESS_TOKEN_TTL` + `BSMCP_REFRESH_TOKEN_TTL` (already on the postgres compose).
- **bsmcp-embedder:** also added `BSMCP_EMBED_PROVIDER`, `BSMCP_EMBED_API_KEY`, `BSMCP_EMBED_API_URL`, `BSMCP_EMBED_DIMS` (already on the postgres compose) so non-`local` embedding providers are configurable from SQLite deployments too.

All wired with `\${VAR:-default}` interpolation matching the existing pattern. Defaults match the binary-side fallbacks (`BSMCP_RERANK_PROVIDER:-none`, `BSMCP_JOB_TIMEOUT_SECS:-3600`, etc.).

## Operator-visible effect

On next compose pull + restart:

1. Containers move from v0.7.x to whatever the current development tip image is (semantic_search precision/rerank modes, directory tool, `_meta.time`, deterministic SBOM, tracing, all the v0.8.0→v0.12.x work).
2. `BSMCP_RERANK_PROVIDER=local` in Portainer / shell env now actually reaches the embedder. First call after restart pulls `BAAI/bge-reranker-v2-m3` (~600 MB) into `/data/models` (volume-mounted, persists across restarts).
3. `BSMCP_LOG_FORMAT=json` now flows through if set — surfaces the structured tracing output Phase 1 built.

## Verification

- [x] Both compose files validate (yaml syntax + service block shape).
- [x] All added var names match the actual env::var keys in the binary side (audited via repo grep).
- [x] CI verify-pr + generate green (compose-only change — should be a no-op for cargo gates).