### PR TITLE
improvement(ci): sweep workflows and docs onto single `main` — CI has been dark since 2026-07-05

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,8 +1,16 @@
-name: Build Development
+name: Build Main
 
-# Build images on every push to `development`. PR squash-merges arrive
-# as push events and take the same path. There is no PR-time image build
-# and no retag-on-merge step (see issue #96).
+# Build images on every push to `main`. PR squash-merges arrive as push
+# events and take the same path. There is no PR-time image build and no
+# retag-on-merge step (see issue #96).
+#
+# Under the single-`main` model the merge IS the deploy — there is no
+# promote step. The `:dev` tag family below is kept deliberately: the
+# compose files in docker/ and the Portainer stacks pin `:dev`, so
+# renaming the tags here would break every running deployment. The tag
+# name is now a stream label ("the rolling build off main"), not a claim
+# about which branch produced it. Versioned/`:latest` images come from a
+# `v*` tag push via release.yml.
 #
 # `workflow_dispatch` stays as a manual rebuild escape hatch.
 #
@@ -12,7 +20,7 @@ name: Build Development
 
 on:
   push:
-    branches: [development]
+    branches: [main]
   workflow_dispatch:
     inputs:
       reason:
@@ -25,7 +33,7 @@ env:
   REPO_URL: https://github.com/bees-roadhouse/bookstack-mcp
 
 concurrency:
-  group: build-development-${{ github.ref }}
+  group: build-main-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/generate-artifacts.yml
+++ b/.github/workflows/generate-artifacts.yml
@@ -1,24 +1,22 @@
 name: Generate Repo Artifacts
 
 # Regenerates SBOM.md and STRUCTURE.md and commits any diff back to the PR
-# source branch. Fires on the same trigger family as the image build:
-# `pull_request: opened/synchronize/reopened` against development or release.
-# That way the regenerated artifacts are part of the PR being reviewed/merged
-# — not retroactively dropped onto development after the fact.
+# source branch. Fires on `pull_request: opened/synchronize/reopened`
+# against main. That way the regenerated artifacts are part of the PR being
+# reviewed/merged — not retroactively dropped onto main after the fact.
 #
 # The re-fire loop is broken by `paths-ignore: [SBOM.md, STRUCTURE.md]` on
 # the `pull_request` trigger below — the auto-commit only touches those two
 # files, so the trigger doesn't fire again. No `[skip ci]` keyword in the
-# commit message: it inherits through squash-merge bodies into the release-
-# branch push event and can suppress `release.yml`'s github-release-on-merge
-# job (issue #73).
+# commit message: it inherits through squash-merge bodies into the push
+# event on main and can suppress the image build (issue #73).
 #
 # For external fork PRs, GITHUB_TOKEN cannot push back to the fork; the
 # job is skipped in that case (the contributor regenerates locally).
 
 on:
   pull_request:
-    branches: [development, release]
+    branches: [main]
     types: [opened, synchronize, reopened]
     paths-ignore:
       - 'SBOM.md'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,26 +2,27 @@ name: Release
 
 # Release-stream concerns. Triggers:
 #
-#   1. push: release          → build and push the release-stream images
-#                               (`:{version}`, `:{version}-{sha}`, `:release`,
-#                               `:latest`), create the v{version} GitHub
-#                               Release entry, attach native bsmcp-server
-#                               binaries for 5 targets.
+#   1. push: tag v*           → build and push the release-stream images
+#                               (`:{version}`, `:{version}-{sha}`,
+#                               `:release`, `:latest`), create the
+#                               v{version} GitHub Release entry, attach
+#                               native bsmcp-server binaries for 5 targets.
 #
-#   2. push: tag v*           → emergency hotfix path. Builds and pushes
-#                               semver-tagged images directly, then
-#                               creates the matching GitHub Release.
-#                               Use only when the normal release flow
-#                               (PR development → release, then merge)
-#                               isn't available — typically because a
-#                               regression on `release` needs a bypass.
+#   2. workflow_dispatch      → manual recovery path.
 #
-#   3. workflow_dispatch       → manual recovery path.
+# Under the single-`main` model (org migration 2026-07-05) there is no
+# `release` branch to push to, so a `v*` tag IS the release trigger — not
+# the emergency bypass it used to be. Cutting a release is:
+#
+#   git tag v0.14.0 && git push origin v0.14.0
+#
+# The tag must match the workspace version in Cargo.toml; tag-release
+# fails the run if it doesn't.
 #
 # verify-pr.yml is the PR-time gating workflow (cargo test/clippy).
-# build-development.yml is the development-stream image builder. This
-# workflow owns the release stream end-to-end (build + release entry +
-# native binaries).
+# build-main.yml is the rolling image builder off `main` (the `:dev` tag
+# family). This workflow owns the release stream end-to-end (build +
+# release entry + native binaries).
 #
 # Canonical references:
 #   https://kb.beesroadhouse.com/books/developer-operations-devops/page/docker-image-build-workflows (1905)
@@ -29,7 +30,6 @@ name: Release
 
 on:
   push:
-    branches: [release]
     tags:
       - 'v*'
   workflow_dispatch:
@@ -38,279 +38,8 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  # Image build on push: release. Builds + pushes the release-stream
-  # tags (:{version}, :{version}-{sha}, :release, :latest). Pinned to
-  # ubuntu-latest; no self-hosted dependency.
-  build-release-images:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: bsmcp-server
-            dockerfile: docker/Dockerfile.server
-            scope: server
-          - image: bsmcp-embedder
-            dockerfile: docker/Dockerfile.embedder
-            scope: embedder
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Resolve version + sha
-        id: vars
-        run: |
-          set -euo pipefail
-          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
-          SHORT_SHA=${GITHUB_SHA:0:7}
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}:${{ steps.vars.outputs.version }}
-            ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.short_sha }}
-            ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}:release
-            ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}:latest
-          labels: |
-            org.opencontainers.image.source=https://github.com/bees-roadhouse/bookstack-mcp
-            org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha,scope=${{ matrix.scope }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.scope }}
-
-  # Transition alias for v0.13.0 ONLY (closes #56). The standalone
-  # bsmcp-worker image is dropped from the build matrix in v0.13.0; this
-  # job publishes `ghcr.io/bees-roadhouse/bsmcp-worker:<tag>` as an
-  # additional name pointing at the same `bsmcp-embedder:<tag>` manifest
-  # so existing compose files keep pulling without a hard break.
-  #
-  # `docker buildx imagetools create` preserves the multi-arch manifest
-  # list (linux/amd64 + linux/arm64) — it's a registry-side rewrite, no
-  # rebuild needed.
-  #
-  # **Delete this job in v0.14.0.** Operators get one release cycle to
-  # update their compose files; after that, `bsmcp-worker:<tag>` will 404.
-  alias-worker-to-embedder:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-    needs: [build-release-images]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Resolve version + sha
-        id: vars
-        run: |
-          set -euo pipefail
-          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
-          SHORT_SHA=${GITHUB_SHA:0:7}
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Tag embedder as worker (transition alias)
-        run: |
-          set -euo pipefail
-          VERSION="${{ steps.vars.outputs.version }}"
-          SHORT_SHA="${{ steps.vars.outputs.short_sha }}"
-          for TAG in "${VERSION}" "${VERSION}-${SHORT_SHA}" "release" "latest"; do
-            echo "Aliasing bsmcp-worker:${TAG} -> bsmcp-embedder:${TAG}"
-            docker buildx imagetools create \
-              -t "${{ env.REGISTRY }}/bees-roadhouse/bsmcp-worker:${TAG}" \
-              "${{ env.REGISTRY }}/bees-roadhouse/bsmcp-embedder:${TAG}"
-          done
-
-  # GitHub Release entry on push: release. Runs in parallel with
-  # build-release-images (the Release body references tags by name, which
-  # resolve to manifests when users pull). Creates the v{version} git
-  # tag (if missing) and the GitHub Release entry; release-binaries-on-
-  # merge attaches native binaries.
-  github-release-on-merge:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: write
-    outputs:
-      tag: ${{ steps.vars.outputs.tag }}
-      version: ${{ steps.vars.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Resolve version + tag
-        id: vars
-        run: |
-          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *"\(.*\)"/\1/')
-          TAG="v${VERSION}"
-          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
-            NEEDS_TAG=false
-          else
-            NEEDS_TAG=true
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "needs_tag=${NEEDS_TAG}" >> "$GITHUB_OUTPUT"
-
-      - name: Create and push tag
-        if: steps.vars.outputs.needs_tag == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.vars.outputs.tag }}" -m "Release ${{ steps.vars.outputs.tag }}"
-          git push origin "${{ steps.vars.outputs.tag }}"
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: bookstack-mcp ${{ steps.vars.outputs.tag }}
-          tag_name: ${{ steps.vars.outputs.tag }}
-          generate_release_notes: true
-          body: |
-            ## Container images
-
-            ```
-            docker pull ghcr.io/bees-roadhouse/bsmcp-server:${{ steps.vars.outputs.version }}
-            docker pull ghcr.io/bees-roadhouse/bsmcp-embedder:${{ steps.vars.outputs.version }}
-            ```
-
-            Or pin to the rolling release tag:
-
-            ```
-            docker pull ghcr.io/bees-roadhouse/bsmcp-server:release
-            docker pull ghcr.io/bees-roadhouse/bsmcp-embedder:release
-            ```
-
-            > **Breaking change (v0.13.0):** `bsmcp-worker` was folded into `bsmcp-embedder`. The embedder image now accepts `--role={embedder|worker|both}` (CLI flag, primary) or `BSMCP_ROLE` (env fallback); default is `embedder`. For one release only, `ghcr.io/bees-roadhouse/bsmcp-worker:<tag>` is published as a registry alias of `ghcr.io/bees-roadhouse/bsmcp-embedder:<tag>` so existing compose files keep pulling. The alias is removed in v0.14.0. See the README's "From v0.12.x to v0.13.0" entry for compose changes.
-
-            ## Native binaries (`bsmcp-server` only)
-
-            Server binaries for common platforms are attached below. The embedder is not released as a bare binary because of its ONNX Runtime dependency — use the container image instead.
-
-  release-binaries-on-merge:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-    needs: [github-release-on-merge]
-    timeout-minutes: 60
-    permissions:
-      contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-22.04
-            archive: tar.gz
-          - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-22.04
-            archive: tar.gz
-            cross: true
-          # Cross-compiled from the Apple-Silicon runner. macos-13 (Intel)
-          # stalls indefinitely at `cargo build` here; macos-14 + the
-          # x86_64-apple-darwin rustup target builds it in minutes. The
-          # macOS SDK ships both arch slices, so cc/openssl-src/bundled
-          # SQLite cross-compile with no extra linker config.
-          - target: x86_64-apple-darwin
-            runner: macos-14
-            archive: tar.gz
-          - target: aarch64-apple-darwin
-            runner: macos-14
-            archive: tar.gz
-          - target: x86_64-pc-windows-msvc
-            runner: windows-2022
-            archive: zip
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Install cross-compilation toolchain (Linux aarch64 only)
-        if: matrix.cross == true
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          mkdir -p .cargo
-          cat >> .cargo/config.toml <<EOF
-          [target.aarch64-unknown-linux-gnu]
-          linker = "aarch64-linux-gnu-gcc"
-          EOF
-          # openssl-src (vendored) and cc-rs need to know which compiler/archiver
-          # to use for the target arch. Without this, openssl-src builds host-arch
-          # binaries that link-error against the aarch64 linker output. The
-          # `_aarch64_unknown_linux_gnu` suffix matches cargo's TARGET triple
-          # underscore form (per cc-rs env var convention).
-          {
-            echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc"
-            echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++"
-            echo "AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar"
-          } >> "$GITHUB_ENV"
-
-      - name: Build server binary
-        run: cargo build --release --locked --target ${{ matrix.target }} -p bsmcp-server
-
-      - name: Package archive (tar.gz)
-        if: matrix.archive == 'tar.gz'
-        run: |
-          STAGE=bsmcp-server-${{ needs.github-release-on-merge.outputs.tag }}-${{ matrix.target }}
-          mkdir "$STAGE"
-          cp target/${{ matrix.target }}/release/bsmcp-server "$STAGE/"
-          cp README.md LICENSE "$STAGE/" 2>/dev/null || true
-          tar czf "$STAGE.tar.gz" "$STAGE"
-          echo "ARCHIVE=$STAGE.tar.gz" >> "$GITHUB_ENV"
-
-      - name: Package archive (zip)
-        if: matrix.archive == 'zip'
-        shell: pwsh
-        run: |
-          $stage = "bsmcp-server-${{ needs.github-release-on-merge.outputs.tag }}-${{ matrix.target }}"
-          New-Item -ItemType Directory -Path $stage | Out-Null
-          Copy-Item "target/${{ matrix.target }}/release/bsmcp-server.exe" "$stage/"
-          if (Test-Path README.md) { Copy-Item README.md "$stage/" }
-          if (Test-Path LICENSE) { Copy-Item LICENSE "$stage/" }
-          Compress-Archive -Path $stage -DestinationPath "$stage.zip"
-          "ARCHIVE=$stage.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Attach archive to GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.github-release-on-merge.outputs.tag }}
-          files: ${{ env.ARCHIVE }}
-
-  # Emergency hotfix path: a `v*` tag was pushed directly. Build the
-  # semver-tagged images and create the GitHub Release. Pinned to
-  # ubuntu-latest; no self-hosted dependency.
+  # A `v*` tag was pushed. Build the semver-tagged images and create the
+  # GitHub Release. Pinned to ubuntu-latest; no self-hosted dependency.
   tag-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -1,15 +1,15 @@
 name: Verify PR
 
 # PR-time gating signal: cargo check + cargo clippy + cargo test on
-# ubuntu-latest. Image builds run out-of-band on push to development /
-# release (build-development.yml / release.yml). This workflow is the
+# ubuntu-latest. Image builds run out-of-band on push to main
+# (build-main.yml) and on v* tags (release.yml). This workflow is the
 # "does it compile, lint, test" gate — not "does the image build."
 #
 # Pinned to GitHub-hosted runners. No self-hosted dependency.
 
 on:
   pull_request:
-    branches: [development, release]
+    branches: [main]
     types: [opened, synchronize, reopened]
 
 concurrency:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,11 +56,12 @@ docker compose -f docker/docker-compose.sqlite.yml up -d
 
 The canonical reference for the org-wide branching standard is the [Branching Strategy](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) page in the Bee's Roadhouse DevOps book. This file mirrors the policy that applies to this repo specifically.
 
-- `development` — default branch; all active work lands here. **PR required** (org-level `Default Branch Protection` ruleset: 1 approving review, thread resolution, no force-push, no deletion). PR merges trigger CI build/package.
-- `release` — stable/production; merged from development when ready to ship. PR required (org-level `Release Branch Protection` ruleset: 1 approving review, merge-commit only, no force-push, no deletion).
+- `main` — the default branch and the only long-lived one. All work lands here by PR. **PR required** (org-level `Default Branch Protection` ruleset, targeting `~DEFAULT_BRANCH`: 0 required approvals as of 2026-05-25, thread resolution, no force-push, no deletion). Merging to `main` publishes the rolling `:dev` image family.
 - Work branches use the four-prefix taxonomy below.
 
-No `main` or `master` branches exist.
+No `development`, `release`, or `master` branches exist. **Merging to `main` is the release** for the rolling stream — there is no promote step. Versioned releases are cut by pushing a `v*` tag.
+
+The org moved off the `development` / `release` model on **2026-07-05**; this repo's workflows and this file were swept to match on 2026-08-11.
 
 ### Work branch prefixes
 
@@ -76,18 +77,27 @@ Breaking changes are orthogonal to type — prefix the **PR title** with `BREAKI
 ### Workflow
 
 ```
-1. git checkout development && git pull
+1. git checkout main && git pull
 2. git checkout -b improvement/my-change      # or feature/, refactor/, bug/
 3. ... commit work (signed via SSH; see Commit Signing below) ...
 4. git push -u origin improvement/my-change
-5. Open PR against development; apply the matching type: + category: labels
+5. Open PR against main; apply the matching type: + category: labels
 6. CI runs verify-pr.yml (cargo test + clippy) and generate-artifacts.yml (SBOM/STRUCTURE auto-commit)
-7. Squash-merge PR into development; delete the work branch
-8. build-development.yml builds + pushes the :dev family of image tags
-9. When ready to ship: open PR from development -> release
+7. Squash-merge PR into main; delete the work branch
+8. build-main.yml builds + pushes the :dev family of image tags
 ```
 
-All changes go through a PR — direct pushes are blocked by the org ruleset (returns `GH013`). For CI emergencies (workflow-bootstrap gap, broken build), use `workflow_dispatch` on `build-development.yml` rather than bypassing the ruleset. Org admins can `gh pr merge --admin` for bootstrap PRs and small docs touchups, but `--admin` still routes through the PR machinery (CI runs, audit trail preserved) — it is not a direct push.
+There is no step 9. The merge is the deploy — any Portainer git stack tracking `main` picks the new image up on its next poll.
+
+To cut a versioned release, bump the workspace version in a normal PR, then tag the merge commit:
+
+```bash
+git tag v0.14.0 && git push origin v0.14.0
+```
+
+`release.yml` fires on the tag: multi-arch `:{version}` / `:{version}-{sha}` / `:release` / `:latest` images, the GitHub Release entry, and native `bsmcp-server` binaries for 5 targets. The tag must match the `Cargo.toml` workspace version or the run fails.
+
+All changes go through a PR — direct pushes are blocked by the org ruleset (returns `GH013`). For CI emergencies (workflow-bootstrap gap, broken build), use `workflow_dispatch` on `build-main.yml` rather than bypassing the ruleset. Org admins can `gh pr merge --admin` for bootstrap PRs and small docs touchups, but `--admin` still routes through the PR machinery (CI runs, audit trail preserved) — it is not a direct push.
 
 ## CI/CD
 
@@ -96,7 +106,9 @@ Build-on-merge pattern. Reference docs:
 - BR DevOps [Docker Image Build Workflows (1905)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/docker-image-build-workflows) — canonical trigger / tag / cache shape.
 - BR DevOps [Branching Strategy (1860)](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) — branch model and direct-push authorization.
 
-**PR-time gating is fast (cargo test + clippy). Images build on merge.** PRs trigger `verify-pr.yml` — `cargo check`, `cargo clippy`, `cargo test --workspace` — on `ubuntu-latest`. No image build on PRs. After squash-merge, `build-development.yml` (push to `development`) or `release.yml` (push to `release` / `v*` tag) builds + pushes the appropriate multi-arch image set. All builds run on GitHub-hosted `ubuntu-latest` — no self-hosted dependency.
+**PR-time gating is fast (cargo test + clippy). Images build on merge.** PRs trigger `verify-pr.yml` — `cargo check`, `cargo clippy`, `cargo test --workspace` — on `ubuntu-latest`. No image build on PRs. After squash-merge, `build-main.yml` (push to `main`) builds + pushes the rolling `:dev` image family; `release.yml` (push of a `v*` tag) builds + pushes the versioned `:latest` / `:release` set. All builds run on GitHub-hosted `ubuntu-latest` — no self-hosted dependency.
+
+The `:dev` tag name predates the single-`main` migration and is kept deliberately: `docker/docker-compose.yml`, `docker/docker-compose.sqlite.yml`, and the Portainer stacks all pin `:dev`. It now means "the rolling build off `main`", not "built from a development branch".
 
 ### Contributor flow (per PR)
 
@@ -105,8 +117,8 @@ Build-on-merge pattern. Reference docs:
 2. ... commit work, sign each commit ...
 3. git push -u origin improvement/my-change
 4. Open PR; verify-pr.yml runs cargo test + clippy
-5. Squash-merge into development; delete the work branch
-6. build-development.yml builds + pushes :dev / :{version}-dev family of tags
+5. Squash-merge into main; delete the work branch
+6. build-main.yml builds + pushes :dev / :{version}-dev family of tags
 ```
 
 No local image build needed. `scripts/publish-pr-image.sh` is still in the repo as an out-of-band escape hatch when CI is unavailable, but it's not part of the normal flow.
@@ -124,12 +136,11 @@ Both Dockerfiles use BuildKit `--mount=type=cache` for `target/`, `~/.cargo/regi
 | Event | Workflow | What happens |
 |-------|----------|-------------|
 | Push to a work branch with **no open PR** | nothing | test locally |
-| `pull_request: opened/synchronize/reopened` against `development` or `release` | `verify-pr.yml` | `cargo check` + `cargo clippy -- -D warnings` + `cargo test --workspace` on `ubuntu-latest`. Fast, image-free. |
+| `pull_request: opened/synchronize/reopened` against `main` | `verify-pr.yml` | `cargo check` + `cargo clippy -- -D warnings` + `cargo test --workspace` on `ubuntu-latest`. Fast, image-free. |
 | Same trigger | `generate-artifacts.yml` | regenerates `SBOM.md` + `STRUCTURE.md`, commits to PR source branch (re-fire loop broken by `paths-ignore`). SBOM/STRUCTURE conflicts on rebase resolve via `merge=ours` in `.gitattributes`. |
-| `push` to `development` (PR-merge commit or otherwise) | `build-development.yml` | multi-arch build + push of all three images on `ubuntu-latest`. Tags: `:dev`, `:dev-{sha}`, `:{version}-dev`, `:{version}-dev-{sha}`. |
-| `workflow_dispatch` on `build-development.yml` | `build-development.yml` | manual rebuild at the current `development` HEAD. Same tag set as the push trigger. |
-| `push` to `release` (always a PR-merge from development) | `release.yml` (`build-release-images` + `github-release-on-merge` + `release-binaries-on-merge`) | builds + pushes `:{version}` / `:{version}-{sha}` / `:release` / `:latest` on `ubuntu-latest`; creates the `v{version}` git tag and GitHub Release entry; builds `bsmcp-server` native binaries for 5 targets and attaches them. |
-| `v*` tag push (emergency hotfix only) | `release.yml` (`tag-release` + `github-release-on-tag` + `release-binaries-on-tag`) | builds & pushes semver-tagged images on `ubuntu-latest`, creates the Release, attaches the server binaries. Use only when the normal PR flow isn't available. |
+| `push` to `main` (PR-merge commit or otherwise) | `build-main.yml` | multi-arch build + push of both images on `ubuntu-latest`. Tags: `:dev`, `:dev-{sha}`, `:{version}-dev`, `:{version}-dev-{sha}`. |
+| `workflow_dispatch` on `build-main.yml` | `build-main.yml` | manual rebuild at the current `main` HEAD. Same tag set as the push trigger. |
+| `v*` tag push | `release.yml` (`tag-release` + `alias-worker-to-embedder-on-tag` + `github-release-on-tag` + `release-binaries-on-tag`) | builds + pushes `:{version}` / `:{version}-{sha}` / `:release` / `:latest` on `ubuntu-latest`; creates the GitHub Release entry; builds `bsmcp-server` native binaries for 5 targets and attaches them. **This is the release mechanism** — there is no release branch. |
 | `workflow_dispatch` on `release.yml` | `release.yml` | manual recovery path for the release stream |
 
 ### Why this shape
@@ -143,13 +154,15 @@ Both Dockerfiles use BuildKit `--mount=type=cache` for `target/`, `~/.cargo/regi
 
 No per-PR image tag. PRs don't build images. Commit-level pinning during review is unnecessary — the PR's source tree IS the artifact to review; reviewers can `cargo build` locally if they want to test.
 
-Development stream (pushed by `build-development.yml` on push to `development`):
-- `dev` — rolling, latest dev build
+Rolling stream (pushed by `build-main.yml` on push to `main`). The `dev`
+prefix is historical — these are builds off `main`, not off a development
+branch — and is kept because the compose files and Portainer stacks pin it:
+- `dev` — rolling, latest build off `main`
 - `dev-{sha}` — immutable per-commit
-- `{version}-dev` — version-level dev rolling
-- `{version}-dev-{sha}` — version-level dev immutable
+- `{version}-dev` — version-level rolling
+- `{version}-dev-{sha}` — version-level immutable
 
-Release stream (pushed by `release.yml`'s `build-release-images` on push to `release`):
+Release stream (pushed by `release.yml`'s `tag-release` on a `v*` tag push):
 - `latest` — rolling, latest release
 - `release` — alias for `latest`
 - `{version}` — pinned semver (e.g., `0.11.0`)
@@ -200,7 +213,7 @@ Default semver bump per branch prefix (override with `BREAKING:` in the PR title
 - `refactor/*` — patch (minor if external behavior changes)
 - `bug/*` — patch
 
-Release: open PR from development -> release. The release-merge fires `build-release-images` (builds + pushes `:{version}` / `:release` / `:latest`) and `github-release-on-merge` (creates the GitHub Release with native binaries).
+Release: bump the workspace version in a normal PR to `main`, then tag the merge commit — `git tag v0.14.0 && git push origin v0.14.0`. The tag fires `tag-release` (builds + pushes `:{version}` / `:release` / `:latest`) and `github-release-on-tag` (creates the GitHub Release with native binaries). The tag must match the `Cargo.toml` version or the run fails.
 
 ## Testing
 

--- a/scripts/publish-pr-image.sh
+++ b/scripts/publish-pr-image.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Optional, vestigial. CI builds images on push to development / release
-# via build-development.yml / release.yml — there is no PR-time image
-# build and no per-PR tag in the current model. This script tags images
+# Optional, vestigial. CI builds images on push to main via build-main.yml
+# and on `v*` tags via release.yml — there is no PR-time image build and
+# no per-PR tag in the current model. This script tags images
 # with `{version}-{slug}` / `{version}-{slug}-{sha}` for local
 # experimentation only; nothing in the normal flow consumes those tags.
 #
@@ -10,10 +10,10 @@
 #   - Reproducing a specific tree's image locally for debugging.
 #
 # For "emergency rebuild when CI is broken" use `workflow_dispatch` on
-# build-development.yml instead — it produces the canonical :dev tags.
+# build-main.yml instead — it produces the canonical :dev tags.
 #
-# Path-aware fast path: when the branch's diff against `origin/development`
-# (or `origin/release` when targeting that) doesn't touch any file that
+# Path-aware fast path: when the branch's diff against `origin/main`
+# doesn't touch any file that
 # affects a given binary, we skip the rebuild and instead retag the
 # latest published `:dev` image as the per-PR tags. Tag-only ops are
 # free; full builds on linux/arm64 take 15+ minutes.
@@ -65,18 +65,17 @@ if ! docker buildx version >/dev/null 2>&1; then
   exit 1
 fi
 
-# Resolve the merge-base ref to diff against. PRs typically target
-# `development`; the release flow targets `release`. We pick whichever
-# remote ref is reachable from HEAD with the shortest history — falls
-# back to development when neither is local.
+# Resolve the merge-base ref to diff against. Under single `main` every
+# PR targets `main`, so there is only one candidate — the loop is kept so
+# a clone without the remote ref still gets a sane fallback.
 resolve_diff_base() {
-  for candidate in origin/development origin/release; do
+  for candidate in origin/main; do
     if git rev-parse --verify "$candidate" >/dev/null 2>&1; then
       echo "$candidate"
       return 0
     fi
   done
-  echo "origin/development"
+  echo "origin/main"
 }
 
 DIFF_BASE=$(resolve_diff_base)
@@ -200,17 +199,17 @@ for arg in "$@"; do
   esac
 done
 
-# Auto-force a real build when publishing directly from development or
-# release. The path-aware fast path's retag-from-dev mode is correct for
+# Auto-force a real build when publishing directly from `main`. The
+# path-aware fast path's retag-from-dev mode is correct for
 # PR work (the merge commit's tree matches the PR head, and the
 # contributor's per-PR image is the right artifact), but for a direct
-# push to development/release we want the resulting image's
+# push to main we want the resulting image's
 # `org.opencontainers.image.revision` label to match the SHA actually
 # being pushed — otherwise label-SHA and tag-SHA can drift on pure
 # CI/docs commits that piggyback an existing image. Always rebuild on
-# the canonical branches; keep the fast path for everything else.
+# the canonical branch; keep the fast path for everything else.
 case "$BRANCH" in
-  development|release)
+  main)
     if [ "$FORCE_REBUILD" != "1" ]; then
       echo "Branch=$BRANCH: forcing rebuild so the image's revision label matches the push SHA."
       echo


### PR DESCRIPTION
## Why

The org migrated to single `main` on **2026-07-05**, and the [Branching Strategy](https://kb.beesroadhouse.com/books/developer-operations-devops/page/branching-strategy) page was rewritten to match on 2026-07-25. This repo never got the sweep.

Consequence: **CI has been completely dark.** Every workflow keys off `development` / `release`, neither of which exists on origin. The last workflow run of any kind was 2026-07-05. PR #140 (the #139 auth fix) merged yesterday with **zero checks**, and no image was built — the fix is on `main` but was never shipped.

The canonical page already prescribes the fix:

> Repos still carrying separate dev-stream and release-stream workflows from the two-branch era now fire both off `main`; consolidating them is per-repo cleanup, not a policy question.

## Triggers retargeted

| Workflow | Before | After |
|---|---|---|
| `verify-pr.yml` | `pull_request: [development, release]` | `pull_request: [main]` |
| `generate-artifacts.yml` | `pull_request: [development, release]` | `pull_request: [main]` |
| `build-development.yml` → `build-main.yml` | `push: [development]` | `push: [main]` |
| `release.yml` | `push: [release]` + `tags: v*` | `tags: v*` only |

`release.yml` carried two parallel halves — four jobs gated on `refs/heads/release` and four on `refs/tags/v*`. The release-branch half is deleted (309 lines); the tag half is unchanged and promoted from "emergency hotfix path" to **the** release mechanism. No dangling `needs:` refs — verified. Cutting a release is now:

```bash
git tag v0.14.0 && git push origin v0.14.0
```

`tag-release` still fails the run if the tag doesn't match the `Cargo.toml` workspace version.

## The `:dev` tags are deliberately unchanged

`docker/docker-compose.yml`, `docker/docker-compose.sqlite.yml`, and the Portainer stacks all pin `:dev`. Renaming the tag family to match the new branch name would break every running deployment for a cosmetic gain. The name is now a stream label — "the rolling build off `main`" — and `DEVELOPMENT.md` says so explicitly rather than leaving it to be inferred.

## Docs and scripts

`DEVELOPMENT.md` stated *"No `main` or `master` branches exist"* — wrong on every point. Swept: the branching section, the workflow steps, the what-runs-on-what table, the GHCR tag conventions, and the versioning/release section.

`scripts/publish-pr-image.sh` was not just stale comments — it had **live logic** on dead refs: `resolve_diff_base()` diffed against `origin/development` / `origin/release` (falling back to `origin/development`, which doesn't resolve), and a `case "$BRANCH" in development|release)` force-rebuild guard that could never match. Both now point at `main`.

## Verification

All four workflow files parse (`yaml.safe_load`) with the expected trigger and job sets. `bash -n` clean on the script. No functional references to `development` / `release` remain in `.github/` or `scripts/`.

**This PR is its own test:** it targets `main`, so if `verify-pr.yml` and `generate-artifacts.yml` report checks here, the retarget works. If no checks appear, the fix is wrong. That's the acceptance criterion.

Follow-ups, not in scope here:
- Four other BR repos carry the same stale triggers: `container-management`, `immichsync`, `zibaladone`, `scoutarr`.
- Three KB pages still describe the two-branch model and contradict the (correct) Branching Strategy page: Docker Image Tagging Strategy (1862), Docker Image Build Workflows (1905), Change Lifecycle (1991) — all last updated 2026-05-23, before the migration.
