### PR TITLE
bug(ci): publish the `:release` and `:{version}-{sha}` tags release.yml already promises

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -85,10 +86,22 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/bees-roadhouse/${{ matrix.image }}
+          # `latest=auto` is metadata-action's default, stated explicitly so
+          # the contract is readable here: a `v*` semver tag gets `:latest`,
+          # a prerelease tag (v1.0.0-rc1) does not.
+          flavor: |
+            latest=auto
+          # The semver hierarchy plus the two tags this workflow's header and
+          # DEVELOPMENT.md have always promised but never actually pushed:
+          # `:release` and `:{version}-{sha}`. Their absence left `:release`
+          # stranded on 0.13.0 after the release-branch workflow that used to
+          # publish it was retired in the single-`main` migration.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.short_sha }}
+            type=raw,value=release
 
       - name: Build and push tagged image
         uses: docker/build-push-action@v6

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -162,14 +162,13 @@ branch — and is kept because the compose files and Portainer stacks pin it:
 - `{version}-dev` — version-level rolling
 - `{version}-dev-{sha}` — version-level immutable
 
-Release stream (pushed by `release.yml`'s `tag-release` on a `v*` tag push):
-- `latest` — rolling, latest release
+Release stream (pushed by `release.yml`'s `tag-release` on a `v*` tag push).
+One trigger, one tag set — the whole list below lands on every `v*` tag:
+- `latest` — rolling, latest release. Skipped on a prerelease tag (`v1.0.0-rc1`) via `latest=auto`.
 - `release` — alias for `latest`
-- `{version}` — pinned semver (e.g., `0.11.0`)
-- `{version}-{sha}` — immutable per-release-merge
-
-Tag-push hotfix (`v*` tag → `release.yml` `tag-release`):
-- `{version}`, `{major}.{minor}`, `{major}` — full semver hierarchy
+- `{version}` — pinned semver (e.g., `0.13.1`)
+- `{major}.{minor}` and `{major}` — the rest of the semver hierarchy
+- `{version}-{sha}` — immutable per-release-commit
 
 Images are published to `ghcr.io/bees-roadhouse/bsmcp-server` and `ghcr.io/bees-roadhouse/bsmcp-embedder` for `linux/amd64` and `linux/arm64`. For v0.13.0 only, `ghcr.io/bees-roadhouse/bsmcp-worker:<tag>` is published as a transitional registry alias of `ghcr.io/bees-roadhouse/bsmcp-embedder:<tag>` so existing compose files keep pulling — operators must still set `--role=worker` on the running container. The alias is removed in v0.14.0.
 


### PR DESCRIPTION
Found while checking why v0.13.0 had no `-dev` image (it was a release-branch commit under the old three-branch model, so `Build Development` never ran on it — expected, not a bug).

The real find: **`release.yml` does not publish `:release`, despite three docs and its own header saying it does.**

## What's wrong

The metadata step emitted only:

```
type=semver,pattern={{version}}         → 0.13.1
type=semver,pattern={{major}}.{{minor}} → 0.13
type=semver,pattern={{major}}           → 0
```

plus `:latest` implicitly. No `:release`, no `:{version}-{sha}`.

Meanwhile `release.yml:7`, and DEVELOPMENT.md lines 98, 143 and 216, all promise `:{version}` / `:{version}-{sha}` / `:release` / `:latest`.

The `:release` tag sitting on GHCR today was pushed by the **release-branch** workflow that the single-`main` migration retired. Nothing publishes it anymore. Tagging `v0.13.1` as-is would leave `:release` pinned to 0.13.0 permanently and silently, and any deployment tracking it would never move again.

## Fix

Add `type=raw,value=release` and `type=raw,value={version}-{short_sha}` (via a new `short_sha` output on the existing `vars` step, which already parses the version for the tag-match check).

Both ride the **same** `build-push-action` invocation as the rest, so every tag on a release resolves to one manifest digest — `:latest`, `:release`, `:0.13.1`, `:0.13`, `:0` and `:0.13.1-{sha}` all point at the same image, matching how the 0.13.0 entry looks on GHCR today.

`flavor: latest=auto` is stated explicitly. It is already the default and nothing changes, but the rule it encodes (`:latest` on a release tag, not on `v1.0.0-rc1`) should be readable in the file.

## Docs

DEVELOPMENT.md described the same trigger twice — a "Release stream" list and a "Tag-push hotfix" list with *different* contents — which is what let the drift hide. Collapsed into one list matching the workflow.

## Verification

YAML parses; all four jobs intact; the meta step resolves to the six expected tag expressions. No Rust changed, so no version bump — this ships as part of v0.13.1, whose tag is not yet cut. The real proof is the release run itself, which I'll verify on GHCR right after tagging.