### PR TITLE
chore(release): bump workspace to v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-common"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-postgres"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-sqlite"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-embedder"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-server"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.12.2"
+version = "0.13.0"
 
 [workspace.dependencies]
 # Structured logging. `json` feature enables the JSON output mode that


### PR DESCRIPTION
Workspace 0.12.2 → 0.13.0. Manifest version is the next release target per the [Change Lifecycle](https://kb.beesroadhouse.com/books/developer-operations-devops/page/change-lifecycle) rule.

## What's in v0.13.0 (already on development)

| PR | Title | Bucket |
|---|---|---|
| #114 | feature(arch): fold bsmcp-worker into bsmcp-embedder --role flag (closes #56) | breaking — worker fold |
| #116 | improvement(acl): five-lever fan-out reduction (closes #58) | ACL perf |
| #117 | feature(search): rerank as flag on semantic_search + content_search (closes #115) | breaking — search surface |
| #118 | bug(auth): widen settings session cookie path to / | auth fix |
| #120 | improvement(settings): generic indexed_shelves, walk-all default (closes #119) | indexer scope refactor |

**Breaking on two fronts** (worker fold image rename + `mode: "rerank"` hard-cut). Both have auto-migrations or structured error paths — no silent breakage on either side.

Also brings: scope-aware ACL with DB-backed L2 cache + read-path prefilter (#116 / closes #58), rerank as an optional flag on both search tools (#117 / closes #115), the v0.10.0-era hive/user_journals shelf scoping replaced with `indexed_shelves` + walk-all-by-default (#120 / closes #119 — fixes the silent no-op-walk on DTC's instance), and the /settings cookie scope widened so /status renders cleanly under browser auth (#118).