### PR TITLE
bug(auth): don't report transient BookStack failures as auth failures (closes #139)

### DIFF
--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -544,7 +544,22 @@ impl BookStackClient {
         };
 
         if resp.status().is_success() {
-            return CredentialCheck::Valid;
+            // A 2xx alone isn't proof we reached BookStack. An auth portal or
+            // misconfigured proxy in front of it happily answers 200 with an
+            // HTML login page; treating that as Valid would admit a session
+            // whose every tool call then fails. Requiring parseable JSON
+            // keeps the old `get()` strictness — but classifies the failure
+            // as Unavailable, since an interceptor says nothing about
+            // whether the credentials are good.
+            return match Self::read_json(resp).await {
+                Ok(_) => CredentialCheck::Valid,
+                Err(e) => {
+                    tracing::warn!(error = %e, "bookstack_non_json_success_response");
+                    CredentialCheck::Unavailable(
+                        "BookStack returned a non-JSON response — check for a proxy or auth portal in front of the API".to_string(),
+                    )
+                }
+            };
         }
 
         let status = resp.status();

--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -217,6 +217,38 @@ pub struct UserIdentity {
     pub name: String,
 }
 
+/// Outcome of `BookStackClient::validate()`. See that method for why the
+/// two failure arms must stay distinct.
+#[derive(Clone, Debug)]
+pub enum CredentialCheck {
+    /// BookStack accepted the credentials.
+    Valid,
+    /// BookStack answered 401/403 — the credentials are genuinely bad.
+    /// Re-authenticating is the fix.
+    Rejected(String),
+    /// BookStack could not be reached or could not answer. Says nothing
+    /// about the credentials; the caller should retry, not re-authenticate.
+    Unavailable(String),
+}
+
+impl CredentialCheck {
+    /// Classify a non-success status from BookStack.
+    ///
+    /// Only 401/403 — BookStack answering "no" — is a credential problem.
+    /// Everything else means we didn't get a usable answer: 5xx from a
+    /// restarting instance or the proxy in front of it, 429, or a 404 from a
+    /// misconfigured `BSMCP_BOOKSTACK_URL`. Re-authenticating fixes none of
+    /// those, so they must not be reported as auth failures (#139).
+    pub fn from_error_status(status: reqwest::StatusCode) -> Self {
+        match status {
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+                CredentialCheck::Rejected(format!("BookStack rejected the credentials: {status}"))
+            }
+            _ => CredentialCheck::Unavailable(format!("BookStack API error: {status}")),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct BookStackClient {
     client: Client,
@@ -487,8 +519,44 @@ impl BookStackClient {
 
     // --- Validation ---
 
-    pub async fn validate(&self) -> Result<Value, String> {
-        self.get("books", &[("count", "1")]).await
+    /// Check the configured credentials against BookStack.
+    ///
+    /// The Rejected/Unavailable split is load-bearing, not cosmetic. Only
+    /// `Rejected` means BookStack answered and said no — the sole case where
+    /// a client should be told to re-authenticate. `Unavailable` means we
+    /// never got an answer: BookStack restarting, a proxy 5xx, a timeout, a
+    /// misconfigured base URL. Collapsing the two into one error (as this
+    /// did before #139) makes every BookStack blip look like an expired
+    /// token, and the callers that acted on it issued 401 +
+    /// `WWW-Authenticate` or deleted a still-valid refresh token.
+    pub async fn validate(&self) -> CredentialCheck {
+        let builder = self
+            .client
+            .get(format!("{}/api/books", self.base_url))
+            .header("Authorization", self.auth_header())
+            .query(&[("count", "1")]);
+
+        let resp = match self.send_with_retry(builder).await {
+            Ok(resp) => resp,
+            // Transport failure, or 429 with the retry budget spent. Never a
+            // statement about the credentials.
+            Err(e) => return CredentialCheck::Unavailable(e),
+        };
+
+        if resp.status().is_success() {
+            return CredentialCheck::Valid;
+        }
+
+        let status = resp.status();
+        let body = Self::read_error_body(resp).await;
+        let check = CredentialCheck::from_error_status(status);
+        match check {
+            CredentialCheck::Rejected(_) => {
+                tracing::warn!(%status, body = %body, "bookstack_credentials_rejected")
+            }
+            _ => tracing::warn!(%status, body = %body, "bookstack_unavailable"),
+        }
+        check
     }
 
     /// Heuristic admin check: BookStack returns 403 from `/api/users` for
@@ -1228,6 +1296,7 @@ fn flatten_book_pages(book: &Value) -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reqwest::StatusCode;
     use serde_json::json;
 
     fn fixture_book() -> Value {
@@ -1293,5 +1362,43 @@ mod tests {
             ]
         });
         assert!(flatten_book_pages(&book).is_empty());
+    }
+
+    // #139: only BookStack answering 401/403 may be reported as a credential
+    // problem. Anything else must stay Unavailable — callers turn Rejected
+    // into a 401 + WWW-Authenticate and delete refresh tokens on it.
+    #[test]
+    fn only_401_and_403_are_credential_rejections() {
+        for status in [StatusCode::UNAUTHORIZED, StatusCode::FORBIDDEN] {
+            assert!(
+                matches!(
+                    CredentialCheck::from_error_status(status),
+                    CredentialCheck::Rejected(_)
+                ),
+                "{status} should be Rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn upstream_failures_are_not_credential_rejections() {
+        let transient = [
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::GATEWAY_TIMEOUT,
+            StatusCode::TOO_MANY_REQUESTS,
+            // A misconfigured BSMCP_BOOKSTACK_URL, not a bad token.
+            StatusCode::NOT_FOUND,
+        ];
+        for status in transient {
+            assert!(
+                matches!(
+                    CredentialCheck::from_error_status(status),
+                    CredentialCheck::Unavailable(_)
+                ),
+                "{status} must not be reported as a credential failure"
+            );
+        }
     }
 }

--- a/crates/bsmcp-server/src/oauth.rs
+++ b/crates/bsmcp-server/src/oauth.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use zeroize::Zeroize;
 
-use bsmcp_common::bookstack::BookStackClient;
+use bsmcp_common::bookstack::{BookStackClient, CredentialCheck};
 use bsmcp_common::config::access_token_ttl;
 
 use crate::sse::AppState;
@@ -345,8 +345,20 @@ pub async fn handle_authorize_submit(
         &form.token_secret,
         state.http_client.clone(),
     );
-    if let Err(e) = bs_client.validate().await {
-        tracing::warn!(error = %e, "oauth_credential_validation_failed");
+    // Don't blame the pasted token when BookStack simply couldn't answer —
+    // the user would rotate a perfectly good API token chasing it (#139).
+    let form_error = match bs_client.validate().await {
+        CredentialCheck::Valid => None,
+        CredentialCheck::Rejected(e) => {
+            tracing::warn!(error = %e, "oauth_credential_validation_rejected");
+            Some("Invalid API token. Check your Token ID and Secret.")
+        }
+        CredentialCheck::Unavailable(e) => {
+            tracing::warn!(error = %e, "oauth_credential_validation_unavailable");
+            Some("Couldn't reach BookStack to check that token. Try again in a moment.")
+        }
+    };
+    if let Some(msg) = form_error {
         let params = AuthorizeParams {
             response_type: form.response_type.clone(),
             client_id: form.client_id.clone(),
@@ -356,12 +368,7 @@ pub async fn handle_authorize_submit(
             code_challenge_method: form.code_challenge_method.clone(),
             return_to: form.return_to.clone(),
         };
-        return Html(render_login_form(
-            &params,
-            &state.bookstack_url,
-            Some("Invalid API token. Check your Token ID and Secret."),
-        ))
-        .into_response();
+        return Html(render_login_form(&params, &state.bookstack_url, Some(msg))).into_response();
     }
 
     // Browser settings flow: skip the OAuth code dance entirely. Issue a settings
@@ -558,13 +565,20 @@ async fn handle_token_authorization_code(
             &client_secret,
             state.http_client.clone(),
         );
-        if let Err(e) = bs_client.validate().await {
-            tracing::warn!(error = %e, "oauth_bookstack_credential_validation_failed");
-            return oauth_error(
-                StatusCode::UNAUTHORIZED,
-                "invalid_client",
-                Some("Invalid BookStack credentials"),
-            );
+        match bs_client.validate().await {
+            CredentialCheck::Valid => {}
+            CredentialCheck::Rejected(e) => {
+                tracing::warn!(error = %e, "oauth_bookstack_credential_validation_rejected");
+                return oauth_error(
+                    StatusCode::UNAUTHORIZED,
+                    "invalid_client",
+                    Some("Invalid BookStack credentials"),
+                );
+            }
+            CredentialCheck::Unavailable(e) => {
+                tracing::warn!(error = %e, "oauth_bookstack_credential_validation_unavailable");
+                return temporarily_unavailable();
+            }
         }
 
         tracing::debug!(
@@ -616,15 +630,28 @@ async fn handle_token_refresh(state: AppState, form: TokenForm) -> Response {
         &token_secret,
         state.http_client.clone(),
     );
-    if let Err(e) = bs_client.validate().await {
-        tracing::warn!(error = %e, "oauth_stored_credentials_invalid");
-        // Consume the invalid refresh token
-        state.db.delete_refresh_token(&old_refresh).await.ok();
-        return oauth_error(
-            StatusCode::UNAUTHORIZED,
-            "invalid_grant",
-            Some("BookStack API credentials are no longer valid. Please re-authenticate with new credentials."),
-        );
+    match bs_client.validate().await {
+        CredentialCheck::Valid => {}
+        CredentialCheck::Rejected(e) => {
+            tracing::warn!(error = %e, "oauth_stored_credentials_rejected");
+            // BookStack answered and said no. The stored credentials this
+            // refresh token wraps are dead, so the token is worthless —
+            // consume it.
+            state.db.delete_refresh_token(&old_refresh).await.ok();
+            return oauth_error(
+                StatusCode::UNAUTHORIZED,
+                "invalid_grant",
+                Some("BookStack API credentials are no longer valid. Please re-authenticate with new credentials."),
+            );
+        }
+        CredentialCheck::Unavailable(e) => {
+            // We never got an answer. Deleting here destroys a valid 90-day
+            // refresh token over a restart or a proxy blip and forces a full
+            // browser re-auth with no recovery path — the core of #139.
+            // Keep the token, tell the client to retry.
+            tracing::warn!(error = %e, "oauth_stored_credentials_unavailable");
+            return temporarily_unavailable();
+        }
     }
 
     // Consume the old refresh token (rotation)
@@ -783,4 +810,20 @@ fn oauth_error(status: StatusCode, error: &str, description: Option<&str>) -> Re
         body["error_description"] = json!(desc);
     }
     (status, Json(body)).into_response()
+}
+
+/// RFC 6749 §4.1.2.1 `temporarily_unavailable` — the token endpoint's way of
+/// saying "not your credentials, try again". Distinct from `invalid_grant`,
+/// which tells the client its token is dead and to start over (#139).
+fn temporarily_unavailable() -> Response {
+    let mut resp = oauth_error(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "temporarily_unavailable",
+        Some("BookStack is unreachable — retry shortly. Your token is still valid."),
+    );
+    resp.headers_mut().insert(
+        header::RETRY_AFTER,
+        crate::sse::RETRY_AFTER_SECS.parse().unwrap(),
+    );
+    resp
 }

--- a/crates/bsmcp-server/src/sse.rs
+++ b/crates/bsmcp-server/src/sse.rs
@@ -16,7 +16,7 @@ use tokio::sync::{mpsc, Mutex, RwLock};
 use tokio_stream::wrappers::ReceiverStream;
 use zeroize::Zeroize;
 
-use bsmcp_common::bookstack::BookStackClient;
+use bsmcp_common::bookstack::{BookStackClient, CredentialCheck};
 use bsmcp_common::db::DbBackend;
 use bsmcp_common::time::TimezoneConfig;
 
@@ -28,6 +28,9 @@ const MAX_SESSIONS_PER_TOKEN: usize = 5;
 const MAX_TOTAL_SESSIONS: usize = 1000;
 const SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
 const MAX_REQUESTS_PER_MINUTE: u32 = 100;
+/// `Retry-After` on a 503 when an upstream is unreachable. Long enough to
+/// cover a container restart, short enough that clients don't stall.
+pub(crate) const RETRY_AFTER_SECS: &str = "5";
 
 #[derive(Clone)]
 pub struct AppState {
@@ -233,6 +236,17 @@ fn unauthorized(hint: &str, headers: &HeaderMap, known_urls: &[String]) -> Respo
     resp
 }
 
+/// BookStack couldn't answer. Deliberately *not* a 401: no
+/// `WWW-Authenticate`, so clients hold onto their token and retry instead of
+/// tearing down and re-running OAuth (#139).
+fn upstream_unavailable(hint: &str) -> Response {
+    let body = serde_json::json!({"error": "upstream_unavailable", "hint": hint});
+    let mut resp = (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response();
+    resp.headers_mut()
+        .insert(header::RETRY_AFTER, RETRY_AFTER_SECS.parse().unwrap());
+    resp
+}
+
 pub async fn resolve_credentials(
     headers: &HeaderMap,
     db: &dyn DbBackend,
@@ -264,7 +278,14 @@ pub async fn resolve_credentials(
         }
         Ok(None) => {}
         Err(e) => {
+            // Same trap as #139, one layer down: a DB blip says nothing
+            // about the token. Falling through to the 401 below would tell
+            // every connected client at once that its token is invalid and
+            // stampede them all into re-auth.
             tracing::error!(error = %e, "auth_token_lookup_error");
+            return Err(upstream_unavailable(
+                "Token store is unavailable — retry shortly",
+            ));
         }
     }
 
@@ -291,13 +312,20 @@ pub async fn handle_sse(State(state): State<AppState>, headers: HeaderMap) -> Re
         state.http_client.clone(),
     );
 
-    if let Err(e) = client.validate().await {
-        tracing::warn!(error = %e, "credential_validation_failed");
-        return unauthorized(
-            "BookStack credentials are invalid or expired — please re-authenticate",
-            &headers,
-            &state.known_urls,
-        );
+    match client.validate().await {
+        CredentialCheck::Valid => {}
+        CredentialCheck::Rejected(e) => {
+            tracing::warn!(error = %e, "credential_validation_rejected");
+            return unauthorized(
+                "BookStack credentials are invalid or expired — please re-authenticate",
+                &headers,
+                &state.known_urls,
+            );
+        }
+        CredentialCheck::Unavailable(e) => {
+            tracing::warn!(error = %e, "credential_validation_unavailable");
+            return upstream_unavailable("BookStack is unreachable — retry shortly");
+        }
     }
 
     let session_id = uuid::Uuid::new_v4().to_string();
@@ -518,13 +546,20 @@ pub async fn handle_streamable(
     let method = request["method"].as_str().unwrap_or("");
 
     if method == "initialize" {
-        if let Err(e) = client.validate().await {
-            tracing::warn!(error = %e, "streamable_credential_validation_failed");
-            return unauthorized(
-                "BookStack credentials are invalid or expired — please re-authenticate",
-                &headers,
-                &state.known_urls,
-            );
+        match client.validate().await {
+            CredentialCheck::Valid => {}
+            CredentialCheck::Rejected(e) => {
+                tracing::warn!(error = %e, "streamable_credential_validation_rejected");
+                return unauthorized(
+                    "BookStack credentials are invalid or expired — please re-authenticate",
+                    &headers,
+                    &state.known_urls,
+                );
+            }
+            CredentialCheck::Unavailable(e) => {
+                tracing::warn!(error = %e, "streamable_credential_validation_unavailable");
+                return upstream_unavailable("BookStack is unreachable — retry shortly");
+            }
         }
     }
 


### PR DESCRIPTION
Closes #139.

## The bug

Not a token-expiry problem. Tokens were already persisted correctly — `access_tokens` / `refresh_tokens`, AES-256-GCM encrypted, 30d/90d wall-clock TTLs, on named volumes that survive restarts. The server was *telling clients* their credentials were bad when it simply couldn't reach BookStack.

`BookStackClient::validate()` was `self.get("books", &[("count","1")])`, which flattened every failure mode into one untyped `Err(String)`:

| Real condition | Old result |
|---|---|
| token revoked (401/403) | `Err("BookStack API error: 401")` |
| BookStack restarting — connection refused | `Err("Request failed")` |
| proxy 502/503/504 | `Err("BookStack API error: 502")` |
| bad `BSMCP_BOOKSTACK_URL` (404) | `Err("BookStack API error: 404")` |
| 429 retries exhausted | `Err("BookStack API error: 429")` |

Every call site read that single `Err` as "credentials are bad". `send_with_retry` only retries 429, so a one-second restart window was enough.

The destructive case was the refresh grant:

```rust
if let Err(e) = bs_client.validate().await {
    state.db.delete_refresh_token(&old_refresh).await.ok();   // valid token, deleted
    return oauth_error(StatusCode::UNAUTHORIZED, "invalid_grant", ...);
}
```

A network blip **permanently deleted a valid 90-day refresh token**, with no recovery path — which is why the symptom presented as "the token expired when BookStack restarted". It really was gone; we deleted it.

## The fix

`validate()` returns a typed `CredentialCheck` instead:

- **`Rejected`** — BookStack answered 401/403. Genuinely bad credentials, re-auth is the fix. Old behavior preserved exactly.
- **`Unavailable`** — transport failure, 5xx, 429, 404. Says nothing about the credentials, so callers return `503` + `Retry-After: 5` and the client keeps its token and retries.

Per call site:

| Site | Before (any failure) | After (`Unavailable`) |
|---|---|---|
| `sse.rs` `handle_sse` (GET) | `401` + `WWW-Authenticate` → full re-auth | `503` + `Retry-After` |
| `sse.rs` `handle_streamable` (`initialize`) | `401` + `WWW-Authenticate` → full re-auth | `503` + `Retry-After` |
| `oauth.rs` refresh grant | **deletes refresh token**, `invalid_grant` | token untouched, `temporarily_unavailable` |
| `oauth.rs` client_credentials | `401 invalid_client` | `temporarily_unavailable` |
| `oauth.rs` authorize form | "Invalid API token" | "Couldn't reach BookStack… try again" |
| `resolve_credentials` | DB error fell through to `401 Invalid or expired token` | `503` + `Retry-After` |

The `WWW-Authenticate` header is the load-bearing detail: under MCP auth it's the explicit instruction to discard the token and re-run OAuth. Withholding it on transient failures is what stops the forced reconnect.

`temporarily_unavailable` is the RFC 6749 §4.1.2.1 code — the token endpoint's standard way to say "not your credentials, retry", distinct from `invalid_grant` which means "your token is dead, start over".

The last row is a bug of the same shape one layer down: a Postgres blip in `resolve_credentials` would have told every connected client its token was invalid simultaneously.

## Testing

Classification is extracted into a pure fn, `CredentialCheck::from_error_status`, with unit tests pinning the contract — 401/403 are the only statuses that may produce `Rejected`; 500/502/503/504/429/404 must stay `Unavailable`.

Gate run locally on `main` @ c3aba64: `cargo check --workspace --all-targets`, `cargo test --workspace` (58 pass in `bsmcp-common`, all suites green), `cargo clippy --workspace --all-targets -- -D warnings` (exit 0), `cargo fmt --all --check` (exit 0).

Manual repro to confirm: connect a client, `docker compose restart bookstack`, issue `initialize` during the window. Before: `401` + re-auth prompt. After: `503`, client retries, session survives.
