### PR TITLE
bug(embedder,acl,server): stop cancelled acl_reconcile stalling the embed queue (closes #148)

### DIFF
--- a/crates/bsmcp-common/src/acl.rs
+++ b/crates/bsmcp-common/src/acl.rs
@@ -252,15 +252,58 @@ fn now_secs() -> i64 {
 ///
 /// Returns `(processed, failed)`. Best-effort: per-page failures are logged
 /// but don't abort the run.
+/// How often the full ACL reconcile publishes progress, in pages.
+const ACL_PROGRESS_EVERY: usize = 50;
+
+/// Result of a full ACL reconcile pass.
+///
+/// `aborted` is true when the job was cancelled part-way — the caller must
+/// not report a cancelled run as a clean completion.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AclReconcileOutcome {
+    pub processed: usize,
+    pub failed: usize,
+    pub aborted: bool,
+}
+
 pub async fn reconcile_all_pages(
     client: &BookStackClient,
     db: &Arc<dyn SemanticDb>,
-) -> Result<(usize, usize), String> {
+    job_id: i64,
+) -> Result<AclReconcileOutcome, String> {
     let role_ctx = build_role_context(client).await?;
     let page_ids = db.list_acl_page_ids().await?;
+    let total = page_ids.len() as i64;
+    db.update_job_progress(job_id, 0, total).await?;
     let mut processed = 0usize;
     let mut failed = 0usize;
-    for page_id in page_ids {
+    for (index, page_id) in page_ids.into_iter().enumerate() {
+        // Per-page cancel check, mirroring the embed pipeline's loop.
+        // Without it a cancelled job runs to completion inside this
+        // function, so the embedder never returns to `claim_next_job`
+        // and the whole embed queue stalls behind work whose result is
+        // already discarded (issue #148).
+        if matches!(db.should_stop_embed_job(job_id).await, Ok(true)) {
+            tracing::info!(
+                job_id,
+                page_index = index,
+                processed,
+                failed,
+                "acl_reconcile_cancelled_aborting"
+            );
+            db.update_job_progress(job_id, index as i64, total).await?;
+            return Ok(AclReconcileOutcome {
+                processed,
+                failed,
+                aborted: true,
+            });
+        }
+        // Publish progress as we go rather than only at the end — a
+        // multi-thousand-page reconcile used to sit at 0/0 for its whole
+        // run, which reads as "wedged" on /status.
+        if index > 0 && index % ACL_PROGRESS_EVERY == 0 {
+            db.update_job_progress(job_id, index as i64, total).await?;
+        }
         let meta = match db.get_page_meta(page_id).await {
             Ok(Some(m)) => m,
             Ok(None) => continue,
@@ -285,7 +328,12 @@ pub async fn reconcile_all_pages(
             }
         }
     }
-    Ok((processed, failed))
+    db.update_job_progress(job_id, total, total).await?;
+    Ok(AclReconcileOutcome {
+        processed,
+        failed,
+        aborted: false,
+    })
 }
 
 /// Recompute ACL for a single page. Called by the webhook handler on

--- a/crates/bsmcp-db-sqlite/src/lib.rs
+++ b/crates/bsmcp-db-sqlite/src/lib.rs
@@ -4150,6 +4150,81 @@ mod lifecycle_tests {
         assert_eq!(j_dup, j1);
     }
 
+    /// Issue #148 — the signal `reconcile_all_pages` polls per page. The
+    /// ACL reconcile loop had no cancel check at all, so a cancelled job
+    /// ran to completion and the embedder never returned to
+    /// `claim_next_job`, stalling the whole embed queue behind discarded
+    /// work.
+    #[tokio::test]
+    async fn embed_should_stop_returns_true_for_cancelled() {
+        let db = temp_db();
+        db.init_semantic_tables().await.unwrap();
+
+        let (job_id, _) = SemanticDb::create_embed_job(&db, "acl_reconcile")
+            .await
+            .unwrap();
+        // Claimed → running → keep going.
+        let claimed = SemanticDb::claim_next_job(&db, "worker-x")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(claimed.id, job_id);
+        assert!(!SemanticDb::should_stop_embed_job(&db, job_id)
+            .await
+            .unwrap());
+
+        // Operator cancels mid-run — the very next per-page poll must stop.
+        SemanticDb::cancel_embed_job(&db, job_id).await.unwrap();
+        assert!(SemanticDb::should_stop_embed_job(&db, job_id)
+            .await
+            .unwrap());
+    }
+
+    /// Issue #148 — a failed-open `acl_reconcile` absorbs every subsequent
+    /// cron enqueue, so ACL data goes stale for as long as nothing resolves
+    /// it. Observed stuck for 9 days on a live instance because the retry
+    /// chain only ran from the worker role.
+    ///
+    /// Pins both halves: the starvation itself, and that resolving the
+    /// blocker is what lets the cron queue work again.
+    #[tokio::test]
+    async fn failed_open_acl_reconcile_starves_the_cron_until_resolved() {
+        let db = temp_db();
+        db.init_semantic_tables().await.unwrap();
+
+        let (first, is_new) = SemanticDb::create_embed_job(&db, "acl_reconcile")
+            .await
+            .unwrap();
+        assert!(is_new);
+        SemanticDb::fail_embed_job(&db, first, "Request failed")
+            .await
+            .unwrap();
+
+        // Every daily cron tick from here collapses onto the dead job.
+        for _ in 0..9 {
+            let (id, is_new) = SemanticDb::create_embed_job(&db, "acl_reconcile")
+                .await
+                .unwrap();
+            assert_eq!(id, first, "cron must coalesce onto the failed-open job");
+            assert!(!is_new, "no new work is queued while it stays failed-open");
+        }
+
+        // The job is discoverable as failed-open, which is what both the
+        // retry chain and the cron's starvation warning key off.
+        let open = SemanticDb::list_failed_open_embed_jobs(&db).await.unwrap();
+        assert!(open.iter().any(|j| j.id == first));
+
+        // Once the reconciler resolves it, the next tick queues real work.
+        SemanticDb::close_embed_job(&db, first, Some("retried"))
+            .await
+            .unwrap();
+        let (next, is_new) = SemanticDb::create_embed_job(&db, "acl_reconcile")
+            .await
+            .unwrap();
+        assert!(is_new, "resolved blocker must stop absorbing enqueues");
+        assert_ne!(next, first);
+    }
+
     #[tokio::test]
     async fn index_should_stop_returns_true_for_cancelled() {
         let db = temp_db();

--- a/crates/bsmcp-embedder/src/main.rs
+++ b/crates/bsmcp-embedder/src/main.rs
@@ -267,6 +267,33 @@ async fn main() {
     }
 }
 
+/// Periodically hand failed-open embed jobs to the retry chain.
+///
+/// Mirrors the cadence and env knobs of the worker's lifecycle loop
+/// (`BSMCP_JOB_RECONCILE_SECS`, `BSMCP_JOB_MAX_RETRY_CHAIN`) so the two
+/// roles behave identically — only one of them runs it at a time.
+fn spawn_embed_job_reconciler(db: Arc<dyn SemanticDb>) {
+    let reconcile_secs: u64 = env::var("BSMCP_JOB_RECONCILE_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(300);
+    let max_chain: usize = env::var("BSMCP_JOB_MAX_RETRY_CHAIN")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5);
+    tracing::info!(
+        reconcile_secs,
+        max_chain,
+        "embedder_embed_job_reconciler_active"
+    );
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(reconcile_secs)).await;
+            worker::reconcile_failed_embed_jobs(&db, max_chain).await;
+        }
+    });
+}
+
 /// Worker role body — lifts `bsmcp-worker/src/main.rs` lines 41-119
 /// minus the duplicated DB/encryption_key bootstrap (the role dispatcher
 /// in `main` already opened the DB).
@@ -338,6 +365,20 @@ async fn run_embedder(_db: Arc<dyn DbBackend>, db: Arc<dyn SemanticDb>, role: Ro
     db.init_semantic_tables()
         .await
         .expect("Failed to initialize semantic tables");
+
+    // The embed queue's retry chain. This used to run only from the worker
+    // role's lifecycle loop, so on a split deployment (embedder container +
+    // worker container) nothing ever retried a failed embed job unless the
+    // worker also had a semantic DB. A single failed-open `acl_reconcile`
+    // then blocked every subsequent cron enqueue via create_embed_job's
+    // dedup — observed stuck for 9 days (issue #148).
+    //
+    // Skipped under Role::Both: the worker side spawned alongside us
+    // already reconciles the same queue, and two reconcilers racing the
+    // same failed-open job would double-enqueue retries.
+    if role == Role::Embedder {
+        spawn_embed_job_reconciler(db.clone());
+    }
 
     // Select embedding provider
     let provider = env::var("BSMCP_EMBED_PROVIDER")

--- a/crates/bsmcp-embedder/src/pipeline.rs
+++ b/crates/bsmcp-embedder/src/pipeline.rs
@@ -356,15 +356,27 @@ pub async fn run_pipeline(
     // by the daily reconciliation cron — no embedding work, just refresh
     // page_view_acl for every previously-stored page.
     if scope == "acl_reconcile" {
-        match reconcile_all_pages(client, db).await {
-            Ok((processed, failed)) => {
-                tracing::info!(processed, failed, "pipeline_acl_reconcile_complete");
-                db.update_job_progress(job_id, processed as i64, (processed + failed) as i64)
-                    .await?;
+        match reconcile_all_pages(client, db, job_id).await {
+            Ok(outcome) => {
+                if outcome.aborted {
+                    tracing::info!(
+                        processed = outcome.processed,
+                        failed = outcome.failed,
+                        "pipeline_acl_reconcile_aborted"
+                    );
+                } else {
+                    tracing::info!(
+                        processed = outcome.processed,
+                        failed = outcome.failed,
+                        "pipeline_acl_reconcile_complete"
+                    );
+                }
+                // Progress is published inside reconcile_all_pages now,
+                // including the final and cancelled-part-way stamps.
                 return Ok(PipelineResult {
-                    succeeded: processed,
+                    succeeded: outcome.processed,
                     failed_pages: Vec::new(),
-                    aborted: false,
+                    aborted: outcome.aborted,
                 });
             }
             Err(e) => {

--- a/crates/bsmcp-server/src/semantic.rs
+++ b/crates/bsmcp-server/src/semantic.rs
@@ -662,8 +662,35 @@ impl SemanticState {
             tokio::time::sleep(Duration::from_secs(5 * 60)).await;
             loop {
                 match self.db.create_embed_job("acl_reconcile").await {
-                    Ok((job_id, is_new)) => {
-                        tracing::info!(job_id, is_new, "semantic_acl_reconcile_cron_queued")
+                    Ok((job_id, true)) => {
+                        tracing::info!(job_id, is_new = true, "semantic_acl_reconcile_cron_queued")
+                    }
+                    // Coalesced onto an existing job. Benign when that job
+                    // is pending/running, but `create_embed_job` also treats
+                    // failed-open as active — so a job that failed and never
+                    // got retried silently absorbs every subsequent cron
+                    // enqueue and ACL data goes stale indefinitely. Nine days
+                    // of that is what motivated issue #148; make it loud.
+                    Ok((job_id, false)) => {
+                        let blocker = self
+                            .db
+                            .list_failed_open_embed_jobs()
+                            .await
+                            .ok()
+                            .and_then(|jobs| jobs.into_iter().find(|j| j.id == job_id));
+                        match blocker {
+                            Some(j) => tracing::warn!(
+                                job_id,
+                                blocked_since = ?j.started_at,
+                                error = j.error.as_deref().unwrap_or("unknown"),
+                                "semantic_acl_reconcile_cron_starved"
+                            ),
+                            None => tracing::info!(
+                                job_id,
+                                is_new = false,
+                                "semantic_acl_reconcile_cron_queued"
+                            ),
+                        }
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "semantic_acl_reconcile_cron_queue_failed")


### PR DESCRIPTION
Closes #148. No version bump — folds into the pending **v0.13.2** release alongside #149.

Three defects behind one live incident. The embed queue reported `0 running, 1 pending` with nothing claiming the pending `all` job, and ACL data had been 9 days stale before anyone noticed.

## A — cancelling a job didn't stop the work, and stalled the whole queue

`reconcile_all_pages` had **no cancellation check anywhere in its loop**. It walks every id from `list_acl_page_ids()` calling `resolve_page_acl` per page. Cancelling job #4600 flipped the DB row to `cancelled`, but the embedder task stayed inside that loop, so it never returned to `claim_next_job` — job #4601 sat pending indefinitely while the DB reported nothing in flight. On the affected instance that's 2435 pages of BookStack API calls made for a result already thrown away.

The embed pipeline's own loop has polled `should_stop_embed_job` per page since it was written; the ACL path never got the same treatment.

- Takes `job_id` and polls `should_stop_embed_job` per page, matching that shape.
- Returns `AclReconcileOutcome { processed, failed, aborted }` so a cancelled run isn't logged as a clean completion — the caller emitted `pipeline_acl_reconcile_complete` and `aborted: false` unconditionally.

## B — the run was invisible while it ran

Progress was published only after the loop finished, so a multi-thousand-page reconcile sat at `0/0` for its entire run. That's exactly what a wedged job looks like, which is what made the incident hard to read. Stamps progress every 50 pages and on the cancel path.

## C — a failed-open acl_reconcile starved the daily cron

`reconcile_failed_embed_jobs` only ever ran from the **worker** role's lifecycle loop, gated on `semantic_for_lifecycle`. On a split deployment (embedder container + worker container) nothing retried a failed embed job unless the worker also had a semantic DB configured.

That compounds with `create_embed_job` dedup, which counts `failed AND resolved_status IS NULL` as active — correct for stopping a webhook storm from double-enqueueing, but it means one dead job absorbs *every* subsequent enqueue for that scope. Job #4599 failed with `Request failed` and swallowed nine days of daily cron ticks, each logging a benign-looking `is_new: false`.

- The embedder role now runs the retry chain for the queue it owns, same env knobs and cadence as the worker (`BSMCP_JOB_RECONCILE_SECS`, `BSMCP_JOB_MAX_RETRY_CHAIN`). Skipped under `Role::Both`, where the worker side already covers it and two reconcilers racing the same failed-open job would double-enqueue retries.
- The cron now warns with the blocking job id, its `started_at` and its error, instead of logging `is_new=false` and moving on.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, `cargo test --workspace` 162 passed / 0 failed.

Two new tests, both pinning contracts the fixes depend on:
- `embed_should_stop_returns_true_for_cancelled` — the per-page signal the ACL loop now polls: false while running, true the moment it's cancelled.
- `failed_open_acl_reconcile_starves_the_cron_until_resolved` — drives nine cron ticks against a failed-open job and asserts every one coalesces onto it, that it's discoverable via `list_failed_open_embed_jobs` (what both the retry chain and the new warning key off), and that resolving it lets the next tick queue real work again.

**Honest coverage note:** the role wiring itself (embedder spawning the reconciler, and skipping it under `Role::Both`) has no automated test — it's a `tokio::spawn` in the role body, and `BookStackClient` is a concrete reqwest-backed struct with no test stub, which is the same reason `reconcile_all_pages` can't be driven end-to-end here. The DB-level contracts above are tested; the wiring is reviewed by reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)