### PR TITLE
bug(transport,mcp): stop bsmcp-server overloading BookStack — session cap + initialize fan-out (closes #138, closes #143)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,10 @@ BSMCP_PUBLIC_DOMAIN=bookstack-mcp.example.com
 # BSMCP_PORT=8080
 # BSMCP_INSTANCE_NAME=My Knowledge Base
 # BSMCP_INSTANCE_DESC=Personal knowledge base
+# Per-token cap on concurrent legacy SSE sessions (default 5). Raise it if one
+# BookStack API token is shared by several MCP clients on the same host. Values
+# that are zero or unparseable fall back to the default.
+# BSMCP_MAX_SESSIONS_PER_TOKEN=5
 # BSMCP_BACKUP_INTERVAL=24
 # BSMCP_BACKUP_PATH=/data/backups
 # PUID=1000

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,11 @@ BSMCP_PUBLIC_DOMAIN=bookstack-mcp.example.com
 # BookStack API token is shared by several MCP clients on the same host. Values
 # that are zero or unparseable fall back to the default.
 # BSMCP_MAX_SESSIONS_PER_TOKEN=5
+# TTL for the `initialize` structure blurb, cached per instance + API token
+# (default 60s). Without it every client connect re-enumerates the whole shelf
+# tree, roughly one API call per shelf. Set 0 to disable. Tool responses are
+# never cached, so list_shelves/get_shelf always hit BookStack live.
+# BSMCP_STRUCTURE_CACHE_TTL_SECS=60
 # BSMCP_BACKUP_INTERVAL=24
 # BSMCP_BACKUP_PATH=/data/backups
 # PUID=1000

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-common"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-postgres"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-sqlite"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-embedder"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-server"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.13.0"
+version = "0.13.1"
 
 [workspace.dependencies]
 # Structured logging. `json` feature enables the JSON output mode that

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The server is pure Rust + bundled SQLite and builds cleanly on any target the Ru
 | `BSMCP_BACKUP_INTERVAL` | No | - | Hours between backups (0 = disabled) |
 | `BSMCP_BACKUP_PATH` | No | `/data/backups` | Backup directory |
 | `BSMCP_BOOKSTACK_RATE_LIMIT_PER_MIN` | No | `180` | Per-process BookStack API request cap. Lower if multiple processes share a token and you see 429s. |
+| `BSMCP_MAX_SESSIONS_PER_TOKEN` | No | `5` | Concurrent legacy SSE sessions allowed per API token. Raise it when one token is shared by several MCP clients on a host. Zero or unparseable values fall back to the default. |
 
 #### Embedder Variables
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The server is pure Rust + bundled SQLite and builds cleanly on any target the Ru
 | `BSMCP_BACKUP_PATH` | No | `/data/backups` | Backup directory |
 | `BSMCP_BOOKSTACK_RATE_LIMIT_PER_MIN` | No | `180` | Per-process BookStack API request cap. Lower if multiple processes share a token and you see 429s. |
 | `BSMCP_MAX_SESSIONS_PER_TOKEN` | No | `5` | Concurrent legacy SSE sessions allowed per API token. Raise it when one token is shared by several MCP clients on a host. Zero or unparseable values fall back to the default. |
+| `BSMCP_STRUCTURE_CACHE_TTL_SECS` | No | `60` | How long the `initialize` structure blurb is cached, per instance + API token. Without it every client connect re-enumerates the whole shelf tree (~1 API call per shelf). `0` disables caching. Tool responses are never cached. |
 
 #### Embedder Variables
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The server is pure Rust + bundled SQLite and builds cleanly on any target the Ru
 | `BSMCP_BACKUP_PATH` | No | `/data/backups` | Backup directory |
 | `BSMCP_BOOKSTACK_RATE_LIMIT_PER_MIN` | No | `180` | Per-process BookStack API request cap. Lower if multiple processes share a token and you see 429s. |
 | `BSMCP_MAX_SESSIONS_PER_TOKEN` | No | `5` | Concurrent legacy SSE sessions allowed per API token. Raise it when one token is shared by several MCP clients on a host. Zero or unparseable values fall back to the default. |
-| `BSMCP_STRUCTURE_CACHE_TTL_SECS` | No | `60` | How long the `initialize` structure blurb is cached, per instance + API token. Without it every client connect re-enumerates the whole shelf tree (~1 API call per shelf). `0` disables caching. Tool responses are never cached. |
+| `BSMCP_STRUCTURE_CACHE_TTL_SECS` | No | `60` | How long the `initialize` structure blurb is cached, per instance + API token. Without it every client connect re-enumerates the whole shelf tree (~1 API call per shelf). `0` disables caching. Tool responses are never cached, and a sweep that hit upstream errors is never cached. The cache is per process, so at N replicas expect the hit rate to divide by N. |
 
 #### Embedder Variables
 

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -3722,16 +3722,25 @@ mod lifecycle_tests {
     use super::*;
     use bsmcp_common::db::{IndexDb, SemanticDb};
     use std::env;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Bumped per `temp_db()` call. pid + wall-clock alone is not unique
+    /// inside one test binary: these tests run in parallel, and two that call
+    /// `temp_db()` within the same clock tick got the same path and silently
+    /// shared a database, which made the job-lifecycle assertions flaky. The
+    /// timestamp still separates one `cargo test` run from the next.
+    static TEMP_DB_SEQ: AtomicU64 = AtomicU64::new(0);
 
     fn temp_db() -> SqliteDb {
         let dir = env::temp_dir();
         let unique = format!(
-            "bsmcp-test-{}-{}.db",
+            "bsmcp-test-{}-{}-{}.db",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            TEMP_DB_SEQ.fetch_add(1, Ordering::Relaxed)
         );
         let path = dir.join(unique);
         SqliteDb::open(&path, "test-encryption-key-thirty-two-chars-long")

--- a/crates/bsmcp-server/src/main.rs
+++ b/crates/bsmcp-server/src/main.rs
@@ -225,6 +225,13 @@ async fn main() {
         "timezone_resolved"
     );
 
+    // Per-token cap on concurrent legacy SSE sessions (issue #138). Streamable
+    // notification GETs no longer consume a slot, but a host running several
+    // MCP clients on one BookStack token can still want more headroom than the
+    // default 5.
+    let max_sessions_per_token = sse::max_sessions_per_token_from_env();
+    tracing::info!(max_sessions_per_token, "session_cap_resolved");
+
     let state = sse::AppState::new(
         bookstack_url,
         db,
@@ -234,6 +241,7 @@ async fn main() {
         backup_path,
         semantic,
         timezone,
+        max_sessions_per_token,
     );
     state.spawn_cleanup();
     state.spawn_backup();

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::env;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
 
@@ -1994,7 +1995,77 @@ async fn build_instructions(client: &BookStackClient, semantic_enabled: bool) ->
     instructions
 }
 
+const DEFAULT_STRUCTURE_CACHE_TTL_SECS: u64 = 60;
+
+/// Rendered `build_structure` output, keyed by BookStack instance + API token
+/// and stamped with the time it was built.
+///
+/// Every MCP `initialize` runs `build_instructions` → `build_structure`, which
+/// costs one `list_shelves`, one `get_shelf` *per shelf*, and one
+/// `list_chapters`. On an instance with ~24 shelves that is ~26 BookStack API
+/// calls per client connect, and every reconnect re-runs the whole sweep.
+/// Measured on a live instance: 1326 `/api/shelves/{id}` calls in one hour,
+/// all from this server, which saturated BookStack's php-fpm pool
+/// (`pm.max_children = 5`) and starved its liveness probe into a restart loop.
+///
+/// The key MUST carry the token id. Shelf visibility is per-token, so a
+/// globally-keyed cache would serve one caller's structure to another —
+/// trading a load bug for a permissions bug.
+static STRUCTURE_CACHE: OnceLock<Mutex<HashMap<String, (Instant, String)>>> = OnceLock::new();
+
+/// `BSMCP_STRUCTURE_CACHE_TTL_SECS`, default 60. Zero disables caching, so an
+/// operator who needs the structure blurb to reflect a write immediately has a
+/// lever without a redeploy.
+fn structure_cache_ttl() -> Duration {
+    let secs = env::var("BSMCP_STRUCTURE_CACHE_TTL_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_STRUCTURE_CACHE_TTL_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Instance + token. See [`STRUCTURE_CACHE`] on why the token id is load-bearing.
+fn structure_cache_key(base_url: &str, token_id: &str) -> String {
+    format!("{base_url}|{token_id}")
+}
+
+fn cached_structure(key: &str, ttl: Duration) -> Option<String> {
+    if ttl.is_zero() {
+        return None;
+    }
+    let guard = STRUCTURE_CACHE.get_or_init(Default::default).lock().ok()?;
+    let (built_at, structure) = guard.get(key)?;
+    (built_at.elapsed() < ttl).then(|| structure.clone())
+}
+
+fn store_structure(key: &str, structure: &str, ttl: Duration) {
+    if ttl.is_zero() {
+        return;
+    }
+    let Ok(mut guard) = STRUCTURE_CACHE.get_or_init(Default::default).lock() else {
+        return;
+    };
+    // Evict expired entries on write so a rotating set of tokens can't grow
+    // the map without bound.
+    guard.retain(|_, (built_at, _)| built_at.elapsed() < ttl);
+    guard.insert(key.to_string(), (Instant::now(), structure.to_string()));
+}
+
 async fn build_structure(client: &BookStackClient) -> Option<String> {
+    let ttl = structure_cache_ttl();
+    let key = structure_cache_key(client.base_url(), client.token_id());
+
+    if let Some(hit) = cached_structure(&key, ttl) {
+        tracing::debug!("structure_cache_hit");
+        return Some(hit);
+    }
+
+    let structure = build_structure_uncached(client).await?;
+    store_structure(&key, &structure, ttl);
+    Some(structure)
+}
+
+async fn build_structure_uncached(client: &BookStackClient) -> Option<String> {
     let shelves = client.list_shelves(500, 0).await.ok()?;
     let shelf_list = shelves["data"].as_array()?;
 
@@ -2612,6 +2683,66 @@ fn update_schema(id_name: &str, fields: &[&str]) -> Value {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    // --- Structure cache (initialize fan-out, issue #143) ---
+    //
+    // STRUCTURE_CACHE is process-global and these tests run in parallel, so
+    // each one uses a distinct key.
+
+    #[test]
+    fn structure_cache_key_separates_tokens_on_one_instance() {
+        // The permissions-critical property: shelf visibility is per-token, so
+        // two tokens against the same BookStack must never collide on a key.
+        let a = structure_cache_key("https://kb.example.com", "token-aaa");
+        let b = structure_cache_key("https://kb.example.com", "token-bbb");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn structure_cache_key_separates_instances_on_one_token() {
+        let a = structure_cache_key("https://kb-one.example.com", "token-aaa");
+        let b = structure_cache_key("https://kb-two.example.com", "token-aaa");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn structure_cache_returns_stored_value_within_ttl() {
+        let ttl = Duration::from_secs(60);
+        let key = structure_cache_key("https://kb.example.com", "within-ttl");
+        store_structure(&key, "Shelf: Ops (ID: 1)\n", ttl);
+        assert_eq!(
+            cached_structure(&key, ttl).as_deref(),
+            Some("Shelf: Ops (ID: 1)\n")
+        );
+    }
+
+    #[test]
+    fn structure_cache_misses_once_the_entry_is_older_than_the_ttl() {
+        // Stored under a long TTL, read back under a tiny one: freshness is
+        // judged at read time, so this exercises expiry without a sleep.
+        let key = structure_cache_key("https://kb.example.com", "expired");
+        store_structure(&key, "Shelf: Ops (ID: 1)\n", Duration::from_secs(60));
+        assert_eq!(cached_structure(&key, Duration::from_nanos(1)), None);
+    }
+
+    #[test]
+    fn structure_cache_never_serves_one_tokens_structure_to_another() {
+        let ttl = Duration::from_secs(60);
+        let mine = structure_cache_key("https://kb.example.com", "leak-mine");
+        let theirs = structure_cache_key("https://kb.example.com", "leak-theirs");
+        store_structure(&mine, "Shelf: Private (ID: 9)\n", ttl);
+        assert_eq!(cached_structure(&theirs, ttl), None);
+    }
+
+    #[test]
+    fn zero_ttl_disables_the_cache_in_both_directions() {
+        let key = structure_cache_key("https://kb.example.com", "disabled");
+        store_structure(&key, "Shelf: Ops (ID: 1)\n", Duration::ZERO);
+        // Nothing stored, and even a populated entry is not served at TTL 0.
+        assert_eq!(cached_structure(&key, Duration::ZERO), None);
+        store_structure(&key, "Shelf: Ops (ID: 1)\n", Duration::from_secs(60));
+        assert_eq!(cached_structure(&key, Duration::ZERO), None);
+    }
 
     /// v0.10.0 surface lock + issue #69: 59 BookStack CRUD plus 1 directory
     /// tool plus 3 semantic tools equals 63. Anything extra means a

--- a/crates/bsmcp-server/src/mcp.rs
+++ b/crates/bsmcp-server/src/mcp.rs
@@ -2038,6 +2038,30 @@ fn cached_structure(key: &str, ttl: Duration) -> Option<String> {
     (built_at.elapsed() < ttl).then(|| structure.clone())
 }
 
+/// One rendered sweep. `complete` is false when any `get_shelf` or the
+/// `list_chapters` call failed, meaning the text is missing shelves or
+/// chapters even though it rendered fine.
+struct StructureSweep {
+    text: String,
+    complete: bool,
+}
+
+/// Cache only a complete sweep.
+///
+/// `build_structure_uncached` skips failed `get_shelf` results rather than
+/// aborting, so a partial sweep still renders non-empty. Caching one would
+/// pin a truncated shelf tree for the whole TTL — and BookStack failing
+/// mid-sweep is precisely the saturated-pool condition this cache exists to
+/// relieve, so the blip and the caching would compound. Before caching
+/// existed this self-healed on the next connect; keep that property.
+fn store_sweep(key: &str, sweep: &StructureSweep, ttl: Duration) {
+    if !sweep.complete {
+        tracing::warn!("structure_sweep_incomplete_not_cached");
+        return;
+    }
+    store_structure(key, &sweep.text, ttl);
+}
+
 fn store_structure(key: &str, structure: &str, ttl: Duration) {
     if ttl.is_zero() {
         return;
@@ -2060,12 +2084,12 @@ async fn build_structure(client: &BookStackClient) -> Option<String> {
         return Some(hit);
     }
 
-    let structure = build_structure_uncached(client).await?;
-    store_structure(&key, &structure, ttl);
-    Some(structure)
+    let sweep = build_structure_uncached(client).await?;
+    store_sweep(&key, &sweep, ttl);
+    Some(sweep.text)
 }
 
-async fn build_structure_uncached(client: &BookStackClient) -> Option<String> {
+async fn build_structure_uncached(client: &BookStackClient) -> Option<StructureSweep> {
     let shelves = client.list_shelves(500, 0).await.ok()?;
     let shelf_list = shelves["data"].as_array()?;
 
@@ -2075,13 +2099,22 @@ async fn build_structure_uncached(client: &BookStackClient) -> Option<String> {
         .map(|id| client.get_shelf(id))
         .collect();
     let shelf_details = futures::future::join_all(shelf_futures).await;
+    let shelves_failed = shelf_details.iter().filter(|r| r.is_err()).count();
 
-    let chapters = client
-        .list_chapters(500, 0)
-        .await
+    let chapters_result = client.list_chapters(500, 0).await;
+    let chapters_failed = chapters_result.is_err();
+    let chapters = chapters_result
         .ok()
         .and_then(|v| v["data"].as_array().cloned())
         .unwrap_or_default();
+
+    if shelves_failed > 0 || chapters_failed {
+        tracing::warn!(
+            shelves_failed,
+            chapters_failed,
+            "structure_sweep_partial_upstream_errors"
+        );
+    }
 
     let mut chapters_by_book: HashMap<i64, Vec<(i64, String, String)>> = HashMap::new();
     for ch in &chapters {
@@ -2139,7 +2172,10 @@ async fn build_structure_uncached(client: &BookStackClient) -> Option<String> {
     if output.is_empty() {
         None
     } else {
-        Some(output)
+        Some(StructureSweep {
+            text: output,
+            complete: shelves_failed == 0 && !chapters_failed,
+        })
     }
 }
 
@@ -2732,6 +2768,36 @@ mod tests {
         let theirs = structure_cache_key("https://kb.example.com", "leak-theirs");
         store_structure(&mine, "Shelf: Private (ID: 9)\n", ttl);
         assert_eq!(cached_structure(&theirs, ttl), None);
+    }
+
+    #[test]
+    fn a_partial_sweep_is_never_cached() {
+        // BookStack saturating mid-sweep still renders a non-empty (but
+        // truncated) tree. Caching it would pin the wrong shelf list for the
+        // whole TTL, and a saturated pool is exactly when this fires.
+        let ttl = Duration::from_secs(60);
+        let key = structure_cache_key("https://kb.example.com", "partial");
+        let sweep = StructureSweep {
+            text: "Shelf: Ops (ID: 1)\n".to_string(),
+            complete: false,
+        };
+        store_sweep(&key, &sweep, ttl);
+        assert_eq!(cached_structure(&key, ttl), None);
+    }
+
+    #[test]
+    fn a_complete_sweep_is_cached() {
+        let ttl = Duration::from_secs(60);
+        let key = structure_cache_key("https://kb.example.com", "complete");
+        let sweep = StructureSweep {
+            text: "Shelf: Ops (ID: 1)\n".to_string(),
+            complete: true,
+        };
+        store_sweep(&key, &sweep, ttl);
+        assert_eq!(
+            cached_structure(&key, ttl).as_deref(),
+            Some("Shelf: Ops (ID: 1)\n")
+        );
     }
 
     #[test]

--- a/crates/bsmcp-server/src/sse.rs
+++ b/crates/bsmcp-server/src/sse.rs
@@ -24,13 +24,50 @@ use crate::mcp;
 use crate::oauth::{AuthCode, AUTH_CODE_TTL};
 use crate::semantic::SemanticState;
 
-const MAX_SESSIONS_PER_TOKEN: usize = 5;
+/// Default per-token cap on concurrent legacy SSE sessions. Overridable at
+/// startup via `BSMCP_MAX_SESSIONS_PER_TOKEN` (issue #138) — a workstation
+/// running two MCP clients against one BookStack API token outgrows 5.
+const DEFAULT_MAX_SESSIONS_PER_TOKEN: usize = 5;
 const MAX_TOTAL_SESSIONS: usize = 1000;
 const SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
 const MAX_REQUESTS_PER_MINUTE: u32 = 100;
 /// `Retry-After` on a 503 when an upstream is unreachable. Long enough to
 /// cover a container restart, short enough that clients don't stall.
 pub(crate) const RETRY_AFTER_SECS: &str = "5";
+
+/// Resolve the per-token legacy-SSE session cap from
+/// `BSMCP_MAX_SESSIONS_PER_TOKEN`, falling back to
+/// [`DEFAULT_MAX_SESSIONS_PER_TOKEN`] when the value is absent, unparseable,
+/// or zero. A typo in the env should not lock every client out of the server.
+pub fn max_sessions_per_token_from_env() -> usize {
+    parse_max_sessions_per_token(
+        std::env::var("BSMCP_MAX_SESSIONS_PER_TOKEN")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// Split out from the env read so the fallback rules stay unit-testable
+/// without mutating process-global state mid-test-run.
+fn parse_max_sessions_per_token(raw: Option<&str>) -> usize {
+    raw.and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_MAX_SESSIONS_PER_TOKEN)
+}
+
+/// Streamable HTTP (MCP 2025-03-26) clients open the server→client
+/// notification stream with a GET on the *same* endpoint they POST to,
+/// carrying the `Mcp-Session-Id` they were issued on `initialize`. A legacy
+/// SSE client (MCP 2024-11-05) never sends that header — it learns its
+/// session id from the `endpoint` event the handshake pushes back. The
+/// header is therefore a reliable discriminator between the two transports
+/// sharing the `/mcp/sse` route.
+fn is_streamable_notification_stream(headers: &HeaderMap) -> bool {
+    headers
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|s| !s.trim().is_empty())
+}
 
 #[derive(Clone)]
 pub struct AppState {
@@ -44,6 +81,10 @@ pub struct AppState {
     pub register_rate_limit: Arc<Mutex<RateLimit>>,
     streamable_rate_limits: Arc<RwLock<HashMap<String, Arc<Mutex<RateLimit>>>>>,
     streamable_sessions: Arc<RwLock<HashMap<String, Instant>>>,
+    /// Per-token cap on concurrent *legacy* SSE sessions, resolved once at
+    /// startup from `BSMCP_MAX_SESSIONS_PER_TOKEN` (issue #138). Streamable
+    /// notification streams are deliberately not counted against it.
+    max_sessions_per_token: usize,
     backup_interval_hours: Option<u64>,
     backup_path: PathBuf,
     pub semantic: Option<Arc<SemanticState>>,
@@ -113,6 +154,7 @@ impl AppState {
         backup_path: PathBuf,
         semantic: Option<Arc<SemanticState>>,
         timezone: Arc<TimezoneConfig>,
+        max_sessions_per_token: usize,
     ) -> Self {
         let http_client = Client::builder()
             .connect_timeout(Duration::from_secs(10))
@@ -130,6 +172,7 @@ impl AppState {
             register_rate_limit: Arc::new(Mutex::new(RateLimit::new(10))),
             streamable_rate_limits: Arc::new(RwLock::new(HashMap::new())),
             streamable_sessions: Arc::new(RwLock::new(HashMap::new())),
+            max_sessions_per_token,
             backup_interval_hours,
             backup_path,
             semantic,
@@ -305,6 +348,28 @@ pub async fn handle_sse(State(state): State<AppState>, headers: HeaderMap) -> Re
             Err(resp) => return resp,
         };
 
+    // Issue #138: a streamable-HTTP client's notification GET is not a legacy
+    // handshake. Allocating a `Session` for it burned a slot in the per-token
+    // cap, so two MCP clients sharing one BookStack token exhausted all five
+    // and every later GET got a 429 — cosmetic in the client log, but it also
+    // meant a wasted `validate()` round-trip against BookStack per reconnect.
+    //
+    // Serve an inert stream instead. The spec permits answering this GET with
+    // 405 as well, but rmcp's handling of that has drifted across versions and
+    // a 405 can push a client into legacy-SSE *fallback* — allocating exactly
+    // the session we are declining here. This server pushes no server-initiated
+    // messages, so the stream carries keepalive comments and nothing else, and
+    // it ends when the client goes away.
+    //
+    // The incoming id is deliberately not checked against `streamable_sessions`:
+    // that map is empty after a restart while clients still hold ids, and
+    // rejecting them would trade the 429 for a 404. `resolve_credentials` above
+    // is the real gate; the header is only a transport discriminator.
+    if is_streamable_notification_stream(&headers) {
+        tracing::debug!("streamable_notification_stream_opened");
+        return notification_stream_response();
+    }
+
     let client = BookStackClient::new(
         &state.bookstack_url,
         &token_id,
@@ -343,7 +408,7 @@ pub async fn handle_sse(State(state): State<AppState>, headers: HeaderMap) -> Re
         }
 
         let count = sessions.values().filter(|s| s.token_id == token_id).count();
-        if count >= MAX_SESSIONS_PER_TOKEN {
+        if count >= state.max_sessions_per_token {
             return (
                 StatusCode::TOO_MANY_REQUESTS,
                 Json(serde_json::json!({"error": "Too many sessions for this token"})),
@@ -371,6 +436,24 @@ pub async fn handle_sse(State(state): State<AppState>, headers: HeaderMap) -> Re
         .await;
 
     let stream = ReceiverStream::new(rx);
+    let mut resp = Sse::new(stream)
+        .keep_alive(KeepAlive::default().interval(Duration::from_secs(15)))
+        .into_response();
+
+    let hdrs = resp.headers_mut();
+    hdrs.insert(header::CACHE_CONTROL, "no-cache, no-store".parse().unwrap());
+    hdrs.insert("X-Accel-Buffering", "no".parse().unwrap());
+
+    resp
+}
+
+/// Inert `text/event-stream` for a streamable-HTTP client's notification
+/// channel. Allocates no [`Session`] and counts against no cap: the server has
+/// no server→client messages to push, so the stream carries only the keepalive
+/// comments `KeepAlive` injects. `futures::stream::pending()` never yields, so
+/// the response ends when the client disconnects and the keepalive write fails.
+fn notification_stream_response() -> Response {
+    let stream = futures::stream::pending::<Result<Event, Infallible>>();
     let mut resp = Sse::new(stream)
         .keep_alive(KeepAlive::default().interval(Duration::from_secs(15)))
         .into_response();
@@ -615,5 +698,68 @@ pub async fn handle_streamable(
             http_resp
         }
         None => StatusCode::ACCEPTED.into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_with_session(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("mcp-session-id", value.parse().unwrap());
+        h
+    }
+
+    // Issue #138: this predicate is what keeps a streamable client's
+    // notification GET from consuming a legacy per-token session slot.
+    #[test]
+    fn streamable_get_is_detected_by_session_header() {
+        let h = headers_with_session("8acb2c83-0d1e-4f4a-9d21-1b2c3d4e5f60");
+        assert!(is_streamable_notification_stream(&h));
+    }
+
+    #[test]
+    fn legacy_sse_handshake_sends_no_session_header() {
+        assert!(!is_streamable_notification_stream(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn blank_session_header_falls_through_to_legacy() {
+        // An empty or whitespace-only header is not a resumable streamable
+        // session, so it must take the legacy path rather than silently
+        // opening an inert stream a legacy client would wait on forever.
+        assert!(!is_streamable_notification_stream(&headers_with_session(
+            ""
+        )));
+        assert!(!is_streamable_notification_stream(&headers_with_session(
+            "   "
+        )));
+    }
+
+    #[test]
+    fn session_cap_defaults_when_unset() {
+        assert_eq!(
+            parse_max_sessions_per_token(None),
+            DEFAULT_MAX_SESSIONS_PER_TOKEN
+        );
+    }
+
+    #[test]
+    fn session_cap_reads_a_valid_override() {
+        assert_eq!(parse_max_sessions_per_token(Some("25")), 25);
+        assert_eq!(parse_max_sessions_per_token(Some("  12  ")), 12);
+    }
+
+    #[test]
+    fn session_cap_rejects_zero_and_garbage() {
+        // A bad value must not lock every client out of the server.
+        for raw in ["0", "-1", "many", ""] {
+            assert_eq!(
+                parse_max_sessions_per_token(Some(raw)),
+                DEFAULT_MAX_SESSIONS_PER_TOKEN,
+                "raw = {raw:?}"
+            );
+        }
     }
 }

--- a/crates/bsmcp-server/src/sse.rs
+++ b/crates/bsmcp-server/src/sse.rs
@@ -342,7 +342,7 @@ pub async fn resolve_credentials(
 
 pub async fn handle_sse(State(state): State<AppState>, headers: HeaderMap) -> Response {
     tracing::debug!(method = "GET", route = "/mcp/sse", "sse_connect_attempt");
-    let (token_id, token_secret) =
+    let (mut token_id, mut token_secret) =
         match resolve_credentials(&headers, state.db.as_ref(), &state.known_urls).await {
             Ok(creds) => creds,
             Err(resp) => return resp,
@@ -354,12 +354,14 @@ pub async fn handle_sse(State(state): State<AppState>, headers: HeaderMap) -> Re
     // and every later GET got a 429 — cosmetic in the client log, but it also
     // meant a wasted `validate()` round-trip against BookStack per reconnect.
     //
-    // Serve an inert stream instead. The spec permits answering this GET with
-    // 405 as well, but rmcp's handling of that has drifted across versions and
-    // a 405 can push a client into legacy-SSE *fallback* — allocating exactly
-    // the session we are declining here. This server pushes no server-initiated
-    // messages, so the stream carries keepalive comments and nothing else, and
-    // it ends when the client goes away.
+    // Serve an inert stream instead. The spec allows answering this GET with
+    // 405 too, and current rmcp maps that onto `ServerDoesNotSupportSse` and
+    // carries on, so 405 is a legitimate — arguably tidier — answer that would
+    // also avoid holding a connection per client. The inert stream is chosen
+    // defensively: `text/event-stream` is the branch every client handles,
+    // whereas correct 405 handling varies by client and version, and this
+    // server has nothing to push either way. See the follow-up issue on
+    // revisiting 405 and capping these streams.
     //
     // The incoming id is deliberately not checked against `streamable_sessions`:
     // that map is empty after a restart while clients still hold ids, and
@@ -367,6 +369,9 @@ pub async fn handle_sse(State(state): State<AppState>, headers: HeaderMap) -> Re
     // is the real gate; the header is only a transport discriminator.
     if is_streamable_notification_stream(&headers) {
         tracing::debug!("streamable_notification_stream_opened");
+        // No `Session` is constructed on this path, so its `Drop` never runs.
+        token_id.zeroize();
+        token_secret.zeroize();
         return notification_stream_response();
     }
 
@@ -450,8 +455,11 @@ pub async fn handle_sse(State(state): State<AppState>, headers: HeaderMap) -> Re
 /// Inert `text/event-stream` for a streamable-HTTP client's notification
 /// channel. Allocates no [`Session`] and counts against no cap: the server has
 /// no server→client messages to push, so the stream carries only the keepalive
-/// comments `KeepAlive` injects. `futures::stream::pending()` never yields, so
-/// the response ends when the client disconnects and the keepalive write fails.
+/// comments `KeepAlive` injects. `futures::stream::pending()` never yields; the
+/// response body is dropped when hyper sees the peer close the connection
+/// (measured at ~60ms, on both graceful FIN and RST), so teardown does not wait
+/// on a keepalive write failing. The keepalive is the backstop for half-open
+/// peers behind a proxy, not the primary disconnect detector.
 fn notification_stream_response() -> Response {
     let stream = futures::stream::pending::<Result<Event, Infallible>>();
     let mut resp = Sse::new(stream)


### PR DESCRIPTION
Closes #138, closes #143.

Two independent bugs, both of which have `bsmcp-server` putting more load on BookStack than it needs to. They were found separately and are reviewable as separate commits.

---

## 1. Streamable-HTTP notification GETs consumed legacy SSE session slots (#138)

`/mcp/sse` serves both transports off one route (`main.rs:245`):

```rust
.route("/mcp/sse", get(sse::handle_sse).post(sse::handle_streamable))
```

A streamable-HTTP client (MCP 2025-03-26) opens the server-to-client notification stream with a `GET` on that same endpoint. That landed in `handle_sse`, was treated as a legacy 2024-11-05 handshake, allocated a full `Session`, and consumed a slot in `MAX_SESSIONS_PER_TOKEN` (5, compile-time). Two MCP clients sharing one BookStack token exhausted all five, and every notification `GET` after that got a 429.

Tools kept working, because only the `GET` was refused and the `POST` path has its own uncapped `streamable_sessions` map. So it presented as a permanent error in client logs with no functional failure. The 429 was also returned *after* `client.validate()` (`sse.rs:315`), so every refused `GET` burned a BookStack round-trip too.

**Fix.** Discriminate on `Mcp-Session-Id` — streamable clients send it, legacy SSE clients never do — and answer those GETs with an inert keepalive-only stream. No `Session`, no cap charge, no `validate()` call.

The spec permits answering with 405 instead. I did not, because rmcp's 405 handling has drifted across versions and a 405 can push a client into legacy-SSE *fallback*, allocating precisely the session being declined. The incoming id is deliberately **not** validated against `streamable_sessions`: that map is empty after a restart while clients still hold ids, so rejecting them would trade the 429 for a 404.

Also adds **`BSMCP_MAX_SESSIONS_PER_TOKEN`** (default 5, falling back on zero/unparseable so a typo can't lock everyone out). It was a compile-time constant with no operator lever.

Reported by @joseluislucas with a root-cause analysis that held up in full on review.

---

## 2. Every `initialize` re-enumerated the whole shelf tree (#143)

`build_structure` fans out over every shelf on **every** `initialize`, uncached: one `list_shelves`, one `get_shelf` per shelf via `join_all`, one `list_chapters`. `sse.rs` builds a fresh `BookStackClient` per request and `BookStackClient::get` goes straight to HTTP, so every reconnect re-ran the sweep.

Measured on a live instance in one hour: **1326** `/api/shelves/{id}` calls across ~24 shelves, plus 56 `/api/shelves` list calls, one per `initialize`. All from `bsmcp-server`; the worker and embedder contributed zero.

That saturated BookStack's php-fpm pool. The linuxserver image ships `pm.max_children = 5` — five concurrent PHP requests total, covering users, API and health checks — so the liveness probe queued past its timeout and restart-looped the container. It hid well: s6 traps SIGTERM so the kill exits 0 (no OOMKilled, no 137), and nothing is actually slow (70–100ms at rest, 5m CPU against a 2-vCPU limit). Concurrency ceiling, not a resource ceiling.

**Fix.** Cache the rendered structure, 60s TTL, overridable via **`BSMCP_STRUCTURE_CACHE_TTL_SECS`** (`0` disables).

Two deliberate choices:

- **Cached at the rendered-structure layer, not inside `get()`.** Caching `shelves/*` in the client would make `list_shelves` / `get_shelf` **tool** responses stale after a write. Only the `initialize` blurb is cached, and that is a hint rather than authoritative data. It also collapses more: a hit costs zero API calls, not just fewer shelf calls.
- **The key carries the token id.** Shelf visibility is per-token, so a globally-keyed cache would serve one caller's structure to another — a permissions bug traded for a load one. Two tests cover that boundary directly, including an explicit "never serves one token's structure to another" case.

Not addressed here: the cache is TTL-only, so a shelf created through this server is absent from the structure blurb for up to 60s. Tools stay live, so this only affects the hint text on connect.

---

## Drive-by: flaky test

`temp_db()` in `bsmcp-db-sqlite` keyed its filename on pid + wall-clock. These tests run in parallel in one process, so two landing in the same clock tick got the same path and silently shared a database.

Measured before: **2 failures in 6 runs** (`complete_job_does_not_overwrite_cancelled`, failing on `assert_eq!(claimed.id, job_id)` because it was claiming another test's job). Single-threaded it passed 4/4, which confirmed the diagnosis. Added a monotonic counter to the filename; **8/8 clean** after.

Included here rather than split out because it intermittently reds `cargo test --workspace` on every PR, not just this one.

---

## Verification

`cargo build`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, `cargo test --workspace` all clean locally. **147 tests pass**, including 12 new ones covering the header discriminator, the session-cap fallback rules, and the structure cache's TTL and per-token isolation.

Version bumped **0.13.0 → 0.13.1** (`bug/*` → patch, per DEVELOPMENT.md).

**What the tests do not cover:** the real client handshake, and the actual API-call reduction against a live BookStack. @joseluislucas offered to test against their deployment (PostgreSQL + pgvector, nginx, codex-mcp-client + claude-code), which is the case that matters most for #138. For #143 the check is whether `/api/shelves/{id}` volume drops to roughly one sweep per token per minute.
