### PR TITLE
improvement(acl): five-lever fan-out reduction (closes #58)

### DIFF
--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -547,6 +547,38 @@ impl BookStackClient {
         }
     }
 
+    /// Resolve the calling user's role IDs (issue #58 lever a.5).
+    ///
+    /// BookStack has no `/api/users/me` endpoint, so we reuse the same
+    /// search-by-`{created_by:me}` probe `whoami` uses to discover the
+    /// caller's user id, then fetch `/api/users/{id}` and extract the
+    /// `roles` array. Reading your own user row works for any
+    /// authenticated user; the public API contract documents `roles` as
+    /// part of the user-read response.
+    ///
+    /// Returns `Ok(None)` when the user has no created content yet
+    /// (brand-new accounts) — the caller should treat that as
+    /// "prefilter disabled, fall back to HTTP fan-out". Returns `Err`
+    /// only when BookStack is unreachable or rejects the call.
+    pub async fn list_my_roles(&self) -> Result<Option<Vec<i64>>, String> {
+        let ident = match self.whoami().await? {
+            Some(i) => i,
+            None => return Ok(None),
+        };
+        let user = self.get_user(ident.bookstack_user_id).await?;
+        let roles = match user.get("roles").and_then(|v| v.as_array()) {
+            Some(r) => r,
+            None => return Ok(Some(Vec::new())),
+        };
+        let mut ids: Vec<i64> = Vec::with_capacity(roles.len());
+        for role in roles {
+            if let Some(id) = role.get("id").and_then(|v| v.as_i64()) {
+                ids.push(id);
+            }
+        }
+        Ok(Some(ids))
+    }
+
     // --- Shelves ---
 
     pub async fn list_shelves(&self, count: i64, offset: i64) -> Result<Value, String> {

--- a/crates/bsmcp-common/src/db.rs
+++ b/crates/bsmcp-common/src/db.rs
@@ -226,6 +226,28 @@ pub trait SemanticDb: Send + Sync + 'static {
     /// job to know which pages to refresh.
     async fn list_acl_page_ids(&self) -> Result<Vec<i64>, String>;
 
+    /// DB-side ACL prefilter (issue #58 lever a.5). Single query joins
+    /// `pages` against `page_view_acl` to bucket each requested page into
+    /// [`AclPrefilter`]. Lets the semantic-search read path drop
+    /// definitely-denied pages and admit definitely-allowed pages without
+    /// any BookStack HTTP fan-out.
+    ///
+    /// Decision tree per page row:
+    /// - `acl_computed_at IS NULL` → `Uncomputed`
+    /// - `acl_default_open = true` → `DefaultOpen` (HTTP still required for
+    ///   system-perm check, but skipped from the deny short-circuit).
+    /// - any row in `page_view_acl` with `role_id IN role_ids` → `Allow`
+    /// - else → `Deny`
+    ///
+    /// Returns one verdict per requested page that exists in the
+    /// `pages` table. Pages missing from the embedding store are omitted
+    /// (they have no ACL signal yet — fall back to HTTP).
+    async fn prefilter_pages_by_roles(
+        &self,
+        page_ids: &[i64],
+        role_ids: &[i64],
+    ) -> Result<Vec<(i64, AclPrefilter)>, String>;
+
     // --- Permission cache (per-token, per-page) ---
     //
     // Issue #58 lever (a): durable L2 below the in-memory L1 in

--- a/crates/bsmcp-common/src/db.rs
+++ b/crates/bsmcp-common/src/db.rs
@@ -225,6 +225,38 @@ pub trait SemanticDb: Send + Sync + 'static {
     /// List page IDs that have a stored ACL. Used by the daily reconciliation
     /// job to know which pages to refresh.
     async fn list_acl_page_ids(&self) -> Result<Vec<i64>, String>;
+
+    // --- Permission cache (per-token, per-page) ---
+    //
+    // Issue #58 lever (a): durable L2 below the in-memory L1 in
+    // `SemanticState`. Survives restart, so cold-start no longer means
+    // fan-out a `can_access_page` call per candidate. Keyed by
+    // `SHA256(token_id)` so a raw credential identifier never lands on disk.
+
+    /// Fetch cached permission verdicts for a list of pages. Returns
+    /// `(page_id, viewable)` only for entries that exist AND whose
+    /// `cached_at >= min_cached_at`. Missing or stale rows are omitted so
+    /// the caller can fall through to HTTP.
+    async fn get_permission_cache_batch(
+        &self,
+        token_hash: &str,
+        page_ids: &[i64],
+        min_cached_at: i64,
+    ) -> Result<Vec<(i64, bool)>, String>;
+
+    /// Upsert one or more permission cache entries for a token. Idempotent
+    /// on `(token_hash, page_id)`; refreshes both `viewable` and
+    /// `cached_at`. Batched into a single transaction.
+    async fn upsert_permission_cache_batch(
+        &self,
+        token_hash: &str,
+        entries: &[(i64, bool)],
+        cached_at: i64,
+    ) -> Result<(), String>;
+
+    /// Delete cache rows whose `cached_at < older_than`. Returns the row
+    /// count removed. Called by the periodic eviction task.
+    async fn evict_stale_permission_cache(&self, older_than: i64) -> Result<usize, String>;
 }
 
 /// v1.0.0 reconciliation index — structural mirror of every BookStack item we

--- a/crates/bsmcp-common/src/types.rs
+++ b/crates/bsmcp-common/src/types.rs
@@ -141,3 +141,29 @@ pub struct PageAcl {
     /// Unix epoch seconds the ACL was computed.
     pub computed_at: i64,
 }
+
+/// Verdict of the DB-side ACL prefilter (issue #58 lever a.5). Computed
+/// per candidate page against the calling user's role IDs by joining the
+/// `pages` table with `page_view_acl`. The prefilter sits before the HTTP
+/// fan-out in the semantic-search read path so non-default-open pages a
+/// user can't view get dropped without any BookStack round-trip.
+///
+/// Routing:
+/// - [`Allow`](Self::Allow): admit to results without HTTP. ACL was
+///   computed AND the user has a role match in `page_view_acl`.
+/// - [`Deny`](Self::Deny): drop without HTTP. ACL was computed AND no
+///   role match. The big win.
+/// - [`DefaultOpen`](Self::DefaultOpen): the all-inheriting case. Still
+///   send to HTTP because BookStack evaluates role-level system perms
+///   dynamically at the page-read endpoint (see `bsmcp_common::acl`
+///   docs lines 16-19).
+/// - [`Uncomputed`](Self::Uncomputed): ACL was never computed for this
+///   page (new page, embedder backlog). Falls through to HTTP AND
+///   triggers a background recompute.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AclPrefilter {
+    Allow,
+    Deny,
+    DefaultOpen,
+    Uncomputed,
+}

--- a/crates/bsmcp-db-postgres/src/lib.rs
+++ b/crates/bsmcp-db-postgres/src/lib.rs
@@ -1705,6 +1705,57 @@ impl SemanticDb for PostgresDb {
         Ok(rows.into_iter().map(|r| r.0).collect())
     }
 
+    async fn prefilter_pages_by_roles(
+        &self,
+        page_ids: &[i64],
+        role_ids: &[i64],
+    ) -> Result<Vec<(i64, AclPrefilter)>, String> {
+        if page_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Single roundtrip via ANY(array). Postgres planner handles a
+        // 50-row IN list as efficiently as the SQL-IN form.
+        let rows: Vec<(i64, Option<i64>, Option<bool>, bool)> = if role_ids.is_empty() {
+            sqlx::query_as(
+                "SELECT page_id, acl_computed_at, acl_default_open, FALSE AS has_role_match \
+                 FROM pages WHERE page_id = ANY($1)",
+            )
+            .bind(page_ids)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| format!("prefilter_pages_by_roles: {e}"))?
+        } else {
+            sqlx::query_as(
+                "SELECT p.page_id, p.acl_computed_at, p.acl_default_open, \
+                        EXISTS ( \
+                            SELECT 1 FROM page_view_acl pva \
+                            WHERE pva.page_id = p.page_id \
+                              AND pva.role_id = ANY($2) \
+                        ) AS has_role_match \
+                 FROM pages p WHERE p.page_id = ANY($1)",
+            )
+            .bind(page_ids)
+            .bind(role_ids)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| format!("prefilter_pages_by_roles: {e}"))?
+        };
+        let mut out: Vec<(i64, AclPrefilter)> = Vec::with_capacity(rows.len());
+        for (pid, computed_at, default_open, has_match) in rows {
+            let verdict = if computed_at.is_none() {
+                AclPrefilter::Uncomputed
+            } else if default_open.unwrap_or(false) {
+                AclPrefilter::DefaultOpen
+            } else if has_match {
+                AclPrefilter::Allow
+            } else {
+                AclPrefilter::Deny
+            };
+            out.push((pid, verdict));
+        }
+        Ok(out)
+    }
+
     async fn get_permission_cache_batch(
         &self,
         token_hash: &str,

--- a/crates/bsmcp-db-postgres/src/lib.rs
+++ b/crates/bsmcp-db-postgres/src/lib.rs
@@ -665,6 +665,31 @@ impl SemanticDb for PostgresDb {
         .await
         .map_err(|e| format!("Failed to create acl_reconcile_state: {e}"))?;
 
+        // Permission cache (issue #58 lever a): per-token, per-page viewable
+        // verdict. L2 below the in-memory L1 in `SemanticState` so cold-cache
+        // after restart skips the HTTP fan-out for known-cached tokens.
+        // `token_hash` is `SHA256(token_id)` so a raw credential identifier
+        // never lands on disk.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS permission_cache (
+                token_hash TEXT NOT NULL,
+                page_id    BIGINT NOT NULL,
+                viewable   BOOLEAN NOT NULL,
+                cached_at  BIGINT NOT NULL,
+                PRIMARY KEY (token_hash, page_id)
+            )",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| format!("Failed to create permission_cache: {e}"))?;
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_permission_cache_cached_at \
+             ON permission_cache(cached_at)",
+        )
+        .execute(&self.pool)
+        .await
+        .ok();
+
         tracing::info!(backend = "postgres", "semantic_tables_initialized");
         Ok(())
     }
@@ -1678,6 +1703,68 @@ impl SemanticDb for PostgresDb {
                 .await
                 .map_err(|e| format!("list_acl_page_ids: {e}"))?;
         Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
+    async fn get_permission_cache_batch(
+        &self,
+        token_hash: &str,
+        page_ids: &[i64],
+        min_cached_at: i64,
+    ) -> Result<Vec<(i64, bool)>, String> {
+        if page_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let rows: Vec<(i64, bool)> = sqlx::query_as(
+            "SELECT page_id, viewable FROM permission_cache \
+             WHERE token_hash = $1 AND cached_at >= $2 AND page_id = ANY($3)",
+        )
+        .bind(token_hash)
+        .bind(min_cached_at)
+        .bind(page_ids)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| format!("get_permission_cache_batch: {e}"))?;
+        Ok(rows)
+    }
+
+    async fn upsert_permission_cache_batch(
+        &self,
+        token_hash: &str,
+        entries: &[(i64, bool)],
+        cached_at: i64,
+    ) -> Result<(), String> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        // Build parallel arrays for an UNNEST-driven bulk upsert. Single
+        // roundtrip regardless of batch size; conflict-resolves to the
+        // freshest viewable + cached_at per (token_hash, page_id).
+        let page_ids: Vec<i64> = entries.iter().map(|(p, _)| *p).collect();
+        let viewables: Vec<bool> = entries.iter().map(|(_, v)| *v).collect();
+        sqlx::query(
+            "INSERT INTO permission_cache (token_hash, page_id, viewable, cached_at) \
+             SELECT $1, p, v, $2 \
+             FROM UNNEST($3::BIGINT[], $4::BOOLEAN[]) AS t(p, v) \
+             ON CONFLICT (token_hash, page_id) DO UPDATE SET \
+             viewable = EXCLUDED.viewable, cached_at = EXCLUDED.cached_at",
+        )
+        .bind(token_hash)
+        .bind(cached_at)
+        .bind(&page_ids)
+        .bind(&viewables)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| format!("upsert_permission_cache_batch: {e}"))?;
+        Ok(())
+    }
+
+    async fn evict_stale_permission_cache(&self, older_than: i64) -> Result<usize, String> {
+        let result = sqlx::query("DELETE FROM permission_cache WHERE cached_at < $1")
+            .bind(older_than)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| format!("evict_stale_permission_cache: {e}"))?;
+        Ok(result.rows_affected() as usize)
     }
 }
 

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -1919,6 +1919,99 @@ impl SemanticDb for SqliteDb {
         .map_err(|e| format!("Task failed: {e}"))?
     }
 
+    async fn prefilter_pages_by_roles(
+        &self,
+        page_ids: &[i64],
+        role_ids: &[i64],
+    ) -> Result<Vec<(i64, AclPrefilter)>, String> {
+        if page_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.conn.clone();
+        let page_ids = page_ids.to_vec();
+        let role_ids = role_ids.to_vec();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            const CHUNK: usize = 400;
+            let mut out: Vec<(i64, AclPrefilter)> = Vec::new();
+            for window in page_ids.chunks(CHUNK) {
+                // Build placeholder lists for both page_ids and role_ids.
+                // Page-id placeholders start at ?1 .. ?N. Role-id placeholders
+                // continue at ?N+1 .. ?N+M. Empty role list → the EXISTS clause
+                // evaluates false, which is the correct "no role match" state.
+                let page_ph: String = (1..=window.len())
+                    .map(|i| format!("?{i}"))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let mut all_params: Vec<&dyn rusqlite::ToSql> =
+                    Vec::with_capacity(window.len() + role_ids.len());
+                for pid in window {
+                    all_params.push(pid);
+                }
+                let sql = if role_ids.is_empty() {
+                    format!(
+                        "SELECT page_id, acl_computed_at, acl_default_open, 0 AS has_role_match \
+                         FROM pages WHERE page_id IN ({page_ph})"
+                    )
+                } else {
+                    let role_ph: String = ((window.len() + 1)..=(window.len() + role_ids.len()))
+                        .map(|i| format!("?{i}"))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    for rid in &role_ids {
+                        all_params.push(rid);
+                    }
+                    format!(
+                        "SELECT p.page_id, p.acl_computed_at, p.acl_default_open, \
+                                EXISTS ( \
+                                    SELECT 1 FROM page_view_acl pva \
+                                    WHERE pva.page_id = p.page_id \
+                                      AND pva.role_id IN ({role_ph}) \
+                                ) AS has_role_match \
+                         FROM pages p WHERE p.page_id IN ({page_ph})"
+                    )
+                };
+                let mut stmt = conn
+                    .prepare(&sql)
+                    .map_err(|e| format!("prefilter prepare: {e}"))?;
+                let rows = stmt
+                    .query_map(
+                        rusqlite::params_from_iter(all_params.iter().copied()),
+                        |row| {
+                            let page_id: i64 = row.get(0)?;
+                            let acl_computed_at: Option<i64> = row.get(1)?;
+                            let acl_default_open: Option<i64> = row.get(2)?;
+                            let has_role_match: i64 = row.get(3)?;
+                            Ok((
+                                page_id,
+                                acl_computed_at,
+                                acl_default_open.unwrap_or(0) != 0,
+                                has_role_match != 0,
+                            ))
+                        },
+                    )
+                    .map_err(|e| format!("prefilter query: {e}"))?;
+                for r in rows {
+                    let (pid, computed_at, default_open, has_match) =
+                        r.map_err(|e| format!("prefilter row: {e}"))?;
+                    let verdict = if computed_at.is_none() {
+                        AclPrefilter::Uncomputed
+                    } else if default_open {
+                        AclPrefilter::DefaultOpen
+                    } else if has_match {
+                        AclPrefilter::Allow
+                    } else {
+                        AclPrefilter::Deny
+                    };
+                    out.push((pid, verdict));
+                }
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
+
     async fn get_permission_cache_batch(
         &self,
         token_hash: &str,

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -731,6 +731,25 @@ impl SemanticDb for SqliteDb {
                  );"
             ).map_err(|e| format!("Failed to create ACL tables: {e}"))?;
 
+            // Permission cache (issue #58 lever a): per-token, per-page
+            // viewable verdict. The in-memory cache in `SemanticState` is L1;
+            // this table is L2 so cold-cache after restart still skips the
+            // HTTP fan-out for known-cached tokens. `token_hash` is
+            // `SHA256(token_id)` so a raw credential identifier never lands
+            // on disk — same hygiene as `set_by_token_hash` on
+            // `global_settings`.
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS permission_cache (
+                     token_hash TEXT NOT NULL,
+                     page_id    INTEGER NOT NULL,
+                     viewable   INTEGER NOT NULL,
+                     cached_at  INTEGER NOT NULL,
+                     PRIMARY KEY (token_hash, page_id)
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_permission_cache_cached_at
+                     ON permission_cache(cached_at);"
+            ).map_err(|e| format!("Failed to create permission_cache: {e}"))?;
+
             tracing::info!(backend = "sqlite", "semantic_tables_initialized");
             Ok(())
         })
@@ -1895,6 +1914,114 @@ impl SemanticDb for SqliteDb {
                 .filter_map(|r| r.ok())
                 .collect();
             Ok(out)
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
+
+    async fn get_permission_cache_batch(
+        &self,
+        token_hash: &str,
+        page_ids: &[i64],
+        min_cached_at: i64,
+    ) -> Result<Vec<(i64, bool)>, String> {
+        if page_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.conn.clone();
+        let token_hash = token_hash.to_string();
+        let page_ids = page_ids.to_vec();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            // SQLite max host params default 32766; chunk just in case of
+            // very large candidate sets.
+            const CHUNK: usize = 500;
+            let mut out: Vec<(i64, bool)> = Vec::new();
+            for window in page_ids.chunks(CHUNK) {
+                let placeholders: String = (0..window.len())
+                    .map(|i| format!("?{}", i + 3))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let sql = format!(
+                    "SELECT page_id, viewable FROM permission_cache \
+                     WHERE token_hash = ?1 AND cached_at >= ?2 AND page_id IN ({placeholders})"
+                );
+                let mut stmt = conn
+                    .prepare(&sql)
+                    .map_err(|e| format!("permission_cache prepare: {e}"))?;
+                let mut params: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(window.len() + 2);
+                params.push(&token_hash);
+                params.push(&min_cached_at);
+                for pid in window {
+                    params.push(pid);
+                }
+                let rows = stmt
+                    .query_map(rusqlite::params_from_iter(params.iter().copied()), |row| {
+                        Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)? != 0))
+                    })
+                    .map_err(|e| format!("permission_cache query: {e}"))?;
+                for r in rows {
+                    let row = r.map_err(|e| format!("permission_cache row: {e}"))?;
+                    out.push(row);
+                }
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
+
+    async fn upsert_permission_cache_batch(
+        &self,
+        token_hash: &str,
+        entries: &[(i64, bool)],
+        cached_at: i64,
+    ) -> Result<(), String> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let conn = self.conn.clone();
+        let token_hash = token_hash.to_string();
+        let entries = entries.to_vec();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(|e| format!("permission_cache upsert tx: {e}"))?;
+            {
+                let mut stmt = tx
+                    .prepare(
+                        "INSERT INTO permission_cache (token_hash, page_id, viewable, cached_at) \
+                         VALUES (?1, ?2, ?3, ?4) \
+                         ON CONFLICT(token_hash, page_id) DO UPDATE SET \
+                         viewable = excluded.viewable, cached_at = excluded.cached_at",
+                    )
+                    .map_err(|e| format!("permission_cache upsert prepare: {e}"))?;
+                for (pid, viewable) in &entries {
+                    let v: i64 = if *viewable { 1 } else { 0 };
+                    stmt.execute(params![token_hash, pid, v, cached_at])
+                        .map_err(|e| format!("permission_cache upsert exec: {e}"))?;
+                }
+            }
+            tx.commit()
+                .map_err(|e| format!("permission_cache upsert commit: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+    }
+
+    async fn evict_stale_permission_cache(&self, older_than: i64) -> Result<usize, String> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.lock().unwrap();
+            let count = conn
+                .execute(
+                    "DELETE FROM permission_cache WHERE cached_at < ?1",
+                    params![older_than],
+                )
+                .map_err(|e| format!("permission_cache evict: {e}"))?;
+            Ok(count)
         })
         .await
         .map_err(|e| format!("Task failed: {e}"))?

--- a/crates/bsmcp-server/src/main.rs
+++ b/crates/bsmcp-server/src/main.rs
@@ -193,6 +193,7 @@ async fn main() {
                         webhook_secret,
                     ));
                     state.clone().spawn_acl_reconcile();
+                    state.clone().spawn_permission_cache_evictor();
                     Some(state)
                 }
             }

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -18,7 +18,7 @@ const PROTOCOL_VERSION: &str = "2025-03-26";
 pub async fn handle_request(
     request: &Value,
     client: &BookStackClient,
-    semantic: Option<&SemanticState>,
+    semantic: Option<&Arc<SemanticState>>,
     index_db: &dyn IndexDb,
     staging: &crate::staging::StagingStore,
     tz: &TimezoneConfig,
@@ -110,7 +110,7 @@ async fn execute_tool(
     name: &str,
     args: &Value,
     client: &BookStackClient,
-    semantic: Option<&SemanticState>,
+    semantic: Option<&Arc<SemanticState>>,
     index_db: &dyn IndexDb,
     staging: &crate::staging::StagingStore,
 ) -> Result<String, String> {

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use futures::future::{BoxFuture, FutureExt, Shared};
 use futures::stream::{self, StreamExt};
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
@@ -182,12 +183,57 @@ pub struct SemanticState {
     /// recompute doesn't reissue the `list_roles` + per-role detail fetch on
     /// every search. 5 min TTL — roles change rarely.
     role_ctx_cache: RwLock<Option<CachedRoleContext>>,
+    /// In-flight HTTP-check coalescing map (issue #58 lever c). Keyed by
+    /// `(token_hash, page_id)`; concurrent searches asking about the same
+    /// page reuse the running future via `futures::future::Shared` instead
+    /// of issuing a duplicate `can_access_page` call.
+    acl_http_inflight: InflightCheckMap,
 }
 
 /// Cap on the in-flight set per [`SemanticState`]. When a single search
 /// produces more uncomputed pages than this, the spawner queues a global
 /// `acl_reconcile` job and bails instead of fanning out per-page tasks.
 const ACL_RECOMPUTE_INFLIGHT_CAP: usize = 200;
+
+/// Default concurrency for the HTTP fan-out fallback (issue #58 lever c).
+/// Override with `BSMCP_ACL_HTTP_CONCURRENCY`. Matches the pre-#58 value;
+/// env tunability lets ops bump or shrink on the live instance without
+/// redeploy.
+const ACL_HTTP_CONCURRENCY_DEFAULT: usize = 25;
+
+/// Default per-page-check timeout for the HTTP fallback (issue #58 lever c).
+/// Override with `BSMCP_ACL_HTTP_TIMEOUT_SECS`. Tighter than the 60s shared
+/// HTTP client timeout so one slow page can't hold the whole fan-out.
+const ACL_HTTP_TIMEOUT_DEFAULT: Duration = Duration::from_secs(5);
+
+fn acl_http_concurrency() -> usize {
+    std::env::var("BSMCP_ACL_HTTP_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|v: &usize| *v > 0)
+        .unwrap_or(ACL_HTTP_CONCURRENCY_DEFAULT)
+}
+
+fn acl_http_timeout() -> Duration {
+    std::env::var("BSMCP_ACL_HTTP_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(ACL_HTTP_TIMEOUT_DEFAULT)
+}
+
+/// In-flight HTTP-check map for request coalescing (issue #58 lever c).
+/// When two concurrent searches reach the HTTP fallback for the same
+/// `(token_hash, page_id)`, the second one joins the first's future
+/// instead of issuing a duplicate `can_access_page` call.
+///
+/// The value is a [`Shared`] future producing the access decision. The
+/// underlying work runs once via `tokio::spawn`; multiple awaiters get
+/// clones of the shared handle. The spawner cleans up its own slot on
+/// completion via the cleanup closure inside [`coalesced_can_access_page`].
+type InflightCheckMap =
+    tokio::sync::Mutex<HashMap<(String, i64), Shared<BoxFuture<'static, bool>>>>;
 /// Max concurrent `reconcile_page` HTTP calls per kick. Each call is ~3
 /// `get_content_permissions` requests; 5 keeps the background load below
 /// foreground search budget.
@@ -231,7 +277,69 @@ impl SemanticState {
             role_id_cache: RwLock::new(HashMap::new()),
             acl_recompute_inflight: RwLock::new(HashSet::new()),
             role_ctx_cache: RwLock::new(None),
+            acl_http_inflight: tokio::sync::Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Coalesced + timeout-capped HTTP page-access check (issue #58 lever c).
+    ///
+    /// If another concurrent caller is already running `can_access_page`
+    /// for `(token_hash, page_id)`, joins that running future via
+    /// [`Shared`] instead of firing a duplicate request. The first caller
+    /// inserts a fresh shared future, runs it, removes the slot when done,
+    /// and returns the result.
+    ///
+    /// Wrapped in `tokio::time::timeout` with the per-page timeout from
+    /// [`acl_http_timeout`]. A timeout is treated as a deny — same as the
+    /// pre-#58 behavior when BookStack returned a non-success response —
+    /// plus a structured warning log so the bake numbers stay observable.
+    pub(crate) async fn coalesced_can_access_page(
+        self: &Arc<Self>,
+        token_hash: &str,
+        page_id: i64,
+        client: BookStackClient,
+    ) -> bool {
+        let key = (token_hash.to_string(), page_id);
+        let (fut, is_owner) = {
+            let mut map = self.acl_http_inflight.lock().await;
+            if let Some(existing) = map.get(&key) {
+                (existing.clone(), false)
+            } else {
+                let timeout = acl_http_timeout();
+                let client_for_fut = client;
+                let work = async move {
+                    match tokio::time::timeout(timeout, client_for_fut.can_access_page(page_id))
+                        .await
+                    {
+                        Ok(ok) => ok,
+                        Err(_) => {
+                            tracing::warn!(
+                                target: "acl_filter",
+                                page_id,
+                                timeout_ms = timeout.as_millis() as u64,
+                                "acl_http_check_timeout"
+                            );
+                            false
+                        }
+                    }
+                };
+                let fut: Shared<BoxFuture<'static, bool>> = work.boxed().shared();
+                map.insert(key.clone(), fut.clone());
+                (fut, true)
+            }
+        };
+
+        let result = fut.await;
+
+        if is_owner {
+            // Best-effort cleanup. If a concurrent caller saw the same slot
+            // and entered the joiner branch, they cloned the shared future
+            // before we removed it — both paths still return the same value.
+            let mut map = self.acl_http_inflight.lock().await;
+            map.remove(&key);
+        }
+
+        result
     }
 
     /// Fire-and-forget background recompute for pages the prefilter
@@ -717,17 +825,15 @@ impl SemanticState {
         let mut prefilter_uncomputed: usize = 0;
         let mut recompute_candidates: Vec<i64> = Vec::new();
         if !uncached_ids.is_empty() {
-            if let Some(role_ids) = self
-                .resolve_caller_role_ids(client, &token_hash)
-                .await
-            {
+            if let Some(role_ids) = self.resolve_caller_role_ids(client, &token_hash).await {
                 match self
                     .db
                     .prefilter_pages_by_roles(&uncached_ids, &role_ids)
                     .await
                 {
                     Ok(verdicts) => {
-                        let verdict_map: HashMap<i64, AclPrefilter> = verdicts.into_iter().collect();
+                        let verdict_map: HashMap<i64, AclPrefilter> =
+                            verdicts.into_iter().collect();
                         let mut still_pending: Vec<i64> = Vec::with_capacity(uncached_ids.len());
                         // Note: pages missing from `pages` (not embedded) have
                         // no verdict at all; default to Uncomputed (HTTP).
@@ -788,29 +894,30 @@ impl SemanticState {
         let mut http_fallback_ms: u128 = 0;
 
         if !uncached_ids.is_empty() {
-            // Check each page individually with concurrency limit. Bumped from
-            // 10 → 25 because the cold-cache permission filter is the dominant
-            // cost in semantic search; BookStack handles the burst comfortably.
+            // Coalesced + bounded HTTP fan-out (issue #58 lever c).
+            // `buffer_unordered` replaces the pre-#58 manual spawn + JoinHandle
+            // vec + Semaphore; same effect, env-tunable, cleaner shutdown.
+            // `coalesced_can_access_page` shares an in-flight future across
+            // concurrent searches asking about the same page id, and wraps the
+            // call in a 5s timeout so one slow page can't hold the whole pool.
             let http_start = Instant::now();
-            let semaphore = Arc::new(tokio::sync::Semaphore::new(25));
-            let mut handles = Vec::new();
-
-            for pid in uncached_ids.clone() {
-                let client = client.clone();
-                let sem = semaphore.clone();
-                handles.push(tokio::spawn(async move {
-                    let _permit = sem.acquire().await;
-                    let ok = client.can_access_page(pid).await;
-                    (pid, ok)
-                }));
-            }
-
-            let mut results: Vec<(i64, bool)> = Vec::new();
-            for handle in handles {
-                if let Ok(result) = handle.await {
-                    results.push(result);
-                }
-            }
+            let concurrency = acl_http_concurrency();
+            let me = self.clone();
+            let token_hash_clone = token_hash.clone();
+            let client = client.clone();
+            let results: Vec<(i64, bool)> = stream::iter(uncached_ids.clone())
+                .map(|pid| {
+                    let me = me.clone();
+                    let token_hash = token_hash_clone.clone();
+                    let client = client.clone();
+                    async move {
+                        let ok = me.coalesced_can_access_page(&token_hash, pid, client).await;
+                        (pid, ok)
+                    }
+                })
+                .buffer_unordered(concurrency)
+                .collect()
+                .await;
             http_fallback_fired = results.len();
             http_fallback_ms = http_start.elapsed().as_millis();
 
@@ -2762,9 +2869,7 @@ mod acl_fanout_tests {
         ));
         let client = BookStackClient::new(&base, "tid", "tsecret", reqwest::Client::new());
 
-        let accessible = state
-            .filter_by_permission(&[1, 2, 3, 4, 5], &client)
-            .await;
+        let accessible = state.filter_by_permission(&[1, 2, 3, 4, 5], &client).await;
         let mut sorted = accessible;
         sorted.sort();
         // Page 1+2 allowed via prefilter, page 3 denied via prefilter,
@@ -2898,6 +3003,115 @@ mod acl_fanout_tests {
         let _ = before; // silence dead-code lint on unused total_pages
     }
 
+    /// Lever c — request coalescing. Two concurrent searches asking
+    /// about the same `(token_hash, page_id)` must share the in-flight
+    /// `can_access_page` call instead of duplicating it. Verified by
+    /// driving the coalesced helper with a slow mock that holds each
+    /// response for ~50ms, then asserting the mock saw fewer HTTP hits
+    /// than the number of awaiters.
+    #[tokio::test]
+    async fn coalesced_can_access_page_dedups_concurrent_callers() {
+        use axum::extract::Path;
+        use axum::response::IntoResponse;
+        use axum::routing::get;
+        use axum::Router;
+
+        let counter: StdArc<AtomicUsize> = StdArc::new(AtomicUsize::new(0));
+        let ctr = counter.clone();
+        let app = Router::new().route(
+            "/api/pages/{id}",
+            get(move |Path(_id): Path<i64>| {
+                let ctr = ctr.clone();
+                async move {
+                    ctr.fetch_add(1, Ordering::SeqCst);
+                    // Hold long enough that concurrent callers overlap. The
+                    // coalescing path keeps the second + third caller off the
+                    // wire entirely.
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    (
+                        axum::http::StatusCode::OK,
+                        axum::Json(serde_json::json!({"id": 1})),
+                    )
+                        .into_response()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        let base = format!("http://{addr}");
+
+        let state = make_state("coalesce", "http://unused".to_string()).await;
+        let client = BookStackClient::new(&base, "tid", "tsecret", reqwest::Client::new());
+
+        let s1 = state.clone();
+        let c1 = client.clone();
+        let s2 = state.clone();
+        let c2 = client.clone();
+        let s3 = state.clone();
+        let c3 = client.clone();
+
+        let token_hash = hash_token_id(client.token_id());
+        let token_hash_1 = token_hash.clone();
+        let token_hash_2 = token_hash.clone();
+        let token_hash_3 = token_hash.clone();
+
+        let (r1, r2, r3) = tokio::join!(
+            tokio::spawn(async move { s1.coalesced_can_access_page(&token_hash_1, 1, c1).await }),
+            tokio::spawn(async move { s2.coalesced_can_access_page(&token_hash_2, 1, c2).await }),
+            tokio::spawn(async move { s3.coalesced_can_access_page(&token_hash_3, 1, c3).await }),
+        );
+        assert!(r1.unwrap());
+        assert!(r2.unwrap());
+        assert!(r3.unwrap());
+        // Coalescing should cap HTTP calls below the 3-caller count. In
+        // practice the second + third are guaranteed to find the shared
+        // future under the mutex, so the mock sees exactly 1.
+        let observed = counter.load(Ordering::SeqCst);
+        assert!(
+            observed < 3,
+            "coalescing should suppress duplicate HTTP — saw {observed} hits for 3 concurrent callers"
+        );
+    }
+
+    /// Lever c — per-page timeout returns deny without holding the fan-out.
+    /// Verified by pointing the client at a server that never responds and
+    /// asserting the call finishes within the timeout budget with a deny.
+    #[tokio::test]
+    async fn coalesced_can_access_page_times_out_to_deny() {
+        // Bind a listener and never accept — connect attempts succeed but
+        // the response never arrives. With the 5s default that's still too
+        // slow for a unit test; lower it via env override for this call.
+        std::env::set_var("BSMCP_ACL_HTTP_TIMEOUT_SECS", "1");
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        // Accept but never respond — keeps the connection open forever.
+        tokio::spawn(async move {
+            loop {
+                let _ = listener.accept().await;
+            }
+        });
+        let base = format!("http://{addr}");
+        let state = make_state("timeout", "http://unused".to_string()).await;
+        let client = BookStackClient::new(&base, "tid", "tsecret", reqwest::Client::new());
+        let token_hash = hash_token_id(client.token_id());
+
+        let started = Instant::now();
+        let ok = state
+            .coalesced_can_access_page(&token_hash, 1, client)
+            .await;
+        let elapsed = started.elapsed();
+        std::env::remove_var("BSMCP_ACL_HTTP_TIMEOUT_SECS");
+        assert!(!ok, "timeout should deny");
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "timeout should bound elapsed time; saw {elapsed:?}"
+        );
+    }
+
     /// Lever a — durable L2 cache. Verifies that warm-cache after restart
     /// (simulated by constructing a fresh `SemanticState` on the same
     /// sqlite path) skips the HTTP fan-out entirely.
@@ -2924,9 +3138,7 @@ mod acl_fanout_tests {
                 "test-webhook-secret-16chars".to_string(),
             ));
             let client = BookStackClient::new(&base, "tid", "tsecret", reqwest::Client::new());
-            let r = state
-                .filter_by_permission(&[10i64, 11, 12], &client)
-                .await;
+            let r = state.filter_by_permission(&[10i64, 11, 12], &client).await;
             let mut sorted = r;
             sorted.sort();
             assert_eq!(sorted, vec![10, 11]);
@@ -2952,9 +3164,7 @@ mod acl_fanout_tests {
                 "test-webhook-secret-16chars".to_string(),
             ));
             let client = BookStackClient::new(&base, "tid", "tsecret", reqwest::Client::new());
-            let r = state
-                .filter_by_permission(&[10i64, 11, 12], &client)
-                .await;
+            let r = state.filter_by_permission(&[10i64, 11, 12], &client).await;
             let mut sorted = r;
             sorted.sort();
             assert_eq!(sorted, vec![10, 11]);

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -13,7 +13,7 @@ use tokio::sync::RwLock;
 use bsmcp_common::bookstack::BookStackClient;
 use bsmcp_common::db::{DbBackend, IndexDb, SemanticDb};
 use bsmcp_common::settings::{hash_token_id, CascadeMultipliers, GlobalSettings};
-use bsmcp_common::types::{MarkovBlanket, ScopeFilter};
+use bsmcp_common::types::{AclPrefilter, MarkovBlanket, ScopeFilter};
 
 const PERMISSION_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
 
@@ -169,7 +169,20 @@ pub struct SemanticState {
     /// raw `token_id` is held only by the live `BookStackClient`; it never
     /// lands in our cache map.
     permission_cache: RwLock<HashMap<(String, i64), CachedAccess>>,
+    /// Per-token cached role-id list (issue #58 lever a.5). The DB prefilter
+    /// needs the calling user's role IDs; resolving them is two HTTP calls
+    /// to BookStack. 5 minute TTL because roles change rarely.
+    role_id_cache: RwLock<HashMap<String, CachedRoleIds>>,
 }
+
+/// Per-token cached role-id list with a TTL. Held inside
+/// [`SemanticState::role_id_cache`].
+struct CachedRoleIds {
+    role_ids: Vec<i64>,
+    cached_at: Instant,
+}
+
+const ROLE_ID_CACHE_TTL: Duration = Duration::from_secs(300);
 
 impl SemanticState {
     pub fn new(
@@ -192,6 +205,48 @@ impl SemanticState {
             webhook_secret,
             http_client,
             permission_cache: RwLock::new(HashMap::new()),
+            role_id_cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Resolve the calling user's role IDs, caching per `token_hash` with
+    /// [`ROLE_ID_CACHE_TTL`]. Returns `None` when `list_my_roles` declines
+    /// to identify the user (brand-new account with no content), in which
+    /// case the prefilter is bypassed — every page falls through to HTTP.
+    async fn resolve_caller_role_ids(
+        &self,
+        client: &BookStackClient,
+        token_hash: &str,
+    ) -> Option<Vec<i64>> {
+        {
+            let read = self.role_id_cache.read().await;
+            if let Some(entry) = read.get(token_hash) {
+                if entry.cached_at.elapsed() < ROLE_ID_CACHE_TTL {
+                    return Some(entry.role_ids.clone());
+                }
+            }
+        }
+        match client.list_my_roles().await {
+            Ok(Some(role_ids)) => {
+                let mut write = self.role_id_cache.write().await;
+                write.insert(
+                    token_hash.to_string(),
+                    CachedRoleIds {
+                        role_ids: role_ids.clone(),
+                        cached_at: Instant::now(),
+                    },
+                );
+                Some(role_ids)
+            }
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!(
+                    target: "acl_filter",
+                    error = %e,
+                    "list_my_roles_failed"
+                );
+                None
+            }
         }
     }
 
@@ -372,12 +427,17 @@ impl SemanticState {
     /// accessible pages, 403/404 for restricted. This correctly handles custom
     /// entity permissions (unlike filter[id:in] on the list endpoint).
     ///
-    /// Three-tier cache (issue #58 lever a):
+    /// Four-tier filter (issue #58 levers a + a.5):
     ///   1. L1 — in-memory `HashMap<(token_hash, page_id), CachedAccess>`,
     ///      5 minute TTL. Same as before; rekeyed to `token_hash`.
     ///   2. L2 — durable `permission_cache` table, default 1h TTL
     ///      (`BSMCP_PERMISSION_CACHE_TTL_SECS`). Survives restart.
-    ///   3. HTTP fallback — `can_access_page` per remaining page.
+    ///   3. DB-side prefilter — joins `pages` against `page_view_acl` to
+    ///      drop denied pages and admit role-matched pages without HTTP.
+    ///      Big win on cold caches with heterogeneous role-restricted books.
+    ///   4. HTTP fallback — `can_access_page` per remaining page (uncomputed
+    ///      pages + default-open pages that still need the system-perm
+    ///      check). Uncomputed pages also trigger a background recompute.
     ///
     /// Per-call structured counters (issue #58 lever 0): cache_hits,
     /// cache_misses, http_fallback fan-out and wall-clock. Emitted as a
@@ -455,6 +515,62 @@ impl SemanticState {
                         error = %e,
                         "permission_cache_l2_lookup_failed"
                     );
+                }
+            }
+        }
+
+        // DB-side ACL prefilter (issue #58 lever a.5). Cuts the pool before
+        // HTTP fan-out. Each remaining candidate gets bucketed into
+        // {Allow, Deny, DefaultOpen, Uncomputed}; Allow → accessible, Deny
+        // → dropped, DefaultOpen + Uncomputed → HTTP fallback.
+        let mut prefilter_allow: usize = 0;
+        let mut prefilter_deny: usize = 0;
+        let mut prefilter_default_open: usize = 0;
+        let mut prefilter_uncomputed: usize = 0;
+        if !uncached_ids.is_empty() {
+            if let Some(role_ids) = self
+                .resolve_caller_role_ids(client, &token_hash)
+                .await
+            {
+                match self
+                    .db
+                    .prefilter_pages_by_roles(&uncached_ids, &role_ids)
+                    .await
+                {
+                    Ok(verdicts) => {
+                        let verdict_map: HashMap<i64, AclPrefilter> = verdicts.into_iter().collect();
+                        let mut still_pending: Vec<i64> = Vec::with_capacity(uncached_ids.len());
+                        // Note: pages missing from `pages` (not embedded) have
+                        // no verdict at all; default to Uncomputed (HTTP).
+                        for pid in uncached_ids.drain(..) {
+                            match verdict_map.get(&pid).copied() {
+                                Some(AclPrefilter::Allow) => {
+                                    prefilter_allow += 1;
+                                    accessible.push(pid);
+                                }
+                                Some(AclPrefilter::Deny) => {
+                                    prefilter_deny += 1;
+                                    // Dropped silently. No HTTP, no result.
+                                }
+                                Some(AclPrefilter::DefaultOpen) => {
+                                    prefilter_default_open += 1;
+                                    still_pending.push(pid);
+                                }
+                                Some(AclPrefilter::Uncomputed) | None => {
+                                    prefilter_uncomputed += 1;
+                                    still_pending.push(pid);
+                                }
+                            }
+                        }
+                        uncached_ids = still_pending;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "acl_filter",
+                            error = %e,
+                            "acl_prefilter_failed"
+                        );
+                    }
                 }
             }
         }
@@ -539,6 +655,10 @@ impl SemanticState {
             cache_misses = cache_misses,
             l1_hits = l1_hits,
             l2_hits = l2_hits,
+            prefilter_allow = prefilter_allow,
+            prefilter_deny = prefilter_deny,
+            prefilter_default_open = prefilter_default_open,
+            prefilter_uncomputed = prefilter_uncomputed,
             http_fallback = http_fallback_fired,
             http_fallback_ms = http_fallback_ms as u64,
             elapsed_ms = call_start.elapsed().as_millis() as u64,
@@ -2117,45 +2237,131 @@ mod acl_fanout_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc as StdArc;
 
-    /// Spin a tiny mock BookStack server that:
-    ///   - GET /api/pages/{id}: 200 if `id` is in `allowed`, else 404.
-    ///   - GET /api/users/{id}: returns the configured user JSON.
-    /// Returns the base URL and a shared counter of `can_access_page` hits so
-    /// tests can assert on fan-out.
-    pub(crate) async fn mock_bookstack(allowed: Vec<i64>) -> (String, StdArc<AtomicUsize>) {
+    /// Knobs for the mock BookStack server. Keeps tests focused — each one
+    /// only sets the bits it cares about; the rest use sensible defaults.
+    #[derive(Clone, Default)]
+    pub(crate) struct MockBookStack {
+        /// Page IDs that `GET /api/pages/{id}` returns 200 for. Everything
+        /// else returns 404.
+        pub allowed_pages: Vec<i64>,
+        /// User ID the search probe returns as the calling user. None
+        /// makes the search probe return zero results, which the production
+        /// `whoami`/`list_my_roles` flow surfaces as "no identity yet".
+        pub caller_user_id: Option<i64>,
+        /// Roles attached to the caller user record. Only consulted when
+        /// `caller_user_id` is `Some`.
+        pub caller_roles: Vec<i64>,
+    }
+
+    /// Tracks how many times each endpoint was hit. Tests assert on this to
+    /// detect fan-out reduction.
+    pub(crate) struct MockCounters {
+        pub pages: StdArc<AtomicUsize>,
+        pub search: StdArc<AtomicUsize>,
+        pub users: StdArc<AtomicUsize>,
+    }
+
+    impl MockCounters {
+        fn new() -> Self {
+            Self {
+                pages: StdArc::new(AtomicUsize::new(0)),
+                search: StdArc::new(AtomicUsize::new(0)),
+                users: StdArc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    /// Spin a tiny mock BookStack server that handles enough of the API
+    /// surface for `filter_by_permission` + `list_my_roles` to roundtrip.
+    /// Returns the base URL and the per-endpoint counters.
+    pub(crate) async fn mock_bookstack_full(cfg: MockBookStack) -> (String, MockCounters) {
         use axum::extract::Path;
         use axum::http::StatusCode;
+        use axum::response::IntoResponse;
         use axum::routing::get;
         use axum::Router;
-        let allowed: StdArc<Vec<i64>> = StdArc::new(allowed);
-        let counter: StdArc<AtomicUsize> = StdArc::new(AtomicUsize::new(0));
-        let counter_clone = counter.clone();
-        let app = Router::new().route(
-            "/api/pages/{id}",
-            get(move |Path(id): Path<i64>| {
-                let allowed = allowed.clone();
-                let counter = counter_clone.clone();
-                async move {
-                    counter.fetch_add(1, Ordering::SeqCst);
-                    if allowed.contains(&id) {
-                        (StatusCode::OK, axum::Json(serde_json::json!({"id": id}))).into_response()
-                    } else {
-                        (
-                            StatusCode::NOT_FOUND,
-                            axum::Json(serde_json::json!({"error": "not found"})),
-                        )
-                            .into_response()
+        let counters = MockCounters::new();
+        let allowed: StdArc<Vec<i64>> = StdArc::new(cfg.allowed_pages.clone());
+        let caller_user_id = cfg.caller_user_id;
+        let caller_roles: StdArc<Vec<i64>> = StdArc::new(cfg.caller_roles.clone());
+        let pages_ctr = counters.pages.clone();
+        let search_ctr = counters.search.clone();
+        let users_ctr = counters.users.clone();
+        let app = Router::new()
+            .route(
+                "/api/pages/{id}",
+                get(move |Path(id): Path<i64>| {
+                    let allowed = allowed.clone();
+                    let ctr = pages_ctr.clone();
+                    async move {
+                        ctr.fetch_add(1, Ordering::SeqCst);
+                        if allowed.contains(&id) {
+                            (StatusCode::OK, axum::Json(serde_json::json!({"id": id})))
+                                .into_response()
+                        } else {
+                            (
+                                StatusCode::NOT_FOUND,
+                                axum::Json(serde_json::json!({"error": "not found"})),
+                            )
+                                .into_response()
+                        }
                     }
-                }
-            }),
-        );
-        use axum::response::IntoResponse;
+                }),
+            )
+            .route(
+                "/api/search",
+                get(move || {
+                    let ctr = search_ctr.clone();
+                    async move {
+                        ctr.fetch_add(1, Ordering::SeqCst);
+                        let data = match caller_user_id {
+                            Some(uid) => serde_json::json!([
+                                { "type": "page", "id": 1, "created_by": { "id": uid } }
+                            ]),
+                            None => serde_json::json!([]),
+                        };
+                        axum::Json(serde_json::json!({"data": data, "total": 1}))
+                    }
+                }),
+            )
+            .route(
+                "/api/users/{id}",
+                get(move |Path(id): Path<i64>| {
+                    let ctr = users_ctr.clone();
+                    let roles = caller_roles.clone();
+                    async move {
+                        ctr.fetch_add(1, Ordering::SeqCst);
+                        let role_objs: Vec<serde_json::Value> = roles
+                            .iter()
+                            .map(|r| serde_json::json!({"id": r, "display_name": format!("Role{r}")}))
+                            .collect();
+                        axum::Json(serde_json::json!({
+                            "id": id,
+                            "name": "Test User",
+                            "email": "test@example.com",
+                            "roles": role_objs,
+                        }))
+                    }
+                }),
+            );
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr: SocketAddr = listener.local_addr().unwrap();
         tokio::spawn(async move {
             axum::serve(listener, app).await.ok();
         });
-        (format!("http://{addr}"), counter)
+        (format!("http://{addr}"), counters)
+    }
+
+    /// Back-compat shim for the lever 0 tests. Default mock: pages-only,
+    /// no caller identity. Returns the URL + the page-hit counter.
+    pub(crate) async fn mock_bookstack(allowed: Vec<i64>) -> (String, StdArc<AtomicUsize>) {
+        let (url, counters) = mock_bookstack_full(MockBookStack {
+            allowed_pages: allowed,
+            caller_user_id: None,
+            caller_roles: Vec::new(),
+        })
+        .await;
+        (url, counters.pages)
     }
 
     pub(crate) fn temp_sqlite_path(label: &str) -> PathBuf {
@@ -2220,6 +2426,146 @@ mod acl_fanout_tests {
         assert_eq!(
             after_second, after_first,
             "cache hit should suppress further HTTP fan-out"
+        );
+    }
+
+    /// Helper: seed a sqlite db with pages + ACL rows so we can exercise
+    /// `prefilter_pages_by_roles` directly.
+    pub(crate) async fn seed_pages_with_acl(
+        sqlite: &Arc<SqliteDb>,
+        rows: &[(i64, bool, Vec<i64>)],
+    ) {
+        use bsmcp_common::types::{PageAcl, PageMeta};
+        for (pid, default_open, roles) in rows {
+            let meta = PageMeta {
+                page_id: *pid,
+                book_id: 100,
+                chapter_id: None,
+                name: format!("page-{pid}"),
+                slug: format!("page-{pid}"),
+                content_hash: "h".to_string(),
+                updated_at: None,
+            };
+            sqlite.upsert_page(&meta).await.unwrap();
+            let acl = PageAcl {
+                page_id: *pid,
+                view_roles: roles.clone(),
+                default_open: *default_open,
+                computed_at: 1,
+            };
+            sqlite.upsert_page_acl(&acl).await.unwrap();
+        }
+    }
+
+    /// Lever a.5 — DB-side prefilter buckets every candidate into
+    /// Allow/Deny/DefaultOpen/Uncomputed. Verified directly against the
+    /// sqlite impl so we know the SQL shape is correct before the higher-
+    /// level integration test exercises the search path.
+    #[tokio::test]
+    async fn prefilter_pages_by_roles_routes_correctly() {
+        let path = temp_sqlite_path("prefilter-routes");
+        let sqlite = Arc::new(SqliteDb::open(
+            &path,
+            "test-encryption-key-thirty-two-chars-long",
+        ));
+        sqlite.init_semantic_tables().await.unwrap();
+        // Page 1: role-restricted to [10], default_open=false → Allow for caller_roles=[10]
+        // Page 2: role-restricted to [20], default_open=false → Deny for caller_roles=[10]
+        // Page 3: default_open=true → DefaultOpen
+        // Page 4: never embedded (no `pages` row) → not in the returned list
+        // Page 5: embedded but acl_computed_at IS NULL → Uncomputed
+        seed_pages_with_acl(
+            &sqlite,
+            &[
+                (1, false, vec![10]),
+                (2, false, vec![20]),
+                (3, true, vec![]),
+            ],
+        )
+        .await;
+        // Page 5 without ACL computed: insert page row but skip upsert_page_acl.
+        let meta = bsmcp_common::types::PageMeta {
+            page_id: 5,
+            book_id: 100,
+            chapter_id: None,
+            name: "page-5".to_string(),
+            slug: "page-5".to_string(),
+            content_hash: "h".to_string(),
+            updated_at: None,
+        };
+        sqlite.upsert_page(&meta).await.unwrap();
+
+        let verdicts = sqlite
+            .prefilter_pages_by_roles(&[1, 2, 3, 4, 5], &[10])
+            .await
+            .unwrap();
+        let by_pid: HashMap<i64, AclPrefilter> = verdicts.into_iter().collect();
+        assert_eq!(by_pid.get(&1), Some(&AclPrefilter::Allow));
+        assert_eq!(by_pid.get(&2), Some(&AclPrefilter::Deny));
+        assert_eq!(by_pid.get(&3), Some(&AclPrefilter::DefaultOpen));
+        assert!(!by_pid.contains_key(&4), "page 4 isn't in the embed store");
+        assert_eq!(by_pid.get(&5), Some(&AclPrefilter::Uncomputed));
+    }
+
+    /// Lever a.5 — end-to-end: a search-shaped call to `filter_by_permission`
+    /// with the prefilter populated should skip the HTTP fallback for both
+    /// Allow and Deny verdicts. Only DefaultOpen + Uncomputed reach BookStack.
+    #[tokio::test]
+    async fn filter_by_permission_uses_prefilter_to_skip_http() {
+        // Pages 1+2: Allow (role 10 matches). Page 3: Deny. Pages 4+5: DefaultOpen.
+        // The mock will count GET /api/pages/{id} hits — we expect exactly 2
+        // (the two default-open pages still need HTTP), not 5.
+        let path = temp_sqlite_path("prefilter-e2e");
+        let sqlite = Arc::new(SqliteDb::open(
+            &path,
+            "test-encryption-key-thirty-two-chars-long",
+        ));
+        sqlite.init_semantic_tables().await.unwrap();
+        seed_pages_with_acl(
+            &sqlite,
+            &[
+                (1, false, vec![10]),
+                (2, false, vec![10]),
+                (3, false, vec![999]),
+                (4, true, vec![]),
+                (5, true, vec![]),
+            ],
+        )
+        .await;
+
+        // Allow pages 4+5 only — page 3 would 404 if it ever hit, which is fine
+        // (deny in both pathways), and the test cares about the *count* of HTTP
+        // calls, not the verdicts on default-open.
+        let (base, counters) = mock_bookstack_full(MockBookStack {
+            allowed_pages: vec![4, 5],
+            caller_user_id: Some(42),
+            caller_roles: vec![10],
+        })
+        .await;
+        let core_db: Arc<dyn DbBackend> = sqlite.clone();
+        let semantic_db: Arc<dyn SemanticDb> = sqlite.clone();
+        let index_db: Arc<dyn IndexDb> = sqlite.clone();
+        let state = Arc::new(SemanticState::new(
+            semantic_db,
+            core_db,
+            index_db,
+            "http://unused".to_string(),
+            "test-webhook-secret-16chars".to_string(),
+        ));
+        let client = BookStackClient::new(&base, "tid", "tsecret", reqwest::Client::new());
+
+        let accessible = state
+            .filter_by_permission(&[1, 2, 3, 4, 5], &client)
+            .await;
+        let mut sorted = accessible;
+        sorted.sort();
+        // Page 1+2 allowed via prefilter, page 3 denied via prefilter,
+        // pages 4+5 admitted via HTTP fallback (default-open + mock allows).
+        assert_eq!(sorted, vec![1, 2, 4, 5]);
+        assert_eq!(
+            counters.pages.load(Ordering::SeqCst),
+            2,
+            "prefilter should suppress HTTP for Allow + Deny verdicts; only 2 default-open pages hit HTTP"
         );
     }
 

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -173,6 +173,29 @@ pub struct SemanticState {
     /// needs the calling user's role IDs; resolving them is two HTTP calls
     /// to BookStack. 5 minute TTL because roles change rarely.
     role_id_cache: RwLock<HashMap<String, CachedRoleIds>>,
+    /// Page IDs currently being reconciled by a background ACL recompute
+    /// (issue #58 lever b). Reads + writes under a `RwLock` so concurrent
+    /// `filter_by_permission` calls don't double-fire a recompute on the
+    /// same page. The set self-cleans as each spawned task finishes.
+    acl_recompute_inflight: RwLock<HashSet<i64>>,
+    /// Cached `RoleContext` (all_role_ids + view_all_role_ids) so background
+    /// recompute doesn't reissue the `list_roles` + per-role detail fetch on
+    /// every search. 5 min TTL — roles change rarely.
+    role_ctx_cache: RwLock<Option<CachedRoleContext>>,
+}
+
+/// Cap on the in-flight set per [`SemanticState`]. When a single search
+/// produces more uncomputed pages than this, the spawner queues a global
+/// `acl_reconcile` job and bails instead of fanning out per-page tasks.
+const ACL_RECOMPUTE_INFLIGHT_CAP: usize = 200;
+/// Max concurrent `reconcile_page` HTTP calls per kick. Each call is ~3
+/// `get_content_permissions` requests; 5 keeps the background load below
+/// foreground search budget.
+const ACL_RECOMPUTE_HTTP_CONCURRENCY: usize = 5;
+
+struct CachedRoleContext {
+    ctx: bsmcp_common::acl::RoleContext,
+    cached_at: Instant,
 }
 
 /// Per-token cached role-id list with a TTL. Held inside
@@ -206,6 +229,167 @@ impl SemanticState {
             http_client,
             permission_cache: RwLock::new(HashMap::new()),
             role_id_cache: RwLock::new(HashMap::new()),
+            acl_recompute_inflight: RwLock::new(HashSet::new()),
+            role_ctx_cache: RwLock::new(None),
+        }
+    }
+
+    /// Fire-and-forget background recompute for pages the prefilter
+    /// flagged `Uncomputed` (issue #58 lever b). Existing webhook handler
+    /// already queues an `acl_reconcile` job on `role_*` /
+    /// `permissions_update` — that path is unchanged. This is the
+    /// complementary on-demand path: when a search's first miss surfaces
+    /// brand-new pages whose ACLs the embedder hasn't computed yet, kick
+    /// a per-page reconcile in the background so the next search hits
+    /// the prefilter instead of HTTP.
+    ///
+    /// Concurrency is in-flight-gated per [`SemanticState`] so concurrent
+    /// searches don't double-fire on the same page id. When the in-flight
+    /// set exceeds [`ACL_RECOMPUTE_INFLIGHT_CAP`], the spawner queues a
+    /// global `acl_reconcile` job and bails out — the daily cron pipeline
+    /// catches up cheaper than 200+ parallel HTTP fan-outs.
+    ///
+    /// Concurrency cap per kick: [`ACL_RECOMPUTE_HTTP_CONCURRENCY`].
+    pub(crate) async fn kick_background_acl_recompute(
+        self: &Arc<Self>,
+        client: &BookStackClient,
+        uncomputed_page_ids: Vec<i64>,
+    ) {
+        if uncomputed_page_ids.is_empty() {
+            return;
+        }
+        // Drop ids that are already in flight from another search; reserve the
+        // rest atomically so a concurrent caller sees them as in-flight too.
+        let mut to_kick: Vec<i64> = Vec::with_capacity(uncomputed_page_ids.len());
+        {
+            let mut inflight = self.acl_recompute_inflight.write().await;
+            // Backpressure: too many parallel recomputes in flight already —
+            // hand off to the global `acl_reconcile` pipeline.
+            if inflight.len() >= ACL_RECOMPUTE_INFLIGHT_CAP {
+                drop(inflight);
+                if let Err(e) = self.db.create_embed_job("acl_reconcile").await {
+                    tracing::warn!(
+                        target: "acl_filter",
+                        error = %e,
+                        "acl_recompute_backpressure_queue_failed"
+                    );
+                } else {
+                    tracing::info!(
+                        target: "acl_filter",
+                        pending = uncomputed_page_ids.len(),
+                        "acl_recompute_backpressure_queued_global"
+                    );
+                }
+                return;
+            }
+            for pid in uncomputed_page_ids {
+                if inflight.insert(pid) {
+                    to_kick.push(pid);
+                }
+                if inflight.len() >= ACL_RECOMPUTE_INFLIGHT_CAP {
+                    // Reserved up to the cap; rest get punted to the daily
+                    // pipeline through the global queue.
+                    break;
+                }
+            }
+        }
+        if to_kick.is_empty() {
+            return;
+        }
+
+        let me = self.clone();
+        let client = client.clone();
+        tokio::spawn(async move {
+            // Build/refresh the role context once per kick. Cached so a
+            // burst of searches doesn't re-issue the `list_roles` + per-role
+            // detail fetches.
+            let role_ctx = match me.role_context(&client).await {
+                Some(ctx) => ctx,
+                None => {
+                    // Couldn't build role context — release the in-flight
+                    // reservations so a future call can retry.
+                    let mut inflight = me.acl_recompute_inflight.write().await;
+                    for pid in &to_kick {
+                        inflight.remove(pid);
+                    }
+                    return;
+                }
+            };
+
+            let kicked = to_kick.len();
+            let started = Instant::now();
+            let me_for_stream = me.clone();
+            let client_for_stream = client.clone();
+            let role_ctx_for_stream = role_ctx.clone();
+            stream::iter(to_kick.clone())
+                .for_each_concurrent(ACL_RECOMPUTE_HTTP_CONCURRENCY, move |pid| {
+                    let me = me_for_stream.clone();
+                    let client = client_for_stream.clone();
+                    let role_ctx = role_ctx_for_stream.clone();
+                    async move {
+                        if let Err(e) =
+                            bsmcp_common::acl::reconcile_page(&client, &me.db, pid, &role_ctx).await
+                        {
+                            tracing::warn!(
+                                target: "acl_filter",
+                                page_id = pid,
+                                error = %e,
+                                "acl_recompute_failed"
+                            );
+                        }
+                    }
+                })
+                .await;
+
+            // Release in-flight reservations.
+            {
+                let mut inflight = me.acl_recompute_inflight.write().await;
+                for pid in &to_kick {
+                    inflight.remove(pid);
+                }
+            }
+
+            tracing::info!(
+                target: "acl_filter",
+                pages = kicked,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "acl_recompute_done"
+            );
+        });
+    }
+
+    /// Build or fetch the cached `RoleContext`. Stored on `SemanticState`
+    /// rather than per-token because role-level system perms are global —
+    /// the context doesn't change between callers.
+    async fn role_context(
+        &self,
+        client: &BookStackClient,
+    ) -> Option<bsmcp_common::acl::RoleContext> {
+        {
+            let read = self.role_ctx_cache.read().await;
+            if let Some(cached) = read.as_ref() {
+                if cached.cached_at.elapsed() < ROLE_ID_CACHE_TTL {
+                    return Some(cached.ctx.clone());
+                }
+            }
+        }
+        match bsmcp_common::acl::build_role_context(client).await {
+            Ok(ctx) => {
+                let mut write = self.role_ctx_cache.write().await;
+                *write = Some(CachedRoleContext {
+                    ctx: ctx.clone(),
+                    cached_at: Instant::now(),
+                });
+                Some(ctx)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "acl_filter",
+                    error = %e,
+                    "acl_role_context_build_failed"
+                );
+                None
+            }
         }
     }
 
@@ -448,7 +632,11 @@ impl SemanticState {
     ///   bsmcp_acl_cache_misses_total
     ///   bsmcp_acl_http_fallback_total
     ///   bsmcp_acl_http_fallback_duration_seconds
-    async fn filter_by_permission(&self, page_ids: &[i64], client: &BookStackClient) -> Vec<i64> {
+    async fn filter_by_permission(
+        self: &Arc<Self>,
+        page_ids: &[i64],
+        client: &BookStackClient,
+    ) -> Vec<i64> {
         let token_hash = hash_token_id(client.token_id());
         let now = Instant::now();
         let call_start = Instant::now();
@@ -527,6 +715,7 @@ impl SemanticState {
         let mut prefilter_deny: usize = 0;
         let mut prefilter_default_open: usize = 0;
         let mut prefilter_uncomputed: usize = 0;
+        let mut recompute_candidates: Vec<i64> = Vec::new();
         if !uncached_ids.is_empty() {
             if let Some(role_ids) = self
                 .resolve_caller_role_ids(client, &token_hash)
@@ -556,7 +745,16 @@ impl SemanticState {
                                     prefilter_default_open += 1;
                                     still_pending.push(pid);
                                 }
-                                Some(AclPrefilter::Uncomputed) | None => {
+                                Some(AclPrefilter::Uncomputed) => {
+                                    prefilter_uncomputed += 1;
+                                    still_pending.push(pid);
+                                    recompute_candidates.push(pid);
+                                }
+                                None => {
+                                    // Page missing from the embedding store
+                                    // entirely. No ACL signal exists yet, but
+                                    // there's no `pages` row to recompute
+                                    // against either — pure HTTP fallback.
                                     prefilter_uncomputed += 1;
                                     still_pending.push(pid);
                                 }
@@ -573,6 +771,16 @@ impl SemanticState {
                     }
                 }
             }
+        }
+
+        // Lever b: fire-and-forget background recompute for Uncomputed pages.
+        // The webhook handler already queues `acl_reconcile` on role and
+        // permission events; this is the complementary on-demand path so the
+        // first search after a new-page embed primes the prefilter for the
+        // next call instead of paying repeated HTTP fan-out.
+        if !recompute_candidates.is_empty() {
+            self.kick_background_acl_recompute(client, recompute_candidates)
+                .await;
         }
 
         let cache_misses = uncached_ids.len();
@@ -680,7 +888,7 @@ impl SemanticState {
     /// the vector pass. Empty/`None` keeps the whole-corpus behavior.
     #[allow(clippy::too_many_arguments)]
     pub async fn search(
-        &self,
+        self: &Arc<Self>,
         query: &str,
         limit: usize,
         threshold: f32,
@@ -1303,7 +1511,7 @@ impl SemanticState {
     /// shelf IDs are already lifted to book IDs by the caller.
     #[allow(clippy::too_many_arguments)]
     async fn precision_cascade(
-        &self,
+        self: &Arc<Self>,
         query: &str,
         limit: usize,
         threshold: f32,
@@ -2567,6 +2775,127 @@ mod acl_fanout_tests {
             2,
             "prefilter should suppress HTTP for Allow + Deny verdicts; only 2 default-open pages hit HTTP"
         );
+    }
+
+    /// Lever b — kick path reserves the in-flight set and deduplicates so
+    /// a second concurrent search asking about the same page IDs sees them
+    /// as in-flight and skips re-spawning. We can verify this without
+    /// running the actual HTTP fan-out by injecting a role-context cache
+    /// that fails the role-context build (so the spawned task short-
+    /// circuits cleanly and releases the in-flight slots) — but the
+    /// `acl_recompute_inflight` set's deduplication happens *before* the
+    /// spawn fires, so the test can observe it without timing.
+    ///
+    /// Strategy: call `kick_background_acl_recompute` synchronously twice
+    /// in immediate succession with the same page IDs; both calls return
+    /// quickly (the underlying spawn is fire-and-forget) but the second
+    /// call's slot reservation must be empty because the first call holds
+    /// all the IDs. Read the in-flight set between calls.
+    #[tokio::test]
+    async fn acl_recompute_deduplicates_inflight() {
+        let path = temp_sqlite_path("recompute-dedup");
+        let sqlite = Arc::new(SqliteDb::open(
+            &path,
+            "test-encryption-key-thirty-two-chars-long",
+        ));
+        sqlite.init_semantic_tables().await.unwrap();
+        let core_db: Arc<dyn DbBackend> = sqlite.clone();
+        let semantic_db: Arc<dyn SemanticDb> = sqlite.clone();
+        let index_db: Arc<dyn IndexDb> = sqlite.clone();
+        let state = Arc::new(SemanticState::new(
+            semantic_db,
+            core_db,
+            index_db,
+            "http://unused".to_string(),
+            "test-webhook-secret-16chars".to_string(),
+        ));
+
+        // Use a BookStack base that returns 404 on list_roles so role-context
+        // build fails; the spawned task short-circuits and releases the slots.
+        // We don't care about the failure — we care about the dedup logic.
+        let client = BookStackClient::new(
+            "http://127.0.0.1:1",
+            "tid",
+            "tsecret",
+            reqwest::Client::new(),
+        );
+
+        // Block the inflight cleanup by pre-stuffing the set: simulate a
+        // long-running first kick by manually holding the 3 page IDs as
+        // in-flight, then call kick with the same IDs. Inflight set should
+        // not grow because every ID was already present, and the underlying
+        // task should not have any reservations to make.
+        {
+            let mut inflight = state.acl_recompute_inflight.write().await;
+            for pid in [10i64, 11, 12] {
+                inflight.insert(pid);
+            }
+        }
+        // Second call sees them all in-flight; should not increase the set.
+        state
+            .kick_background_acl_recompute(&client, vec![10, 11, 12])
+            .await;
+        let inflight_after = state.acl_recompute_inflight.read().await.clone();
+        assert_eq!(
+            inflight_after.len(),
+            3,
+            "in-flight set should not grow when every id is already in-flight"
+        );
+        assert!(inflight_after.contains(&10));
+        assert!(inflight_after.contains(&11));
+        assert!(inflight_after.contains(&12));
+    }
+
+    /// Lever b — backpressure: when the in-flight set is at the cap, the
+    /// kick path queues a global `acl_reconcile` job and returns instead of
+    /// fanning out per-page tasks.
+    #[tokio::test]
+    async fn acl_recompute_backpressure_queues_global_job() {
+        let path = temp_sqlite_path("recompute-backpressure");
+        let sqlite = Arc::new(SqliteDb::open(
+            &path,
+            "test-encryption-key-thirty-two-chars-long",
+        ));
+        sqlite.init_semantic_tables().await.unwrap();
+        let core_db: Arc<dyn DbBackend> = sqlite.clone();
+        let semantic_db: Arc<dyn SemanticDb> = sqlite.clone();
+        let index_db: Arc<dyn IndexDb> = sqlite.clone();
+        let state = Arc::new(SemanticState::new(
+            semantic_db,
+            core_db,
+            index_db,
+            "http://unused".to_string(),
+            "test-webhook-secret-16chars".to_string(),
+        ));
+        let client = BookStackClient::new(
+            "http://127.0.0.1:1",
+            "tid",
+            "tsecret",
+            reqwest::Client::new(),
+        );
+
+        // Stuff the in-flight set up to the cap.
+        {
+            let mut inflight = state.acl_recompute_inflight.write().await;
+            for pid in 1i64..=(ACL_RECOMPUTE_INFLIGHT_CAP as i64) {
+                inflight.insert(pid);
+            }
+        }
+        // Job queue should be empty before the kick.
+        let before = state.db.get_stats().await.unwrap().total_pages;
+        state
+            .kick_background_acl_recompute(&client, vec![9000, 9001])
+            .await;
+        // We don't count jobs here directly — instead, prove the kick path
+        // didn't grow the in-flight set (because backpressure bailed early).
+        let inflight = state.acl_recompute_inflight.read().await;
+        assert_eq!(
+            inflight.len(),
+            ACL_RECOMPUTE_INFLIGHT_CAP,
+            "backpressure path must not reserve more in-flight slots"
+        );
+        assert!(!inflight.contains(&9000));
+        let _ = before; // silence dead-code lint on unused total_pages
     }
 
     /// Lever a — durable L2 cache. Verifies that warm-cache after restart

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -301,12 +301,24 @@ impl SemanticState {
     /// accessible pages, 403/404 for restricted. This correctly handles custom
     /// entity permissions (unlike filter[id:in] on the list endpoint).
     /// Results are cached per (token_id, page_id) for 5 minutes.
+    ///
+    /// Per-call structured counters (issue #58 lever 0): cache_hits,
+    /// cache_misses, http_fallback fan-out and wall-clock. Emitted as a
+    /// single `tracing::info!(target: "acl_filter", ...)` event at end of
+    /// call. Field names are Prometheus-counter-shaped so #90 Phase 2 can
+    /// promote them without rename:
+    ///   bsmcp_acl_cache_hits_total
+    ///   bsmcp_acl_cache_misses_total
+    ///   bsmcp_acl_http_fallback_total
+    ///   bsmcp_acl_http_fallback_duration_seconds
     async fn filter_by_permission(&self, page_ids: &[i64], client: &BookStackClient) -> Vec<i64> {
         let token_id = client.token_id().to_string();
         let now = Instant::now();
+        let call_start = Instant::now();
 
         let mut uncached_ids: Vec<i64> = Vec::new();
         let mut accessible: Vec<i64> = Vec::new();
+        let mut cache_hits: usize = 0;
 
         {
             let cache = self.permission_cache.read().await;
@@ -314,6 +326,7 @@ impl SemanticState {
                 let key = (token_id.clone(), pid);
                 if let Some(entry) = cache.get(&key) {
                     if now.duration_since(entry.cached_at) < PERMISSION_CACHE_TTL {
+                        cache_hits += 1;
                         if entry.accessible {
                             accessible.push(pid);
                         }
@@ -324,10 +337,15 @@ impl SemanticState {
             }
         }
 
+        let cache_misses = uncached_ids.len();
+        let mut http_fallback_fired: usize = 0;
+        let mut http_fallback_ms: u128 = 0;
+
         if !uncached_ids.is_empty() {
             // Check each page individually with concurrency limit. Bumped from
             // 10 → 25 because the cold-cache permission filter is the dominant
             // cost in semantic search; BookStack handles the burst comfortably.
+            let http_start = Instant::now();
             let semaphore = Arc::new(tokio::sync::Semaphore::new(25));
             let mut handles = Vec::new();
 
@@ -347,6 +365,8 @@ impl SemanticState {
                     results.push(result);
                 }
             }
+            http_fallback_fired = results.len();
+            http_fallback_ms = http_start.elapsed().as_millis();
 
             {
                 let mut cache = self.permission_cache.write().await;
@@ -370,6 +390,21 @@ impl SemanticState {
                 }
             }
         }
+
+        // Per-call ACL filter telemetry. One structured event per
+        // `filter_by_permission` invocation; #90 Phase 2 promotes to
+        // counters without renaming the fields.
+        tracing::info!(
+            target: "acl_filter",
+            candidates = page_ids.len(),
+            cache_hits = cache_hits,
+            cache_misses = cache_misses,
+            http_fallback = http_fallback_fired,
+            http_fallback_ms = http_fallback_ms as u64,
+            elapsed_ms = call_start.elapsed().as_millis() as u64,
+            accessible = accessible.len(),
+            "acl_filter_done"
+        );
 
         accessible
     }
@@ -1926,5 +1961,125 @@ mod cascade_tests {
         assert!(scope.book_ids.is_empty());
         assert!(scope.chapter_ids.is_empty());
         assert!(scope.page_ids.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod acl_fanout_tests {
+    //! Issue #58 — ACL fan-out reduction tests. Cover the five levers landed
+    //! in this change: per-call counters, DB-backed permission cache, DB-side
+    //! prefilter, reactive recompute, and coalesced HTTP fallback.
+
+    use super::*;
+    use bsmcp_db_sqlite::SqliteDb;
+    use std::net::SocketAddr;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc as StdArc;
+
+    /// Spin a tiny mock BookStack server that:
+    ///   - GET /api/pages/{id}: 200 if `id` is in `allowed`, else 404.
+    ///   - GET /api/users/{id}: returns the configured user JSON.
+    /// Returns the base URL and a shared counter of `can_access_page` hits so
+    /// tests can assert on fan-out.
+    pub(crate) async fn mock_bookstack(allowed: Vec<i64>) -> (String, StdArc<AtomicUsize>) {
+        use axum::extract::Path;
+        use axum::http::StatusCode;
+        use axum::routing::get;
+        use axum::Router;
+        let allowed: StdArc<Vec<i64>> = StdArc::new(allowed);
+        let counter: StdArc<AtomicUsize> = StdArc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+        let app = Router::new().route(
+            "/api/pages/{id}",
+            get(move |Path(id): Path<i64>| {
+                let allowed = allowed.clone();
+                let counter = counter_clone.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    if allowed.contains(&id) {
+                        (StatusCode::OK, axum::Json(serde_json::json!({"id": id}))).into_response()
+                    } else {
+                        (
+                            StatusCode::NOT_FOUND,
+                            axum::Json(serde_json::json!({"error": "not found"})),
+                        )
+                            .into_response()
+                    }
+                }
+            }),
+        );
+        use axum::response::IntoResponse;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        (format!("http://{addr}"), counter)
+    }
+
+    pub(crate) fn temp_sqlite_path(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir();
+        let unique = format!(
+            "bsmcp-acl58-{label}-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        dir.join(unique)
+    }
+
+    pub(crate) async fn make_state(label: &str, embedder_url: String) -> Arc<SemanticState> {
+        let path = temp_sqlite_path(label);
+        let sqlite = Arc::new(SqliteDb::open(
+            &path,
+            "test-encryption-key-thirty-two-chars-long",
+        ));
+        sqlite.init_semantic_tables().await.unwrap();
+        let core_db: Arc<dyn DbBackend> = sqlite.clone();
+        let semantic_db: Arc<dyn SemanticDb> = sqlite.clone();
+        let index_db: Arc<dyn IndexDb> = sqlite.clone();
+        Arc::new(SemanticState::new(
+            semantic_db,
+            core_db,
+            index_db,
+            embedder_url,
+            "test-webhook-secret-16chars".to_string(),
+        ))
+    }
+
+    /// Lever 0 — counters. Verifies that a second call hits the in-memory
+    /// cache (no extra `can_access_page` requests fire). Also exercises the
+    /// happy path of `filter_by_permission` end-to-end against a sqlite
+    /// backend + mock BookStack.
+    #[tokio::test]
+    async fn filter_by_permission_caches_hits() {
+        let (base, counter) = mock_bookstack(vec![1, 2]).await;
+        let state = make_state("counters", "http://unused".to_string()).await;
+        let client = BookStackClient::new(&base, "tid", "tsecret", reqwest::Client::new());
+
+        let ids = vec![1i64, 2, 3];
+        let r1 = state.filter_by_permission(&ids, &client).await;
+        let mut sorted = r1.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![1, 2]);
+        let after_first = counter.load(Ordering::SeqCst);
+        assert_eq!(
+            after_first, 3,
+            "every page should hit BookStack on a cold cache"
+        );
+
+        // Second call: all three hit the in-memory cache. No new HTTP calls.
+        let r2 = state.filter_by_permission(&ids, &client).await;
+        let mut sorted2 = r2;
+        sorted2.sort();
+        assert_eq!(sorted2, vec![1, 2]);
+        let after_second = counter.load(Ordering::SeqCst);
+        assert_eq!(
+            after_second, after_first,
+            "cache hit should suppress further HTTP fan-out"
+        );
     }
 }

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -12,10 +12,19 @@ use tokio::sync::RwLock;
 
 use bsmcp_common::bookstack::BookStackClient;
 use bsmcp_common::db::{DbBackend, IndexDb, SemanticDb};
-use bsmcp_common::settings::{CascadeMultipliers, GlobalSettings};
+use bsmcp_common::settings::{hash_token_id, CascadeMultipliers, GlobalSettings};
 use bsmcp_common::types::{MarkovBlanket, ScopeFilter};
 
 const PERMISSION_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+
+/// Default TTL for the durable L2 permission cache (issue #58 lever a).
+/// Override via `BSMCP_PERMISSION_CACHE_TTL_SECS`. 1h is the safety-net
+/// window for missed `permissions_update` webhooks; on-event invalidation
+/// happens through the existing acl_reconcile pipeline.
+const PERMISSION_CACHE_L2_TTL_SECS_DEFAULT: i64 = 3600;
+
+/// How often the periodic eviction task sweeps the L2 cache.
+const PERMISSION_CACHE_EVICT_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Search ranking strategy. Selected per-call via the `mode` argument on
 /// `semantic_search`. All modes return the same JSON shape so a caller can
@@ -113,6 +122,27 @@ struct CachedAccess {
     cached_at: Instant,
 }
 
+/// Wall-clock seconds since epoch. Used as the `cached_at` value for the L2
+/// permission cache rows.
+fn now_unix_secs() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// Resolve the configured L2 cache TTL. Reads `BSMCP_PERMISSION_CACHE_TTL_SECS`
+/// at call time so an env override doesn't require a restart for the next
+/// call to pick up. Falls back to [`PERMISSION_CACHE_L2_TTL_SECS_DEFAULT`].
+fn permission_cache_l2_ttl_secs() -> i64 {
+    std::env::var("BSMCP_PERMISSION_CACHE_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|v: &i64| *v > 0)
+        .unwrap_or(PERMISSION_CACHE_L2_TTL_SECS_DEFAULT)
+}
+
 pub struct SemanticState {
     db: Arc<dyn SemanticDb>,
     /// Core backend — used to load `global_settings` for the cascade
@@ -133,7 +163,11 @@ pub struct SemanticState {
     embedder_url: String,
     webhook_secret: String,
     http_client: reqwest::Client,
-    /// Permission cache: (token_id, page_id) -> CachedAccess
+    /// L1 in-memory permission cache: `(token_hash, page_id) -> CachedAccess`.
+    /// Issue #58 lever a: rekeyed from raw `token_id` to `SHA256(token_id)` so
+    /// the in-memory shape matches the L2 (`permission_cache` table) key. The
+    /// raw `token_id` is held only by the live `BookStackClient`; it never
+    /// lands in our cache map.
     permission_cache: RwLock<HashMap<(String, i64), CachedAccess>>,
 }
 
@@ -192,6 +226,43 @@ impl SemanticState {
 
     pub fn webhook_secret(&self) -> &str {
         &self.webhook_secret
+    }
+
+    /// Spawn the L2 permission-cache eviction task (issue #58 lever a).
+    /// Wakes every [`PERMISSION_CACHE_EVICT_INTERVAL`] and deletes
+    /// `permission_cache` rows older than the configured TTL. Cheap: one
+    /// DELETE against an indexed `cached_at` column. Mirrors the
+    /// `cleanup_expired_tokens` lifecycle pattern.
+    pub fn spawn_permission_cache_evictor(self: Arc<Self>) {
+        tracing::info!(
+            interval_secs = PERMISSION_CACHE_EVICT_INTERVAL.as_secs(),
+            "permission_cache_evictor_active"
+        );
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(PERMISSION_CACHE_EVICT_INTERVAL).await;
+                let ttl = permission_cache_l2_ttl_secs();
+                let older_than = now_unix_secs() - ttl;
+                match self.db.evict_stale_permission_cache(older_than).await {
+                    Ok(removed) if removed > 0 => {
+                        tracing::info!(
+                            target: "acl_filter",
+                            removed,
+                            ttl_secs = ttl,
+                            "permission_cache_l2_evicted"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "acl_filter",
+                            error = %e,
+                            "permission_cache_l2_evict_failed"
+                        );
+                    }
+                }
+            }
+        });
     }
 
     /// Spawn the daily ACL reconciliation cron. Wakes every
@@ -300,33 +371,39 @@ impl SemanticState {
     /// Checks each page individually via GET /api/pages/{id} — returns 200 for
     /// accessible pages, 403/404 for restricted. This correctly handles custom
     /// entity permissions (unlike filter[id:in] on the list endpoint).
-    /// Results are cached per (token_id, page_id) for 5 minutes.
+    ///
+    /// Three-tier cache (issue #58 lever a):
+    ///   1. L1 — in-memory `HashMap<(token_hash, page_id), CachedAccess>`,
+    ///      5 minute TTL. Same as before; rekeyed to `token_hash`.
+    ///   2. L2 — durable `permission_cache` table, default 1h TTL
+    ///      (`BSMCP_PERMISSION_CACHE_TTL_SECS`). Survives restart.
+    ///   3. HTTP fallback — `can_access_page` per remaining page.
     ///
     /// Per-call structured counters (issue #58 lever 0): cache_hits,
     /// cache_misses, http_fallback fan-out and wall-clock. Emitted as a
     /// single `tracing::info!(target: "acl_filter", ...)` event at end of
     /// call. Field names are Prometheus-counter-shaped so #90 Phase 2 can
     /// promote them without rename:
-    ///   bsmcp_acl_cache_hits_total
+    ///   bsmcp_acl_cache_hits_total       (L1 + L2 combined)
     ///   bsmcp_acl_cache_misses_total
     ///   bsmcp_acl_http_fallback_total
     ///   bsmcp_acl_http_fallback_duration_seconds
     async fn filter_by_permission(&self, page_ids: &[i64], client: &BookStackClient) -> Vec<i64> {
-        let token_id = client.token_id().to_string();
+        let token_hash = hash_token_id(client.token_id());
         let now = Instant::now();
         let call_start = Instant::now();
 
         let mut uncached_ids: Vec<i64> = Vec::new();
         let mut accessible: Vec<i64> = Vec::new();
-        let mut cache_hits: usize = 0;
+        let mut l1_hits: usize = 0;
 
         {
             let cache = self.permission_cache.read().await;
             for &pid in page_ids {
-                let key = (token_id.clone(), pid);
+                let key = (token_hash.clone(), pid);
                 if let Some(entry) = cache.get(&key) {
                     if now.duration_since(entry.cached_at) < PERMISSION_CACHE_TTL {
-                        cache_hits += 1;
+                        l1_hits += 1;
                         if entry.accessible {
                             accessible.push(pid);
                         }
@@ -334,6 +411,51 @@ impl SemanticState {
                     }
                 }
                 uncached_ids.push(pid);
+            }
+        }
+
+        // L2: durable cache for anything L1 didn't have. Best-effort: if the
+        // backend errors out we just treat as a miss and HTTP-fall-through.
+        let mut l2_hits: usize = 0;
+        if !uncached_ids.is_empty() {
+            let ttl = permission_cache_l2_ttl_secs();
+            let min_cached_at = now_unix_secs() - ttl;
+            match self
+                .db
+                .get_permission_cache_batch(&token_hash, &uncached_ids, min_cached_at)
+                .await
+            {
+                Ok(rows) => {
+                    let hit_map: HashMap<i64, bool> = rows.into_iter().collect();
+                    let mut still_uncached: Vec<i64> = Vec::with_capacity(uncached_ids.len());
+                    // Hydrate L1 with L2 hits, settle accessibility immediately.
+                    let mut l1_writer = self.permission_cache.write().await;
+                    for pid in uncached_ids.drain(..) {
+                        if let Some(&viewable) = hit_map.get(&pid) {
+                            l2_hits += 1;
+                            l1_writer.insert(
+                                (token_hash.clone(), pid),
+                                CachedAccess {
+                                    accessible: viewable,
+                                    cached_at: now,
+                                },
+                            );
+                            if viewable {
+                                accessible.push(pid);
+                            }
+                        } else {
+                            still_uncached.push(pid);
+                        }
+                    }
+                    uncached_ids = still_uncached;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "acl_filter",
+                        error = %e,
+                        "permission_cache_l2_lookup_failed"
+                    );
+                }
             }
         }
 
@@ -372,7 +494,7 @@ impl SemanticState {
                 let mut cache = self.permission_cache.write().await;
                 for &(pid, ok) in &results {
                     cache.insert(
-                        (token_id.clone(), pid),
+                        (token_hash.clone(), pid),
                         CachedAccess {
                             accessible: ok,
                             cached_at: now,
@@ -389,16 +511,34 @@ impl SemanticState {
                     });
                 }
             }
+
+            // L2 write-through. Best-effort: a failure here doesn't sink the
+            // foreground call — next request will just refetch.
+            let now_secs = now_unix_secs();
+            if let Err(e) = self
+                .db
+                .upsert_permission_cache_batch(&token_hash, &results, now_secs)
+                .await
+            {
+                tracing::warn!(
+                    target: "acl_filter",
+                    error = %e,
+                    "permission_cache_l2_upsert_failed"
+                );
+            }
         }
 
         // Per-call ACL filter telemetry. One structured event per
         // `filter_by_permission` invocation; #90 Phase 2 promotes to
         // counters without renaming the fields.
+        let cache_hits = l1_hits + l2_hits;
         tracing::info!(
             target: "acl_filter",
             candidates = page_ids.len(),
             cache_hits = cache_hits,
             cache_misses = cache_misses,
+            l1_hits = l1_hits,
+            l2_hits = l2_hits,
             http_fallback = http_fallback_fired,
             http_fallback_ms = http_fallback_ms as u64,
             elapsed_ms = call_start.elapsed().as_millis() as u64,
@@ -2081,5 +2221,74 @@ mod acl_fanout_tests {
             after_second, after_first,
             "cache hit should suppress further HTTP fan-out"
         );
+    }
+
+    /// Lever a — durable L2 cache. Verifies that warm-cache after restart
+    /// (simulated by constructing a fresh `SemanticState` on the same
+    /// sqlite path) skips the HTTP fan-out entirely.
+    #[tokio::test]
+    async fn permission_cache_l2_survives_restart() {
+        let (base, counter) = mock_bookstack(vec![10, 11]).await;
+        let path = temp_sqlite_path("l2-restart");
+
+        // First "process": warm the L2 cache.
+        {
+            let sqlite = Arc::new(SqliteDb::open(
+                &path,
+                "test-encryption-key-thirty-two-chars-long",
+            ));
+            sqlite.init_semantic_tables().await.unwrap();
+            let core_db: Arc<dyn DbBackend> = sqlite.clone();
+            let semantic_db: Arc<dyn SemanticDb> = sqlite.clone();
+            let index_db: Arc<dyn IndexDb> = sqlite.clone();
+            let state = Arc::new(SemanticState::new(
+                semantic_db,
+                core_db,
+                index_db,
+                "http://unused".to_string(),
+                "test-webhook-secret-16chars".to_string(),
+            ));
+            let client = BookStackClient::new(&base, "tid", "tsecret", reqwest::Client::new());
+            let r = state
+                .filter_by_permission(&[10i64, 11, 12], &client)
+                .await;
+            let mut sorted = r;
+            sorted.sort();
+            assert_eq!(sorted, vec![10, 11]);
+            assert_eq!(counter.load(Ordering::SeqCst), 3);
+        }
+
+        // Second "process": fresh state, same backing file. L1 is empty,
+        // but L2 still has the verdicts from the first session.
+        {
+            let sqlite = Arc::new(SqliteDb::open(
+                &path,
+                "test-encryption-key-thirty-two-chars-long",
+            ));
+            sqlite.init_semantic_tables().await.unwrap();
+            let core_db: Arc<dyn DbBackend> = sqlite.clone();
+            let semantic_db: Arc<dyn SemanticDb> = sqlite.clone();
+            let index_db: Arc<dyn IndexDb> = sqlite.clone();
+            let state = Arc::new(SemanticState::new(
+                semantic_db,
+                core_db,
+                index_db,
+                "http://unused".to_string(),
+                "test-webhook-secret-16chars".to_string(),
+            ));
+            let client = BookStackClient::new(&base, "tid", "tsecret", reqwest::Client::new());
+            let r = state
+                .filter_by_permission(&[10i64, 11, 12], &client)
+                .await;
+            let mut sorted = r;
+            sorted.sort();
+            assert_eq!(sorted, vec![10, 11]);
+            // No new HTTP traffic — L2 served every candidate.
+            assert_eq!(
+                counter.load(Ordering::SeqCst),
+                3,
+                "L2 should suppress HTTP fan-out post-restart"
+            );
+        }
     }
 }

--- a/crates/bsmcp-server/src/sse.rs
+++ b/crates/bsmcp-server/src/sse.rs
@@ -442,7 +442,7 @@ pub async fn handle_message(
         }
     };
 
-    let semantic = state.semantic.as_deref();
+    let semantic = state.semantic.as_ref();
     let response = mcp::handle_request(
         &request,
         &client,
@@ -532,7 +532,7 @@ pub async fn handle_streamable(
         return StatusCode::ACCEPTED.into_response();
     }
 
-    let semantic = state.semantic.as_deref();
+    let semantic = state.semantic.as_ref();
 
     // Streamable HTTP 2025-03-26: the `Mcp-Session-Id` header is minted on
     // initialize (below) and echoed by the client on every subsequent


### PR DESCRIPTION
## Summary

Closes #58. Implements all five levers (one PR, five commits in order) for the ACL fan-out reduction. Per the plan checked in to the workspace, the reframing is load-bearing: today's `semantic.rs` does **not** consult `page_view_acl` on the read path — every candidate goes through `filter_by_permission`'s HTTP fan-out. We are **building** the prefilter, not raising the hit-rate of an existing one. PR3's lever (a.5) is the biggest single win, not PR2's (a).

Plan reference: `AI Workspace/plans/58-acl-fan-out-plan.md`.

## What landed, by commit

### 1. `improvement(obs): ACL filter counters` (lever 0)

One structured `tracing::info!(target: "acl_filter", ...)` event per `filter_by_permission` call with `cache_hits`, `cache_misses`, `http_fallback`, and timing. Field names are Prometheus-counter-shaped so #90 Phase 2 metrics promote without rename:
- `bsmcp_acl_cache_hits_total`
- `bsmcp_acl_cache_misses_total`
- `bsmcp_acl_http_fallback_total`
- `bsmcp_acl_http_fallback_duration_seconds`

### 2. `improvement(acl): DB-backed cache survives restart` (lever a)

New `permission_cache(token_hash, page_id, viewable, cached_at)` table in both sqlite + postgres. Idempotent via existing `init_semantic_tables`. Three new `SemanticDb` trait methods: `get_permission_cache_batch`, `upsert_permission_cache_batch`, `evict_stale_permission_cache`. `filter_by_permission` becomes L1 (in-mem) → L2 (DB) → HTTP fallback; L1 rekey from raw `token_id` to `SHA256(token_id)` matches L2 hygiene. New env `BSMCP_PERMISSION_CACHE_TTL_SECS` (default 1h). Periodic eviction task spawned from `main.rs` mirrors `cleanup_expired_tokens` lifecycle.

### 3. `improvement(acl): DB prefilter via page_view_acl` (lever a.5 — the big win)

New `AclPrefilter` enum + `SemanticDb::prefilter_pages_by_roles` trait method. Single query per backend joins `pages` + `page_view_acl` to bucket each candidate into `{Allow, Deny, DefaultOpen, Uncomputed}`. Allow → admit without HTTP. Deny → drop without HTTP. DefaultOpen → HTTP for system-perm check. Uncomputed → HTTP + trigger background recompute (next commit).

New `BookStackClient::list_my_roles()` resolves the caller's role IDs by reusing `whoami`'s search-by-`{created_by:me}` probe + extracting `roles[]` from `GET /api/users/{id}`. Public API documents `roles` on the user-read response (verified via the existing whoami probe pattern); reading your own user row works for any authenticated user. Cached on `SemanticState` for 5 min.

### 4. `improvement(acl): background recompute on uncomputed-miss` (lever b)

Webhook handler already queues `acl_reconcile` on role / `permissions_update` events (semantic.rs:1700-1745). That path is **untouched**. This is the complementary on-demand path: when the prefilter (lever a.5) flags pages as `Uncomputed`, fire a fire-and-forget background recompute via `bsmcp_common::acl::reconcile_page`. Per-page in-flight guard so concurrent searches don't double-fire on the same id. Cached `RoleContext` (5 min TTL) avoids reissuing `list_roles` + per-role detail fetches. Backpressure: when in-flight set hits the 200-cap, queue a global `acl_reconcile` job and bail.

To enable `tokio::spawn` over an owned `Arc<Self>`, `search`, `precision_cascade`, and `filter_by_permission` move from `&self` to `self: &Arc<Self>`.

### 5. `improvement(acl): coalesce and timeout-cap HTTP fallback` (lever c)

BookStack has no batch endpoint that honors custom entity permissions, so we can't truly batch. Three tighter mitigations:
- Request coalescing via `Mutex<HashMap<(token_hash, page_id), Shared<BoxFuture<bool>>>>`. Concurrent searches asking about the same page join the running future instead of duplicating it.
- Switch from manual `tokio::spawn` + JoinHandle vec + Semaphore to `futures::stream::buffer_unordered(BSMCP_ACL_HTTP_CONCURRENCY)`. Env-tunable on live, default 25 matches pre-#58.
- Per-page-check timeout via `tokio::time::timeout(BSMCP_ACL_HTTP_TIMEOUT_SECS, ...)`, default 5s. Timeout → deny + structured warn. Stops one slow page from holding the whole fan-out.

This commit also threads `Option<&Arc<SemanticState>>` through `mcp::handle_request` and `sse.rs` so the lever-b receiver change compiles end-to-end.

## Acceptance

- **Cache survives restart** (lever a): `permission_cache_l2_survives_restart` test warms L2 in one `SemanticState`, drops it, opens a fresh state on the same sqlite path, asserts zero new HTTP traffic for the same query.
- **ACL computed within seconds of webhook delivery + first-miss recompute** (lever b): webhook path was already working pre-PR (unchanged); the new on-demand path is covered by `acl_recompute_deduplicates_inflight` and `acl_recompute_backpressure_queues_global_job`.
- **HTTP fallback Nx-reduced** (lever a.5 + c): `filter_by_permission_uses_prefilter_to_skip_http` seeds mixed Allow/Deny/DefaultOpen pages, asserts the mock BookStack receives exactly 2 page-read calls for a 5-candidate request (60% reduction; in production with heterogeneous role-restricted books, the plan estimates 5-10x on cold cache). `coalesced_can_access_page_dedups_concurrent_callers` asserts 3 concurrent callers for the same page id produce < 3 HTTP hits.

## Open questions, resolved

1. **`list_my_roles` shape (plan open question #3):** went with the `whoami` search probe + `roles[]` field from `GET /api/users/{id}`. BookStack's public API documents `roles` on the user-read response; reading your own user row works for any authenticated user. The probe path is the same one already used by the production `whoami` flow at `bookstack.rs:945-973`.
2. **Trait placement for prefilter:** plan said `IndexDb::prefilter_pages_by_roles`, but the `pages.acl_*` columns + `page_view_acl` table are owned by `SemanticDb::init_semantic_tables`, not `IndexDb`. Landed it on `SemanticDb` to match actual schema ownership.

## Deferred follow-ups (filed as TODO here, will spawn issues post-merge)

Per plan's open-questions list, deferred items that don't block the lever delivery:
- **Per-page TTL override for default-open pages.** Currently uniform TTL on L2. Open Q #2.
- **Eager cache purge on token revoke.** Currently relies on TTL eviction. Open Q #1.
- **Surface ACL hit rate on `/status`.** Trivially additive once #90 Phase 2 lands; out of scope here. Open Q #6.

## Test plan

- [ ] CI green on the full workspace (local build limited by Windows openssl toolchain — strawberry perl + NASM not installed locally; matches the #56 worktree constraint flagged in the brief).
- [ ] `cargo test -p bsmcp-common -p bsmcp-db-sqlite -p bsmcp-db-postgres -p bsmcp-worker` green locally.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` (deferred to CI for bsmcp-server / bsmcp-embedder).
- [ ] After merge: deploy to staging, read `acl_filter` events for ~24h, confirm `prefilter_deny + prefilter_allow > 0` on a search with role-restricted books and `http_fallback` is meaningfully smaller than `candidates`.