### PR TITLE
bug(worker,common): index shelf-less books, retry delta-walk page failures, fix pagination truncation (closes #147)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-common"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-postgres"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-db-sqlite"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-embedder"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "bsmcp-server"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.13.1"
+version = "0.13.2"
 
 [workspace.dependencies]
 # Structured logging. `json` feature enables the JSON output mode that

--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -10,6 +10,43 @@ use crate::rate_limit::{self, RateLimiter};
 /// Maximum size for file content fetched from URLs (50MB).
 const MAX_FILE_CONTENT_SIZE: usize = 50 * 1024 * 1024;
 
+/// Rows requested per page when sweeping a list endpoint to exhaustion.
+///
+/// Matches BookStack's default `API_MAX_ITEM_COUNT`. An instance
+/// configured lower simply returns short pages — `paginate_step` advances
+/// by what actually came back, so a mismatch costs extra round trips but
+/// never skips or truncates.
+const LIST_PAGE_SIZE: i64 = 500;
+
+/// One step of a paginated sweep: the entity ids on this page, and the
+/// offset the next request should start at (`None` once the sweep is done).
+///
+/// The offset advances by the number of rows the server **actually
+/// returned**, never by the count we asked for. BookStack clamps `count`
+/// to the instance's `API_MAX_ITEM_COUNT`, so an over-large request comes
+/// back short — advancing by the requested size would skip rows, and
+/// treating a short page as "last page" would silently truncate the sweep
+/// after a single request. Termination is an empty page, or `total` being
+/// reached; a response missing `total` falls through to the empty-page
+/// check rather than stopping early.
+fn paginate_step(page: &Value, offset: i64) -> (Vec<i64>, Option<i64>) {
+    let Some(arr) = page.get("data").and_then(|v| v.as_array()) else {
+        return (Vec::new(), None);
+    };
+    if arr.is_empty() {
+        return (Vec::new(), None);
+    }
+    let ids: Vec<i64> = arr
+        .iter()
+        .filter_map(|item| item.get("id").and_then(|v| v.as_i64()))
+        .collect();
+    let next = offset + arr.len() as i64;
+    match page.get("total").and_then(|v| v.as_i64()) {
+        Some(total) if next >= total => (ids, None),
+        _ => (ids, Some(next)),
+    }
+}
+
 /// Check if an IP address is in a private, loopback, or link-local range.
 fn is_restricted_ip(ip: &IpAddr) -> bool {
     match ip {
@@ -682,29 +719,16 @@ impl BookStackClient {
     /// branching). BookStack's `/api/shelves` caps at 500 per page; we page
     /// until `data` comes back empty.
     pub async fn list_all_shelves(&self) -> Result<Vec<i64>, String> {
-        const PAGE_SIZE: i64 = 500;
         let mut ids = Vec::new();
         let mut offset = 0i64;
         loop {
-            let page = self.list_shelves(PAGE_SIZE, offset).await?;
-            let arr = page
-                .get("data")
-                .and_then(|v| v.as_array())
-                .cloned()
-                .unwrap_or_default();
-            if arr.is_empty() {
-                break;
+            let page = self.list_shelves(LIST_PAGE_SIZE, offset).await?;
+            let (page_ids, next) = paginate_step(&page, offset);
+            ids.extend(page_ids);
+            match next {
+                Some(n) => offset = n,
+                None => break,
             }
-            let page_len = arr.len() as i64;
-            for shelf in arr {
-                if let Some(id) = shelf.get("id").and_then(|v| v.as_i64()) {
-                    ids.push(id);
-                }
-            }
-            if page_len < PAGE_SIZE {
-                break;
-            }
-            offset += PAGE_SIZE;
         }
         Ok(ids)
     }
@@ -748,29 +772,16 @@ impl BookStackClient {
     /// `list_all_shelves`. The index worker's full walk is shelf-rooted, so
     /// this is how it reaches books that sit on no shelf at all (issue #147).
     pub async fn list_all_books(&self) -> Result<Vec<i64>, String> {
-        const PAGE_SIZE: i64 = 500;
         let mut ids = Vec::new();
         let mut offset = 0i64;
         loop {
-            let page = self.list_books(PAGE_SIZE, offset).await?;
-            let arr = page
-                .get("data")
-                .and_then(|v| v.as_array())
-                .cloned()
-                .unwrap_or_default();
-            if arr.is_empty() {
-                break;
+            let page = self.list_books(LIST_PAGE_SIZE, offset).await?;
+            let (page_ids, next) = paginate_step(&page, offset);
+            ids.extend(page_ids);
+            match next {
+                Some(n) => offset = n,
+                None => break,
             }
-            let page_len = arr.len() as i64;
-            for book in arr {
-                if let Some(id) = book.get("id").and_then(|v| v.as_i64()) {
-                    ids.push(id);
-                }
-            }
-            if page_len < PAGE_SIZE {
-                break;
-            }
-            offset += PAGE_SIZE;
         }
         Ok(ids)
     }
@@ -1344,6 +1355,94 @@ mod tests {
     use super::*;
     use reqwest::StatusCode;
     use serde_json::json;
+
+    /// Simulate a BookStack list endpoint: `server_cap` is the instance's
+    /// `API_MAX_ITEM_COUNT`, which clamps whatever `count` we asked for.
+    fn fake_list_page(total: usize, offset: i64, requested: i64, server_cap: i64) -> Value {
+        let granted = requested.min(server_cap).max(0) as usize;
+        let start = (offset.max(0) as usize).min(total);
+        let end = (start + granted).min(total);
+        let rows: Vec<Value> = (start..end)
+            .map(|i| json!({ "id": i as i64 + 1 }))
+            .collect();
+        json!({ "data": rows, "total": total as i64 })
+    }
+
+    /// Drive `paginate_step` the way `list_all_books` does.
+    fn sweep(total: usize, requested: i64, server_cap: i64) -> (Vec<i64>, usize) {
+        let mut ids = Vec::new();
+        let mut offset = 0i64;
+        let mut requests = 0usize;
+        loop {
+            let page = fake_list_page(total, offset, requested, server_cap);
+            requests += 1;
+            assert!(requests < 1000, "sweep failed to terminate");
+            let (page_ids, next) = paginate_step(&page, offset);
+            ids.extend(page_ids);
+            match next {
+                Some(n) => offset = n,
+                None => break,
+            }
+        }
+        (ids, requests)
+    }
+
+    /// The regression that motivated `paginate_step`: asking for more than
+    /// the instance's `API_MAX_ITEM_COUNT` used to break the sweep after
+    /// one page, because a clamped response looks like a short final page.
+    /// Every id must still be collected.
+    #[test]
+    fn sweep_survives_a_server_side_count_clamp() {
+        let (ids, requests) = sweep(1200, 1000, 500);
+        assert_eq!(ids.len(), 1200, "clamped sweep must not truncate");
+        assert_eq!(ids.first(), Some(&1));
+        assert_eq!(ids.last(), Some(&1200));
+        // 500 + 500 + 200 — the short final page ends it, no wasted request.
+        assert_eq!(requests, 3);
+    }
+
+    #[test]
+    fn sweep_collects_everything_when_request_matches_cap() {
+        let (ids, requests) = sweep(1200, 500, 500);
+        assert_eq!(ids.len(), 1200);
+        assert_eq!(requests, 3);
+    }
+
+    /// An exact multiple of the page size must not spin forever or drop
+    /// the tail — `total` ends it without a trailing empty request.
+    #[test]
+    fn sweep_handles_exact_multiple_of_page_size() {
+        let (ids, requests) = sweep(1000, 500, 500);
+        assert_eq!(ids.len(), 1000);
+        assert_eq!(requests, 2);
+    }
+
+    #[test]
+    fn sweep_handles_empty_and_single_page_instances() {
+        assert_eq!(sweep(0, 500, 500).0.len(), 0);
+        assert_eq!(sweep(1, 500, 500).0.len(), 1);
+        assert_eq!(sweep(499, 500, 500).0.len(), 499);
+    }
+
+    /// A response with no `total` must fall through to the empty-page
+    /// check rather than stopping after the first page.
+    #[test]
+    fn paginate_step_without_total_keeps_going() {
+        let page = json!({ "data": [{ "id": 7 }, { "id": 8 }] });
+        assert_eq!(paginate_step(&page, 0), (vec![7, 8], Some(2)));
+
+        let empty = json!({ "data": [] });
+        assert_eq!(paginate_step(&empty, 2), (Vec::new(), None));
+    }
+
+    #[test]
+    fn paginate_step_tolerates_a_malformed_page() {
+        assert_eq!(paginate_step(&json!({}), 0), (Vec::new(), None));
+        // Rows without a usable id are skipped, but still advance the
+        // offset — otherwise the sweep would re-request them forever.
+        let page = json!({ "data": [{ "id": 3 }, { "name": "no id" }], "total": 9 });
+        assert_eq!(paginate_step(&page, 0), (vec![3], Some(2)));
+    }
 
     fn fixture_book() -> Value {
         // Mimics the shape of `GET /api/books/{id}` — top-level pages

--- a/crates/bsmcp-common/src/bookstack.rs
+++ b/crates/bsmcp-common/src/bookstack.rs
@@ -744,6 +744,37 @@ impl BookStackClient {
         .await
     }
 
+    /// Every book id the token can see, paginated. Mirrors
+    /// `list_all_shelves`. The index worker's full walk is shelf-rooted, so
+    /// this is how it reaches books that sit on no shelf at all (issue #147).
+    pub async fn list_all_books(&self) -> Result<Vec<i64>, String> {
+        const PAGE_SIZE: i64 = 500;
+        let mut ids = Vec::new();
+        let mut offset = 0i64;
+        loop {
+            let page = self.list_books(PAGE_SIZE, offset).await?;
+            let arr = page
+                .get("data")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            if arr.is_empty() {
+                break;
+            }
+            let page_len = arr.len() as i64;
+            for book in arr {
+                if let Some(id) = book.get("id").and_then(|v| v.as_i64()) {
+                    ids.push(id);
+                }
+            }
+            if page_len < PAGE_SIZE {
+                break;
+            }
+            offset += PAGE_SIZE;
+        }
+        Ok(ids)
+    }
+
     pub async fn get_book(&self, id: i64) -> Result<Value, String> {
         self.get(&format!("books/{id}"), &[]).await
     }

--- a/crates/bsmcp-embedder/src/pipeline.rs
+++ b/crates/bsmcp-embedder/src/pipeline.rs
@@ -428,8 +428,16 @@ pub async fn run_pipeline(
             all_page_ids.push(pid);
         }
 
-        let total_in_response = list.get("total").and_then(|v| v.as_i64()).unwrap_or(0);
-        offset += 100;
+        // Advance by rows actually returned, not by the count we asked
+        // for — BookStack clamps `count` to API_MAX_ITEM_COUNT, and a
+        // fixed stride would skip rows on an instance capped below it.
+        // A response missing `total` falls through to the empty-page
+        // check at the top of the loop instead of truncating here.
+        offset += pages.len() as i64;
+        let total_in_response = list
+            .get("total")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(i64::MAX);
         if offset >= total_in_response {
             break;
         }

--- a/crates/bsmcp-embedder/src/pipeline.rs
+++ b/crates/bsmcp-embedder/src/pipeline.rs
@@ -474,9 +474,23 @@ pub async fn run_pipeline(
         )
         .await
         {
-            Ok(()) => {
+            Ok(outcome) => {
                 succeeded += 1;
                 consecutive_failures = 0;
+                // One line per page at INFO — this is the progress readout
+                // for a running job. `page`/`total_pages` make it obvious
+                // how far along a multi-thousand-page walk is without
+                // polling /status.
+                tracing::info!(
+                    job_id,
+                    page = i + 1,
+                    total_pages,
+                    page_id = *page_id,
+                    name = %outcome.name,
+                    chunks = outcome.chunks,
+                    skipped = outcome.skipped,
+                    "pipeline_page_embedded"
+                );
             }
             Err(e) => {
                 tracing::error!(page_id = *page_id, error = %e, "pipeline_page_embed_failed");
@@ -527,6 +541,16 @@ pub async fn run_pipeline(
 
 /// Embed a single page: fetch, check hash, chunk, embed, store relationships.
 /// When `force` is true, skip the content hash check and always re-embed.
+/// What one page's embed pass actually did, so the caller can log
+/// per-page progress at INFO without re-fetching the page.
+struct PageOutcome {
+    name: String,
+    chunks: usize,
+    /// Content hash matched and the page was left alone. Only reachable
+    /// when `force` is false.
+    skipped: bool,
+}
+
 async fn embed_single_page(
     db: &Arc<dyn SemanticDb>,
     embedder: &Arc<dyn Embedder>,
@@ -535,7 +559,7 @@ async fn embed_single_page(
     force: bool,
     shelf_lookup: &HashMap<i64, String>,
     role_ctx: Option<&RoleContext>,
-) -> Result<(), String> {
+) -> Result<PageOutcome, String> {
     let page = client.get_page(page_id).await?;
 
     let html = page.get("html").and_then(|v| v.as_str()).unwrap_or("");
@@ -570,7 +594,11 @@ async fn embed_single_page(
     if !force {
         if let Ok(Some(existing_hash)) = db.get_page_content_hash(page_id).await {
             if existing_hash == content_hash {
-                return Ok(());
+                return Ok(PageOutcome {
+                    name: name.to_string(),
+                    chunks: 0,
+                    skipped: true,
+                });
             }
         }
     }
@@ -605,7 +633,11 @@ async fn embed_single_page(
             );
         }
         db.upsert_page(&meta).await?;
-        return Ok(());
+        return Ok(PageOutcome {
+            name: name.to_string(),
+            chunks: 0,
+            skipped: false,
+        });
     }
     tracing::debug!(
         page_id,
@@ -679,6 +711,7 @@ async fn embed_single_page(
         }
     }
     db.replace_relationships(page_id, &targets).await?;
+    let chunk_count = chunk_inserts.len();
 
     // Store final page metadata with real content_hash — this is the commit marker.
     db.upsert_page(&meta).await?;
@@ -700,5 +733,9 @@ async fn embed_single_page(
         }
     }
 
-    Ok(())
+    Ok(PageOutcome {
+        name: name.to_string(),
+        chunks: chunk_count,
+        skipped: false,
+    })
 }

--- a/crates/bsmcp-embedder/src/worker.rs
+++ b/crates/bsmcp-embedder/src/worker.rs
@@ -31,6 +31,7 @@
 //! worker walks. Per-user content access for live MCP requests still uses
 //! the user's own token; the worker is structural reconciliation only.
 
+use std::collections::HashSet;
 use std::env;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -369,11 +370,13 @@ impl IndexWorker {
             }
         };
         if shelves.is_empty() {
+            // Not fatal — the orphan sweep below still reaches every visible
+            // book. A token that sees books but no shelves is unusual enough
+            // to warn about, though.
             tracing::warn!("indexworker_full_walk_no_shelves_visible");
-            self.stamp_full_walk_done().await?;
-            return Ok(());
         }
         let mut total_pages = 0usize;
+        let mut walked_books: HashSet<i64> = HashSet::new();
         for shelf_id in shelves {
             // Per-shelf/book/chapter/page status check. This (and every
             // other should_stop_index_job call in walk_*) is a `WHERE id = ?`
@@ -384,14 +387,60 @@ impl IndexWorker {
                 tracing::info!(job_id, walk = "all", "indexworker_walk_stopped");
                 return Ok(());
             }
-            match self.walk_shelf(shelf_id, job_id).await {
+            match self.walk_shelf(shelf_id, job_id, &mut walked_books).await {
                 Ok(n) => total_pages += n,
                 Err(e) => tracing::error!(shelf_id, error = %e, "indexworker_walk_shelf_failed"),
             }
         }
+        total_pages += self.walk_orphan_books(job_id, &walked_books).await;
         self.stamp_full_walk_done().await?;
         tracing::info!(total_pages, "indexworker_full_walk_complete");
         Ok(())
+    }
+
+    /// Second pass of the full walk — books that sit on no shelf.
+    ///
+    /// BookStack doesn't require a book to be shelved, and `walk_all` above
+    /// only reaches books through a shelf's `books` array. Without this pass
+    /// an unshelved book never enters `bookstack_books`, so every page under
+    /// it trips the missing-parent check in `reconcile_page` on every single
+    /// delta walk, forever (issue #147).
+    ///
+    /// Indexed with `shelf_id: None`, matching what `reconcile_book` writes
+    /// when its shelf probe finds no owner. Failures are logged per-book and
+    /// don't abort the walk — same contract as `walk_shelf`.
+    async fn walk_orphan_books(&self, job_id: i64, walked: &HashSet<i64>) -> usize {
+        let all_books = match self.bs_client.list_all_books().await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!(error = %e, "indexworker_full_walk_list_books_failed");
+                return 0;
+            }
+        };
+        let orphans = orphan_book_ids(&all_books, walked);
+        if orphans.is_empty() {
+            return 0;
+        }
+        tracing::info!(
+            orphan_count = orphans.len(),
+            total_books = all_books.len(),
+            "indexworker_full_walk_orphan_books"
+        );
+        let mut count = 0usize;
+        for book_id in orphans {
+            if matches!(self.index_db.should_stop_index_job(job_id).await, Ok(true)) {
+                tracing::info!(job_id, walk = "orphan_books", "indexworker_walk_stopped");
+                return count;
+            }
+            match self
+                .walk_book(book_id, None, classify_shelf(0), job_id)
+                .await
+            {
+                Ok(n) => count += n,
+                Err(e) => tracing::error!(book_id, error = %e, "indexworker_walk_book_failed"),
+            }
+        }
+        count
     }
 
     async fn stamp_full_walk_done(&self) -> Result<(), String> {
@@ -431,6 +480,7 @@ impl IndexWorker {
 
         let mut newest_seen = last_walk.clone();
         let mut reconciled = 0usize;
+        let mut deferred = 0usize;
         for page in pages {
             let Some(page_id) = page.get("id").and_then(|v| v.as_i64()) else {
                 continue;
@@ -440,16 +490,21 @@ impl IndexWorker {
                 .and_then(|v| v.as_str())
                 .map(String::from);
 
-            if let Err(e) = self.reconcile_page(page_id).await {
-                tracing::error!(
-                    walk = "delta",
-                    page_id,
-                    error = %e,
-                    "indexworker_reconcile_page_failed"
-                );
-                continue;
+            match self.reconcile_page(page_id).await {
+                Ok(()) => reconciled += 1,
+                Err(e) => {
+                    if defer_delta_page(&self.index_db, page_id, &e).await.is_err() {
+                        // The job queue is the only path back to this page,
+                        // and the checkpoint below would otherwise advance
+                        // past it. Stop the window here instead: `pages` is
+                        // sorted +updated_at, so leaving the checkpoint at
+                        // the last handed-off page re-lists this one and
+                        // everything after it on the next run.
+                        break;
+                    }
+                    deferred += 1;
+                }
             }
-            reconciled += 1;
             if let Some(ts) = updated_at {
                 if ts > newest_seen {
                     newest_seen = ts;
@@ -471,13 +526,22 @@ impl IndexWorker {
             .await?;
         tracing::info!(
             reconciled,
+            deferred,
             advanced_to = %advance_to,
             "indexworker_walk_delta_complete"
         );
         Ok(())
     }
 
-    async fn walk_shelf(&self, shelf_id: i64, job_id: i64) -> Result<usize, String> {
+    /// Walks one shelf. Every book id reached is recorded in `walked_books`
+    /// — books live on zero, one, or many shelves, and the orphan sweep in
+    /// `walk_orphan_books` needs to know which ones this pass covered.
+    async fn walk_shelf(
+        &self,
+        shelf_id: i64,
+        job_id: i64,
+        walked_books: &mut HashSet<i64>,
+    ) -> Result<usize, String> {
         let shelf = self.bs_client.get_shelf(shelf_id).await?;
         let name = string_field(&shelf, "name");
         let slug = string_field(&shelf, "slug");
@@ -509,6 +573,10 @@ impl IndexWorker {
                 tracing::info!(job_id, walk = "shelf", "indexworker_walk_stopped");
                 return Ok(count);
             }
+            // Recorded before the walk, not after: this tracks coverage, not
+            // success. A book whose walk failed here shouldn't be retried by
+            // the orphan sweep — it isn't an orphan.
+            walked_books.insert(book_id);
             match self
                 .walk_book(book_id, Some(shelf_id), shelf_kind, job_id)
                 .await
@@ -1199,6 +1267,72 @@ async fn cascade_missing_parent(
     ))
 }
 
+/// Hand a failed delta-walk page to the job queue.
+///
+/// `walk_delta` reconciles pages inline rather than as `page:{id}` jobs, so
+/// a failure there has no job row for the #54 retry-chain reconciler to pick
+/// up — and the delta checkpoint advances past it, dropping the page from
+/// every future window. Enqueueing a real job gives the failure an owner
+/// with bounded retries (issue #147).
+///
+/// Emits the `indexworker_reconcile_page_failed` line the inline path used
+/// to emit, now carrying the `job_id` that owns the retry. Repeat deferrals
+/// of the same page coalesce onto one job via `create_index_job`'s dedup.
+async fn defer_delta_page(
+    index_db: &Arc<dyn IndexDb>,
+    page_id: i64,
+    reconcile_error: &str,
+) -> Result<i64, String> {
+    match index_db
+        .create_index_job(&format!("page:{page_id}"), "both", "delta_retry")
+        .await
+    {
+        Ok((job_id, is_new)) => {
+            if is_new {
+                tracing::error!(
+                    walk = "delta",
+                    page_id,
+                    job_id,
+                    error = %reconcile_error,
+                    "indexworker_reconcile_page_failed"
+                );
+            } else {
+                tracing::debug!(
+                    walk = "delta",
+                    page_id,
+                    job_id,
+                    error = %reconcile_error,
+                    "indexworker_delta_page_retry_coalesced"
+                );
+            }
+            Ok(job_id)
+        }
+        Err(e) => {
+            tracing::error!(
+                walk = "delta",
+                page_id,
+                error = %reconcile_error,
+                enqueue_error = %e,
+                "indexworker_delta_page_retry_enqueue_failed"
+            );
+            Err(e)
+        }
+    }
+}
+
+/// Visible book ids that the shelf pass didn't reach, in listing order.
+///
+/// Also collapses duplicates: `list_all_books` pages by offset, so a book
+/// created mid-pagination can surface twice, and walking it twice is pure
+/// waste.
+fn orphan_book_ids(all: &[i64], walked: &HashSet<i64>) -> Vec<i64> {
+    let mut seen = HashSet::new();
+    all.iter()
+        .copied()
+        .filter(|id| !walked.contains(id) && seen.insert(*id))
+        .collect()
+}
+
 fn current_unix() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1557,6 +1691,96 @@ mod reconcile_tests {
             book_jobs.len(),
             1,
             "failed-open parent job must absorb subsequent cascades, got {book_jobs:?}"
+        );
+    }
+
+    /// Issue #147 — a page that fails inside the delta walk must end up
+    /// owned by a real `page:{id}` job. `walk_delta` reconciles inline, so
+    /// without the hand-off the #54 reconciler never sees the failure and
+    /// the delta checkpoint advances past the page for good.
+    #[tokio::test]
+    async fn delta_page_failure_becomes_a_retryable_job() {
+        let db = temp_db();
+        let job_id = defer_delta_page(&db, 3172, "page 3172 parent book 72 not in index")
+            .await
+            .expect("enqueue succeeds");
+
+        let pending = db.list_pending_index_jobs(50).await.unwrap();
+        let page_jobs: Vec<_> = pending.iter().filter(|j| j.scope == "page:3172").collect();
+        assert_eq!(page_jobs.len(), 1, "one owner job, got {page_jobs:?}");
+        assert_eq!(page_jobs[0].id, job_id);
+        assert_eq!(page_jobs[0].kind, "both");
+        assert_eq!(page_jobs[0].triggered_by, "delta_retry");
+
+        // A later delta walk re-listing the same still-broken page must not
+        // stack a second job on top of the first.
+        let again = defer_delta_page(&db, 3172, "still missing")
+            .await
+            .expect("second deferral coalesces");
+        assert_eq!(again, job_id);
+        let pending = db.list_pending_index_jobs(50).await.unwrap();
+        assert_eq!(
+            pending.iter().filter(|j| j.scope == "page:3172").count(),
+            1,
+            "repeat deferrals coalesce onto the same job"
+        );
+    }
+
+    /// The deferred job is a normal queue citizen: when it fails, the #54
+    /// reconciler retries it like any other. This is what makes "will retry"
+    /// true for delta-walk failures.
+    #[tokio::test]
+    async fn deferred_delta_page_job_is_picked_up_by_the_retry_chain() {
+        let db = temp_db();
+        let job_id = defer_delta_page(&db, 3917, "parent book 85 not in index")
+            .await
+            .unwrap();
+        db.fail_index_job(job_id, "parent still missing")
+            .await
+            .unwrap();
+
+        reconcile_failed_index_jobs(&db, 5).await;
+
+        let listed = db.list_index_jobs(20).await.unwrap();
+        let original = listed.iter().find(|j| j.id == job_id).unwrap();
+        assert_eq!(original.resolved_status.as_deref(), Some("retried"));
+        let retry = listed
+            .iter()
+            .find(|j| j.retry_of == Some(job_id))
+            .expect("retry job queued");
+        assert_eq!(retry.scope, "page:3917");
+        assert_eq!(retry.status, "pending");
+    }
+
+    /// Issue #147 — books on no shelf are invisible to the shelf-rooted
+    /// walk, so the orphan sweep is the only thing that indexes them.
+    #[test]
+    fn orphan_book_ids_returns_only_unshelved_books() {
+        let walked: HashSet<i64> = [10, 11, 12].into_iter().collect();
+        assert_eq!(
+            orphan_book_ids(&[10, 11, 12, 72, 85], &walked),
+            vec![72, 85]
+        );
+    }
+
+    /// A book on two shelves is walked once per shelf by the shelf pass and
+    /// must not be swept again. An empty shelf pass makes every book an
+    /// orphan — that's the no-shelves-visible case, and indexing everything
+    /// we can see is the right answer there.
+    #[test]
+    fn orphan_book_ids_handles_multi_shelf_and_empty_walks() {
+        let walked: HashSet<i64> = [10].into_iter().collect();
+        assert!(orphan_book_ids(&[10], &walked).is_empty());
+        assert_eq!(orphan_book_ids(&[10, 72], &HashSet::new()), vec![10, 72]);
+    }
+
+    /// `list_all_books` pages by offset, so a book created mid-pagination
+    /// can appear in two pages. Walking it twice is wasted API calls.
+    #[test]
+    fn orphan_book_ids_dedupes_paginated_duplicates() {
+        assert_eq!(
+            orphan_book_ids(&[72, 85, 72, 85, 90], &HashSet::new()),
+            vec![72, 85, 90]
         );
     }
 


### PR DESCRIPTION
Closes #147. Ships as **v0.13.2** (patch — `bug/*` prefix per the DEVELOPMENT.md semver table).

## Defect 1 — shelf-less books never entered the index

`walk_all` was shelf-rooted: `list_all_shelves()` -> `walk_shelf` -> the book ids in that shelf's `books` array. BookStack doesn't require a book to be shelved, so an unshelved book never landed in `bookstack_books`, and every page under it tripped the parent check in `reconcile_page` on **every** delta walk, forever.

- New `BookStackClient::list_all_books()`, paginated, mirroring `list_all_shelves`.
- New `walk_orphan_books` second pass over books the shelf walk didn't reach, indexed with `shelf_id: None` — same thing `reconcile_book` writes when its shelf probe finds no owner.
- `walk_shelf` records every book id it reaches in a `HashSet`, so a book on two shelves isn't swept twice and a previously-indexed orphan still refreshes on later full walks. Recorded *before* the walk, not after: it tracks coverage, not success, so a book whose walk failed isn't misfiled as an orphan.
- The no-shelves-visible case no longer early-returns. It warns and falls through to the orphan sweep, which is the right answer there — index what the token can see.

## Defect 2 — "will retry" was false inside a delta walk

`walk_delta` reconciled pages **inline** rather than as `page:{id}` jobs, so a failure had no job row for the #54 retry-chain reconciler to pick up. The checkpoint then advanced past it — to the newest *successfully* reconciled page, or to `now()` when every page in the window failed — dropping the page from every future delta window. The cascade landed the parent book; the page stayed unindexed until someone edited it again or a full walk was triggered (cold start only).

- Failures now enqueue a real `page:{id}` job via `defer_delta_page`, so the bounded retry chain owns them.
- The checkpoint advances for pages handed off successfully; when the enqueue itself fails the window stops there, and since `pages` is sorted `+updated_at` that re-lists the failure and everything after it next run.
- Cursor advance is deliberately kept rather than stalling at the first failure — a permanently-broken page must not re-list the same window forever. `max_chain` already bounds the retry.
- The existing `indexworker_reconcile_page_failed` event name is preserved (log greps keep working) and now carries the `job_id` that owns the retry.

## Defect 3 — paginated sweeps truncate on a server-side count clamp

Found while answering whether the 500-row page size is configurable. BookStack clamps the `count` query param to the instance's `API_MAX_ITEM_COUNT`, so an over-large request comes back short. Both `list_all_*` sweeps treated a short page as the last page:

```rust
if page_len < PAGE_SIZE { break; }
offset += PAGE_SIZE;
```

Against an instance capped below the requested size that breaks after the first page — a silently truncated index, no error, no log line — and the fixed stride skips rows in the other direction. The loops were only correct because `500` happened to equal BookStack's default cap; **any instance configured lower was already losing rows.**

- Extracts `paginate_step`, which advances by rows actually returned and terminates on an empty page or on `total` being reached. A response missing `total` falls through to the empty-page check instead of ending the sweep early.
- Same defect class fixed in the embed pipeline's page enumeration: it advanced a hardcoded `100` regardless of what came back, and `unwrap_or(0)` on a missing `total` ended the sweep after one page.

This is also the prerequisite for ever making the page size configurable — that was deferred, not done here.

## Also in this PR

`improvement(embedder): log per-page embed progress at INFO` — a running pipeline job was observable only via `update_job_progress` in the DB. `embed_single_page` now returns a `PageOutcome` (name, chunk count, skipped) so the caller emits one INFO line per page with position/total/id/title/chunks, no re-fetch. Requested separately; kept as its own commit.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, `cargo test --workspace` 160 passed / 0 failed.

Eleven new tests. On the index queue:
- `delta_page_failure_becomes_a_retryable_job` — one owner job, correct scope/kind/triggered_by, repeat deferrals coalesce.
- `deferred_delta_page_job_is_picked_up_by_the_retry_chain` — the deferred job is a normal queue citizen; failing it produces a retry. This is what makes "will retry" true.
- `orphan_book_ids_returns_only_unshelved_books`, `..._handles_multi_shelf_and_empty_walks`, `..._dedupes_paginated_duplicates`.

On pagination, driven through a fake list endpoint that clamps `count` the way BookStack does:
- `sweep_survives_a_server_side_count_clamp` — 1200 rows, asking 1000 against a 500 cap, all 1200 collected in 3 requests. This is the regression.
- `sweep_collects_everything_when_request_matches_cap`, `sweep_handles_exact_multiple_of_page_size`, `sweep_handles_empty_and_single_page_instances`.
- `paginate_step_without_total_keeps_going`, `paginate_step_tolerates_a_malformed_page` — rows with no usable id still advance the offset, so a malformed page can't loop forever.

Helpers are tested directly rather than end-to-end, matching the existing rationale on `cascade_missing_parent_coalesces_concurrent_children`: `BookStackClient` is a concrete reqwest-backed struct with no test stub.

## Not in scope

#148 (cancelled `acl_reconcile` keeps running and blocks the embed queue; failed-open `acl_reconcile` starves the daily cron) is the embed queue, not the index queue. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)