### PR TITLE
bug(ci): timeout-cap release jobs; cross-build x86_64 macOS on Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
   build-release-images:
     if: github.event_name == 'push' && github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write
@@ -112,6 +113,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/release'
     needs: [build-release-images]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       packages: write
     steps:
@@ -154,6 +156,7 @@ jobs:
   github-release-on-merge:
     if: github.event_name == 'push' && github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     outputs:
@@ -216,6 +219,7 @@ jobs:
   release-binaries-on-merge:
     if: github.event_name == 'push' && github.ref == 'refs/heads/release'
     needs: [github-release-on-merge]
+    timeout-minutes: 60
     permissions:
       contents: write
     strategy:
@@ -229,8 +233,13 @@ jobs:
             runner: ubuntu-22.04
             archive: tar.gz
             cross: true
+          # Cross-compiled from the Apple-Silicon runner. macos-13 (Intel)
+          # stalls indefinitely at `cargo build` here; macos-14 + the
+          # x86_64-apple-darwin rustup target builds it in minutes. The
+          # macOS SDK ships both arch slices, so cc/openssl-src/bundled
+          # SQLite cross-compile with no extra linker config.
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-14
             archive: tar.gz
           - target: aarch64-apple-darwin
             runner: macos-14
@@ -305,6 +314,7 @@ jobs:
   tag-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: write
       packages: write
@@ -371,6 +381,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [tag-release]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       packages: write
     steps:
@@ -415,6 +426,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [tag-release]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     outputs:
@@ -453,6 +465,7 @@ jobs:
   release-binaries-on-tag:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [github-release-on-tag]
+    timeout-minutes: 60
     permissions:
       contents: write
     strategy:
@@ -466,8 +479,13 @@ jobs:
             runner: ubuntu-22.04
             archive: tar.gz
             cross: true
+          # Cross-compiled from the Apple-Silicon runner. macos-13 (Intel)
+          # stalls indefinitely at `cargo build` here; macos-14 + the
+          # x86_64-apple-darwin rustup target builds it in minutes. The
+          # macOS SDK ships both arch slices, so cc/openssl-src/bundled
+          # SQLite cross-compile with no extra linker config.
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-14
             archive: tar.gz
           - target: aarch64-apple-darwin
             runner: macos-14

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -168,7 +168,7 @@ Each GitHub Release attaches `bsmcp-server` archives for these targets:
 |--------|---------|--------|
 | `x86_64-unknown-linux-gnu` | `.tar.gz` | ubuntu-22.04 (glibc ≥ 2.35) |
 | `aarch64-unknown-linux-gnu` | `.tar.gz` | ubuntu-22.04 + cross-linker |
-| `x86_64-apple-darwin` | `.tar.gz` | macos-13 |
+| `x86_64-apple-darwin` | `.tar.gz` | macos-14 (cross-compiled from Apple Silicon) |
 | `aarch64-apple-darwin` | `.tar.gz` | macos-14 |
 | `x86_64-pc-windows-msvc` | `.zip` | windows-2022 |
 


### PR DESCRIPTION
## What

Every Release run has been going **red** on release merges. Root cause: the `x86_64-apple-darwin` native-binary leg hangs at `cargo build` on the `macos-13` runner and runs to the **24-hour platform cap** before GitHub cancels it. No job in `release.yml` had a `timeout-minutes`, so one stalled leg burned a full day and reddened the whole run.

That red run masked the truth: image tagging (`:latest` / `:release` / `:{version}`) and the `v{version}` git tag + GitHub Release were all **succeeding** — verified on GHCR (v0.12.2 tags all sit on the image built 2026-05-29 14:40) and via the existing `v0.12.2` git tag. The only real losses were the red status and the missing Intel-mac binary on every Release.

## Changes

- **`timeout-minutes` on all 8 jobs** (native binaries 60, multi-arch image builds 120, release-entry/alias jobs 15–20). A hang now fails one leg in minutes instead of stalling 24h; `fail-fast: false` keeps the other legs and the image build unaffected.
- **`x86_64-apple-darwin` moved `macos-13` → `macos-14`**, cross-compiled from Apple Silicon. The rustup target is already installed by the toolchain step, and the macOS SDK ships both arch slices, so `cc` / bundled SQLite / vendored openssl build with no extra linker config. macos-13 is being retired by GitHub anyway.
- `DEVELOPMENT.md` runner table updated to match.

## Timing

The workflow that executes on a release merge is the copy on the `release` branch. This needs to land in `development` **before** the v0.13.0 development→release sync to take effect for v0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)